### PR TITLE
Add design fingerprinting engine with semantic embeddings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,8 @@
       "Bash(mv post-commit.pre-entire post-commit)",
       "Bash(mv pre-push.pre-entire pre-push)",
       "Bash(mv prepare-commit-msg.pre-entire prepare-commit-msg)",
-      "Bash(pnpm:*)"
+      "Bash(pnpm:*)",
+      "Bash(npx:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,9 @@
       "Bash(mv pre-push.pre-entire pre-push)",
       "Bash(mv prepare-commit-msg.pre-entire prepare-commit-msg)",
       "Bash(pnpm:*)",
-      "Bash(npx:*)"
+      "Bash(npx:*)",
+      "Bash(grep -v \"^$\")",
+      "Bash(grep -v \"warning$\")"
     ]
   }
 }

--- a/packages/ghost-cli/src/bin.ts
+++ b/packages/ghost-cli/src/bin.ts
@@ -93,7 +93,18 @@ const profileCommand = defineCommand({
       let fingerprint: DesignFingerprint;
 
       if (args.registry) {
-        fingerprint = await profileRegistry(args.registry);
+        // Still load config if available — for embedding settings
+        let embeddingConfig: import("@ghost/core").EmbeddingConfig | undefined;
+        try {
+          const config = await loadConfig({
+            configPath: args.config,
+            requireDesignSystems: false,
+          });
+          embeddingConfig = config.embedding;
+        } catch {
+          // No config file is fine when --registry is provided
+        }
+        fingerprint = await profileRegistry(args.registry, embeddingConfig);
       } else {
         const config = await loadConfig({
           configPath: args.config,

--- a/packages/ghost-cli/src/bin.ts
+++ b/packages/ghost-cli/src/bin.ts
@@ -1,9 +1,18 @@
 #!/usr/bin/env node
 
+import { readFile, writeFile } from "node:fs/promises";
+import type { DesignFingerprint } from "@ghost/core";
 import {
+  compareFingerprints,
   formatCLIReport,
+  formatComparison,
+  formatComparisonJSON,
+  formatFingerprint,
+  formatFingerprintJSON,
   formatJSONReport,
   loadConfig,
+  profile,
+  profileRegistry,
   scan,
 } from "@ghost/core";
 import { defineCommand, runMain } from "citty";
@@ -51,6 +60,117 @@ const scanCommand = defineCommand({
   },
 });
 
+const profileCommand = defineCommand({
+  meta: {
+    name: "profile",
+    description: "Generate a design fingerprint for a project",
+  },
+  args: {
+    config: {
+      type: "string",
+      description: "Path to ghost config file",
+      alias: "c",
+    },
+    registry: {
+      type: "string",
+      description:
+        "Path or URL to a registry.json (profiles registry directly)",
+      alias: "r",
+    },
+    output: {
+      type: "string",
+      description: "Write fingerprint to file",
+      alias: "o",
+    },
+    format: {
+      type: "string",
+      description: "Output format: cli or json",
+      default: "cli",
+    },
+  },
+  async run({ args }) {
+    try {
+      let fingerprint: DesignFingerprint;
+
+      if (args.registry) {
+        fingerprint = await profileRegistry(args.registry);
+      } else {
+        const config = await loadConfig({
+          configPath: args.config,
+          requireDesignSystems: false,
+        });
+        fingerprint = await profile(config);
+      }
+
+      const output =
+        args.format === "json"
+          ? formatFingerprintJSON(fingerprint)
+          : formatFingerprint(fingerprint);
+
+      if (args.output) {
+        await writeFile(args.output, formatFingerprintJSON(fingerprint));
+        console.log(`Fingerprint written to ${args.output}`);
+      }
+
+      process.stdout.write(`${output}\n`);
+      process.exit(0);
+    } catch (err) {
+      console.error(
+        `Error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(2);
+    }
+  },
+});
+
+const compareCommand = defineCommand({
+  meta: {
+    name: "compare",
+    description: "Compare two design fingerprints",
+  },
+  args: {
+    source: {
+      type: "positional",
+      description: "Path to source fingerprint JSON",
+      required: true,
+    },
+    target: {
+      type: "positional",
+      description: "Path to target fingerprint JSON",
+      required: true,
+    },
+    format: {
+      type: "string",
+      description: "Output format: cli or json",
+      default: "cli",
+    },
+  },
+  async run({ args }) {
+    try {
+      const sourceData = await readFile(args.source, "utf-8");
+      const targetData = await readFile(args.target, "utf-8");
+
+      const source: DesignFingerprint = JSON.parse(sourceData);
+      const target: DesignFingerprint = JSON.parse(targetData);
+
+      const comparison = compareFingerprints(source, target);
+
+      const output =
+        args.format === "json"
+          ? formatComparisonJSON(comparison)
+          : formatComparison(comparison);
+
+      process.stdout.write(`${output}\n`);
+      process.exit(comparison.distance > 0.5 ? 1 : 0);
+    } catch (err) {
+      console.error(
+        `Error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(2);
+    }
+  },
+});
+
 const main = defineCommand({
   meta: {
     name: "ghost",
@@ -59,6 +179,8 @@ const main = defineCommand({
   },
   subCommands: {
     scan: scanCommand,
+    profile: profileCommand,
+    compare: compareCommand,
   },
 });
 

--- a/packages/ghost-core/src/config.ts
+++ b/packages/ghost-core/src/config.ts
@@ -77,6 +77,7 @@ function mergeDefaults(raw: GhostConfig): GhostConfig {
     ignore: raw.ignore ?? DEFAULT_CONFIG.ignore,
     visual: raw.visual,
     llm: raw.llm,
+    embedding: raw.embedding,
     extractors: raw.extractors,
   };
 }

--- a/packages/ghost-core/src/config.ts
+++ b/packages/ghost-core/src/config.ts
@@ -23,37 +23,35 @@ export function defineConfig(config: GhostConfig): GhostConfig {
   return config;
 }
 
-export async function loadConfig(
-  configPath?: string,
-  cwd: string = process.cwd(),
-): Promise<GhostConfig> {
-  let resolvedPath: string | undefined;
+interface LoadConfigOptions {
+  configPath?: string;
+  cwd?: string;
+  requireDesignSystems?: boolean;
+}
 
+async function resolveConfigFile(
+  configPath: string | undefined,
+  cwd: string,
+): Promise<string> {
   if (configPath) {
-    resolvedPath = resolve(cwd, configPath);
-    if (!existsSync(resolvedPath)) {
-      throw new Error(`Config file not found: ${resolvedPath}`);
+    const resolved = resolve(cwd, configPath);
+    if (!existsSync(resolved)) {
+      throw new Error(`Config file not found: ${resolved}`);
     }
-  } else {
-    for (const file of CONFIG_FILES) {
-      const candidate = resolve(cwd, file);
-      if (existsSync(candidate)) {
-        resolvedPath = candidate;
-        break;
-      }
-    }
-    if (!resolvedPath) {
-      throw new Error(
-        `No ghost config found. Create one of: ${CONFIG_FILES.join(", ")}`,
-      );
-    }
+    return resolved;
   }
 
-  const jiti = createJiti(resolvedPath);
-  const mod = await jiti.import(resolvedPath);
-  const raw =
-    (mod as { default?: GhostConfig }).default ?? (mod as GhostConfig);
+  for (const file of CONFIG_FILES) {
+    const candidate = resolve(cwd, file);
+    if (existsSync(candidate)) return candidate;
+  }
 
+  throw new Error(
+    `No ghost config found. Create one of: ${CONFIG_FILES.join(", ")}`,
+  );
+}
+
+function validateDesignSystems(raw: GhostConfig): void {
   if (!raw.designSystems || !Array.isArray(raw.designSystems)) {
     throw new Error("Config must include a designSystems array");
   }
@@ -69,12 +67,45 @@ export async function loadConfig(
     if (!ds.styleEntry)
       throw new Error(`Design system "${ds.name}" must have a styleEntry`);
   }
+}
 
+function mergeDefaults(raw: GhostConfig): GhostConfig {
   return {
     designSystems: raw.designSystems,
     scan: { ...DEFAULT_CONFIG.scan, ...raw.scan },
     rules: { ...DEFAULT_CONFIG.rules, ...raw.rules },
     ignore: raw.ignore ?? DEFAULT_CONFIG.ignore,
     visual: raw.visual,
+    llm: raw.llm,
+    extractors: raw.extractors,
   };
+}
+
+export async function loadConfig(
+  configPathOrOptions?: string | LoadConfigOptions,
+  cwd: string = process.cwd(),
+): Promise<GhostConfig> {
+  let configPath: string | undefined;
+  let requireDesignSystems = true;
+
+  if (typeof configPathOrOptions === "object") {
+    configPath = configPathOrOptions.configPath;
+    cwd = configPathOrOptions.cwd ?? cwd;
+    requireDesignSystems = configPathOrOptions.requireDesignSystems ?? true;
+  } else {
+    configPath = configPathOrOptions;
+  }
+
+  const resolvedPath = await resolveConfigFile(configPath, cwd);
+
+  const jiti = createJiti(resolvedPath);
+  const mod = await jiti.import(resolvedPath);
+  const raw =
+    (mod as { default?: GhostConfig }).default ?? (mod as GhostConfig);
+
+  if (requireDesignSystems) {
+    validateDesignSystems(raw);
+  }
+
+  return mergeDefaults(raw);
 }

--- a/packages/ghost-core/src/extractors/css.ts
+++ b/packages/ghost-core/src/extractors/css.ts
@@ -1,0 +1,121 @@
+import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import type {
+  ExtractedFile,
+  ExtractedMaterial,
+  Extractor,
+  ExtractorOptions,
+} from "../types.js";
+
+const CSS_EXTENSIONS = [".css"];
+const COMPONENT_EXTENSIONS = [".tsx", ".jsx", ".vue", ".svelte"];
+const COMPONENT_DIRS = ["components/ui", "src/components/ui", "src/components"];
+const IGNORE_DIRS = ["node_modules", ".git", "dist", "build", ".next", ".nuxt"];
+
+async function walkDir(
+  dir: string,
+  extensions: string[],
+  maxFiles: number,
+): Promise<string[]> {
+  const results: string[] = [];
+
+  async function walk(current: string): Promise<void> {
+    if (results.length >= maxFiles) return;
+    if (!existsSync(current)) return;
+
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      if (results.length >= maxFiles) break;
+      const fullPath = join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        if (!IGNORE_DIRS.includes(entry.name)) {
+          await walk(fullPath);
+        }
+      } else if (extensions.some((ext) => entry.name.endsWith(ext))) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  await walk(dir);
+  return results;
+}
+
+function hasCustomProperties(content: string): boolean {
+  return /--[a-zA-Z][\w-]*\s*:/.test(content);
+}
+
+export const cssExtractor: Extractor = {
+  name: "css",
+
+  async detect(cwd: string): Promise<boolean> {
+    const cssFiles = await walkDir(cwd, CSS_EXTENSIONS, 5);
+    for (const file of cssFiles) {
+      const content = await readFile(file, "utf-8");
+      if (hasCustomProperties(content)) return true;
+    }
+    return false;
+  },
+
+  async extract(
+    cwd: string,
+    options?: ExtractorOptions,
+  ): Promise<ExtractedMaterial> {
+    const maxFiles = options?.maxFiles ?? 50;
+    const styleFiles: ExtractedFile[] = [];
+    const componentFiles: ExtractedFile[] = [];
+
+    // Gather CSS files
+    const cssFiles = await walkDir(cwd, CSS_EXTENSIONS, maxFiles);
+    for (const file of cssFiles) {
+      const content = await readFile(file, "utf-8");
+      styleFiles.push({
+        path: relative(cwd, file),
+        content,
+        type: "css",
+      });
+    }
+
+    // Gather component files
+    const componentDir = options?.componentDir
+      ? join(cwd, options.componentDir)
+      : null;
+
+    const searchDirs = componentDir
+      ? [componentDir]
+      : COMPONENT_DIRS.map((d) => join(cwd, d)).filter(existsSync);
+
+    for (const dir of searchDirs) {
+      const files = await walkDir(dir, COMPONENT_EXTENSIONS, maxFiles);
+      for (const file of files) {
+        const content = await readFile(file, "utf-8");
+        componentFiles.push({
+          path: relative(cwd, file),
+          content,
+          type: "component",
+        });
+      }
+    }
+
+    // Count tokens from CSS files
+    let tokenCount = 0;
+    for (const sf of styleFiles) {
+      const matches = sf.content.match(/--[a-zA-Z][\w-]*\s*:/g);
+      if (matches) tokenCount += matches.length;
+    }
+
+    return {
+      styleFiles,
+      componentFiles,
+      configFiles: [],
+      metadata: {
+        framework: "css",
+        componentLibrary: null,
+        tokenCount,
+        componentCount: componentFiles.length,
+      },
+    };
+  },
+};

--- a/packages/ghost-core/src/extractors/index.ts
+++ b/packages/ghost-core/src/extractors/index.ts
@@ -1,0 +1,51 @@
+import type {
+  ExtractedMaterial,
+  Extractor,
+  ExtractorOptions,
+} from "../types.js";
+import { cssExtractor } from "./css.js";
+import { tailwindExtractor } from "./tailwind.js";
+
+// Ordered by specificity — more specific extractors first
+const BUILTIN_EXTRACTORS: Extractor[] = [tailwindExtractor, cssExtractor];
+
+export async function detectExtractors(cwd: string): Promise<Extractor[]> {
+  const matched: Extractor[] = [];
+  for (const extractor of BUILTIN_EXTRACTORS) {
+    if (await extractor.detect(cwd)) {
+      matched.push(extractor);
+    }
+  }
+  return matched;
+}
+
+export async function extract(
+  cwd: string,
+  options?: ExtractorOptions & { extractorNames?: string[] },
+): Promise<ExtractedMaterial> {
+  let extractors: Extractor[];
+
+  if (options?.extractorNames?.length) {
+    extractors = BUILTIN_EXTRACTORS.filter((e) =>
+      options.extractorNames?.includes(e.name),
+    );
+    if (!extractors.length) {
+      throw new Error(
+        `No matching extractors found for: ${options.extractorNames.join(", ")}`,
+      );
+    }
+  } else {
+    extractors = await detectExtractors(cwd);
+    if (!extractors.length) {
+      throw new Error(
+        "No style framework detected. Ghost needs CSS custom properties, Tailwind, or similar.",
+      );
+    }
+  }
+
+  // Use the most specific extractor (first match)
+  return extractors[0].extract(cwd, options);
+}
+
+export { cssExtractor } from "./css.js";
+export { tailwindExtractor } from "./tailwind.js";

--- a/packages/ghost-core/src/extractors/tailwind.ts
+++ b/packages/ghost-core/src/extractors/tailwind.ts
@@ -1,0 +1,207 @@
+import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import type {
+  ExtractedFile,
+  ExtractedMaterial,
+  Extractor,
+  ExtractorOptions,
+} from "../types.js";
+
+const TAILWIND_CONFIG_PATTERNS = [
+  "tailwind.config.ts",
+  "tailwind.config.js",
+  "tailwind.config.mjs",
+  "tailwind.config.cjs",
+];
+
+const STYLE_EXTENSIONS = [".css"];
+const COMPONENT_EXTENSIONS = [".tsx", ".jsx", ".vue", ".svelte"];
+const COMPONENT_DIRS = ["components/ui", "src/components/ui", "src/components"];
+const IGNORE_DIRS = ["node_modules", ".git", "dist", "build", ".next", ".nuxt"];
+
+const TAILWIND_INDICATORS = [
+  /@tailwind\b/,
+  /@theme\b/,
+  /@apply\b/,
+  /@config\b/,
+];
+
+// Matches className="..." or className={...} or class="..."
+const CLASS_REGEX =
+  /(?:className|class)\s*=\s*(?:"([^"]+)"|'([^']+)'|\{[^}]*["'`]([^"'`]+)["'`])/g;
+
+async function walkDir(
+  dir: string,
+  extensions: string[],
+  maxFiles: number,
+): Promise<string[]> {
+  const results: string[] = [];
+
+  async function walk(current: string): Promise<void> {
+    if (results.length >= maxFiles) return;
+    if (!existsSync(current)) return;
+
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      if (results.length >= maxFiles) break;
+      const fullPath = join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        if (!IGNORE_DIRS.includes(entry.name)) {
+          await walk(fullPath);
+        }
+      } else if (extensions.some((ext) => entry.name.endsWith(ext))) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  await walk(dir);
+  return results;
+}
+
+function isTailwindCSS(content: string): boolean {
+  return TAILWIND_INDICATORS.some((re) => re.test(content));
+}
+
+function extractClassNames(content: string): string[] {
+  const classes: string[] = [];
+  CLASS_REGEX.lastIndex = 0;
+  for (
+    let match = CLASS_REGEX.exec(content);
+    match !== null;
+    match = CLASS_REGEX.exec(content)
+  ) {
+    const value = match[1] ?? match[2] ?? match[3];
+    if (value) {
+      classes.push(...value.split(/\s+/).filter(Boolean));
+    }
+  }
+  return classes;
+}
+
+function detectComponentLibrary(cwd: string): string | null {
+  try {
+    const pkgPath = join(cwd, "package.json");
+    if (!existsSync(pkgPath)) return null;
+
+    // Synchronous read is fine for a small JSON file during detection
+    const raw = require("node:fs").readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(raw);
+    const allDeps = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+
+    if (allDeps["@shadcn/ui"] || existsSync(join(cwd, "components.json")))
+      return "shadcn";
+    if (allDeps["@radix-ui/react-slot"]) return "radix";
+    if (allDeps["@chakra-ui/react"]) return "chakra";
+    if (allDeps["@mui/material"]) return "mui";
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export const tailwindExtractor: Extractor = {
+  name: "tailwind",
+
+  async detect(cwd: string): Promise<boolean> {
+    // Check for tailwind config files
+    for (const pattern of TAILWIND_CONFIG_PATTERNS) {
+      if (existsSync(join(cwd, pattern))) return true;
+    }
+
+    // Check for @tailwind or @theme directives in CSS files
+    const cssFiles = await walkDir(cwd, STYLE_EXTENSIONS, 10);
+    for (const file of cssFiles) {
+      const content = await readFile(file, "utf-8");
+      if (isTailwindCSS(content)) return true;
+    }
+
+    return false;
+  },
+
+  async extract(
+    cwd: string,
+    options?: ExtractorOptions,
+  ): Promise<ExtractedMaterial> {
+    const maxFiles = options?.maxFiles ?? 50;
+    const styleFiles: ExtractedFile[] = [];
+    const componentFiles: ExtractedFile[] = [];
+    const configFiles: ExtractedFile[] = [];
+
+    // Gather Tailwind config
+    for (const pattern of TAILWIND_CONFIG_PATTERNS) {
+      const configPath = join(cwd, pattern);
+      if (existsSync(configPath)) {
+        const content = await readFile(configPath, "utf-8");
+        configFiles.push({
+          path: pattern,
+          content,
+          type: "tailwind-config",
+        });
+        break;
+      }
+    }
+
+    // Gather CSS files (prioritize those with Tailwind directives)
+    const cssFiles = await walkDir(cwd, STYLE_EXTENSIONS, maxFiles);
+    for (const file of cssFiles) {
+      const content = await readFile(file, "utf-8");
+      styleFiles.push({
+        path: relative(cwd, file),
+        content,
+        type: "css",
+      });
+    }
+
+    // Gather component files
+    const componentDir = options?.componentDir
+      ? join(cwd, options.componentDir)
+      : null;
+
+    const searchDirs = componentDir
+      ? [componentDir]
+      : COMPONENT_DIRS.map((d) => join(cwd, d)).filter(existsSync);
+
+    let allClassNames: string[] = [];
+
+    for (const dir of searchDirs) {
+      const files = await walkDir(dir, COMPONENT_EXTENSIONS, maxFiles);
+      for (const file of files) {
+        const content = await readFile(file, "utf-8");
+        componentFiles.push({
+          path: relative(cwd, file),
+          content,
+          type: "component",
+        });
+        allClassNames.push(...extractClassNames(content));
+      }
+    }
+
+    // Deduplicate class names for metadata
+    allClassNames = [...new Set(allClassNames)];
+
+    // Count tokens from CSS files
+    let tokenCount = 0;
+    for (const sf of styleFiles) {
+      const matches = sf.content.match(/--[a-zA-Z][\w-]*\s*:/g);
+      if (matches) tokenCount += matches.length;
+    }
+
+    return {
+      styleFiles,
+      componentFiles,
+      configFiles,
+      metadata: {
+        framework: "tailwind",
+        componentLibrary: detectComponentLibrary(cwd),
+        tokenCount,
+        componentCount: componentFiles.length,
+      },
+    };
+  },
+};

--- a/packages/ghost-core/src/fingerprint/colors.ts
+++ b/packages/ghost-core/src/fingerprint/colors.ts
@@ -1,0 +1,140 @@
+import type { SemanticColor } from "../types.js";
+
+// Parse hex color to RGB
+function hexToRgb(hex: string): [number, number, number] | null {
+  const cleaned = hex.replace("#", "");
+  let r: number;
+  let g: number;
+  let b: number;
+
+  if (cleaned.length === 3) {
+    r = Number.parseInt(cleaned[0] + cleaned[0], 16);
+    g = Number.parseInt(cleaned[1] + cleaned[1], 16);
+    b = Number.parseInt(cleaned[2] + cleaned[2], 16);
+  } else if (cleaned.length === 6) {
+    r = Number.parseInt(cleaned.slice(0, 2), 16);
+    g = Number.parseInt(cleaned.slice(2, 4), 16);
+    b = Number.parseInt(cleaned.slice(4, 6), 16);
+  } else {
+    return null;
+  }
+
+  return [r, g, b];
+}
+
+// Parse rgb()/rgba() to RGB
+function parseRgbFunction(value: string): [number, number, number] | null {
+  const match = value.match(/rgba?\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+// Convert sRGB to linear RGB
+function linearize(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+// Convert linear RGB to OKLCH via OKLab
+// Simplified implementation based on the OKLCH spec
+function rgbToOklch(r: number, g: number, b: number): [number, number, number] {
+  const lr = linearize(r);
+  const lg = linearize(g);
+  const lb = linearize(b);
+
+  // sRGB to LMS (using OKLab matrix)
+  const l = Math.cbrt(
+    0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb,
+  );
+  const m = Math.cbrt(
+    0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb,
+  );
+  const s = Math.cbrt(
+    0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb,
+  );
+
+  // LMS to OKLab
+  const L = 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s;
+  const a = 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s;
+  const bVal = 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s;
+
+  // OKLab to OKLCH
+  const C = Math.sqrt(a * a + bVal * bVal);
+  let H = (Math.atan2(bVal, a) * 180) / Math.PI;
+  if (H < 0) H += 360;
+
+  return [
+    Math.round(L * 1000) / 1000,
+    Math.round(C * 1000) / 1000,
+    Math.round(H * 10) / 10,
+  ];
+}
+
+export function parseColorToOklch(
+  value: string,
+): [number, number, number] | null {
+  const trimmed = value.trim();
+
+  // Try hex
+  if (trimmed.startsWith("#")) {
+    const rgb = hexToRgb(trimmed);
+    if (rgb) return rgbToOklch(...rgb);
+  }
+
+  // Try rgb()/rgba()
+  if (trimmed.startsWith("rgb")) {
+    const rgb = parseRgbFunction(trimmed);
+    if (rgb) return rgbToOklch(...rgb);
+  }
+
+  // Try oklch() directly
+  const oklchMatch = trimmed.match(/oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)/);
+  if (oklchMatch) {
+    return [
+      Number(oklchMatch[1]),
+      Number(oklchMatch[2]),
+      Number(oklchMatch[3]),
+    ];
+  }
+
+  return null;
+}
+
+export function colorToSemanticColor(
+  role: string,
+  value: string,
+): SemanticColor {
+  const oklch = parseColorToOklch(value);
+  return { role, value, oklch: oklch ?? undefined };
+}
+
+export function classifySaturation(
+  colors: SemanticColor[],
+): "muted" | "vibrant" | "mixed" {
+  const chromas = colors.map((c) => c.oklch?.[1] ?? 0).filter((c) => c > 0);
+
+  if (chromas.length === 0) return "muted";
+
+  const avg = chromas.reduce((a, b) => a + b, 0) / chromas.length;
+  if (avg > 0.15) return "vibrant";
+  if (avg < 0.05) return "muted";
+  return "mixed";
+}
+
+export function classifyContrast(
+  colors: SemanticColor[],
+): "high" | "moderate" | "low" {
+  const lightnesses = colors
+    .map((c) => c.oklch?.[0] ?? 0.5)
+    .filter((_, _i, arr) => arr.length > 1);
+
+  if (lightnesses.length < 2) return "moderate";
+
+  const min = Math.min(...lightnesses);
+  const max = Math.max(...lightnesses);
+  const range = max - min;
+
+  if (range > 0.7) return "high";
+  if (range < 0.3) return "low";
+  return "moderate";
+}

--- a/packages/ghost-core/src/fingerprint/compare.ts
+++ b/packages/ghost-core/src/fingerprint/compare.ts
@@ -1,0 +1,312 @@
+import type {
+  DesignFingerprint,
+  DimensionDelta,
+  FingerprintComparison,
+} from "../types.js";
+
+// Dimension weights — palette and spacing have higher visual impact
+const WEIGHTS: Record<string, number> = {
+  palette: 0.3,
+  spacing: 0.2,
+  typography: 0.2,
+  surfaces: 0.15,
+  architecture: 0.15,
+};
+
+export function compareFingerprints(
+  source: DesignFingerprint,
+  target: DesignFingerprint,
+): FingerprintComparison {
+  const dimensions: Record<string, DimensionDelta> = {};
+
+  dimensions.palette = comparePalette(source, target);
+  dimensions.spacing = compareSpacing(source, target);
+  dimensions.typography = compareTypography(source, target);
+  dimensions.surfaces = compareSurfaces(source, target);
+  dimensions.architecture = compareArchitecture(source, target);
+
+  // Weighted overall distance
+  let distance = 0;
+  for (const [key, weight] of Object.entries(WEIGHTS)) {
+    distance += (dimensions[key]?.distance ?? 0) * weight;
+  }
+
+  const summary = buildSummary(dimensions, distance);
+
+  return { source, target, distance, dimensions, summary };
+}
+
+function comparePalette(
+  a: DesignFingerprint,
+  b: DesignFingerprint,
+): DimensionDelta {
+  const distances: number[] = [];
+
+  // Compare dominant colors by OKLCH delta-E
+  const maxDominant = Math.max(
+    a.palette.dominant.length,
+    b.palette.dominant.length,
+  );
+  if (maxDominant > 0) {
+    for (let i = 0; i < maxDominant; i++) {
+      const ca = a.palette.dominant[i];
+      const cb = b.palette.dominant[i];
+      if (ca?.oklch && cb?.oklch) {
+        distances.push(oklchDistance(ca.oklch, cb.oklch));
+      } else if (ca || cb) {
+        distances.push(1); // one is missing
+      }
+    }
+  }
+
+  // Compare semantic role coverage
+  const aRoles = new Set(a.palette.semantic.map((c) => c.role));
+  const bRoles = new Set(b.palette.semantic.map((c) => c.role));
+  const allRoles = new Set([...aRoles, ...bRoles]);
+  const sharedRoles = [...allRoles].filter(
+    (r) => aRoles.has(r) && bRoles.has(r),
+  );
+  const roleCoverage =
+    allRoles.size > 0 ? 1 - sharedRoles.length / allRoles.size : 0;
+  distances.push(roleCoverage);
+
+  // Compare qualitative
+  if (a.palette.saturationProfile !== b.palette.saturationProfile)
+    distances.push(0.5);
+  if (a.palette.contrast !== b.palette.contrast) distances.push(0.5);
+
+  // Compare semantic colors that exist in both
+  for (const role of sharedRoles) {
+    const ca = a.palette.semantic.find((c) => c.role === role);
+    const cb = b.palette.semantic.find((c) => c.role === role);
+    if (ca?.oklch && cb?.oklch) {
+      distances.push(oklchDistance(ca.oklch, cb.oklch));
+    }
+  }
+
+  const distance = avg(distances);
+  const description = describePaletteChange(a, b, distance);
+
+  return { dimension: "palette", distance, description };
+}
+
+function compareSpacing(
+  a: DesignFingerprint,
+  b: DesignFingerprint,
+): DimensionDelta {
+  const distances: number[] = [];
+
+  // Scale similarity (Jaccard-like)
+  const aSet = new Set(a.spacing.scale);
+  const bSet = new Set(b.spacing.scale);
+  const union = new Set([...aSet, ...bSet]);
+  const intersection = [...union].filter((v) => aSet.has(v) && bSet.has(v));
+  distances.push(union.size > 0 ? 1 - intersection.length / union.size : 0);
+
+  // Regularity delta
+  distances.push(Math.abs(a.spacing.regularity - b.spacing.regularity));
+
+  // Base unit match
+  if (a.spacing.baseUnit && b.spacing.baseUnit) {
+    distances.push(a.spacing.baseUnit === b.spacing.baseUnit ? 0 : 0.5);
+  }
+
+  const distance = avg(distances);
+  return {
+    dimension: "spacing",
+    distance,
+    description:
+      distance < 0.1
+        ? "Spacing scales are nearly identical"
+        : distance < 0.3
+          ? "Minor spacing differences"
+          : "Significant spacing divergence",
+  };
+}
+
+function compareTypography(
+  a: DesignFingerprint,
+  b: DesignFingerprint,
+): DimensionDelta {
+  const distances: number[] = [];
+
+  // Family match
+  const sharedFamilies = a.typography.families.filter((f) =>
+    b.typography.families.includes(f),
+  );
+  const allFamilies = new Set([
+    ...a.typography.families,
+    ...b.typography.families,
+  ]);
+  distances.push(
+    allFamilies.size > 0 ? 1 - sharedFamilies.length / allFamilies.size : 0,
+  );
+
+  // Size ramp similarity
+  const aRamp = new Set(a.typography.sizeRamp);
+  const bRamp = new Set(b.typography.sizeRamp);
+  const rampUnion = new Set([...aRamp, ...bRamp]);
+  const rampIntersection = [...rampUnion].filter(
+    (v) => aRamp.has(v) && bRamp.has(v),
+  );
+  distances.push(
+    rampUnion.size > 0 ? 1 - rampIntersection.length / rampUnion.size : 0,
+  );
+
+  // Line height pattern
+  if (a.typography.lineHeightPattern !== b.typography.lineHeightPattern)
+    distances.push(0.3);
+
+  const distance = avg(distances);
+  return {
+    dimension: "typography",
+    distance,
+    description:
+      distance < 0.1
+        ? "Typography systems match"
+        : distance < 0.3
+          ? "Minor typographic differences"
+          : "Different typographic language",
+  };
+}
+
+function compareSurfaces(
+  a: DesignFingerprint,
+  b: DesignFingerprint,
+): DimensionDelta {
+  const distances: number[] = [];
+
+  // Border radii overlap
+  const aRadii = new Set(a.surfaces.borderRadii);
+  const bRadii = new Set(b.surfaces.borderRadii);
+  const radiiUnion = new Set([...aRadii, ...bRadii]);
+  const radiiIntersection = [...radiiUnion].filter(
+    (v) => aRadii.has(v) && bRadii.has(v),
+  );
+  distances.push(
+    radiiUnion.size > 0 ? 1 - radiiIntersection.length / radiiUnion.size : 0,
+  );
+
+  // Shadow complexity
+  if (a.surfaces.shadowComplexity !== b.surfaces.shadowComplexity)
+    distances.push(0.5);
+
+  // Border usage
+  if (a.surfaces.borderUsage !== b.surfaces.borderUsage) distances.push(0.3);
+
+  const distance = avg(distances);
+  return {
+    dimension: "surfaces",
+    distance,
+    description:
+      distance < 0.1
+        ? "Surface treatments align"
+        : distance < 0.3
+          ? "Minor surface differences"
+          : "Distinct surface language",
+  };
+}
+
+function compareArchitecture(
+  a: DesignFingerprint,
+  b: DesignFingerprint,
+): DimensionDelta {
+  const distances: number[] = [];
+
+  // Tokenization delta
+  distances.push(
+    Math.abs(a.architecture.tokenization - b.architecture.tokenization),
+  );
+
+  // Methodology overlap
+  const aMethods = new Set(a.architecture.methodology);
+  const bMethods = new Set(b.architecture.methodology);
+  const allMethods = new Set([...aMethods, ...bMethods]);
+  const sharedMethods = [...allMethods].filter(
+    (m) => aMethods.has(m) && bMethods.has(m),
+  );
+  distances.push(
+    allMethods.size > 0 ? 1 - sharedMethods.length / allMethods.size : 0,
+  );
+
+  // Component count ratio
+  const maxCount = Math.max(
+    a.architecture.componentCount,
+    b.architecture.componentCount,
+  );
+  const minCount = Math.min(
+    a.architecture.componentCount,
+    b.architecture.componentCount,
+  );
+  distances.push(maxCount > 0 ? 1 - minCount / maxCount : 0);
+
+  // Naming pattern
+  if (a.architecture.namingPattern !== b.architecture.namingPattern)
+    distances.push(0.3);
+
+  const distance = avg(distances);
+  return {
+    dimension: "architecture",
+    distance,
+    description:
+      distance < 0.1
+        ? "Architecturally aligned"
+        : distance < 0.3
+          ? "Minor architectural differences"
+          : "Fundamentally different architecture",
+  };
+}
+
+// --- Helpers ---
+
+function oklchDistance(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  // Weighted OKLCH distance (lightness matters most, then chroma, then hue)
+  const dL = Math.abs(a[0] - b[0]); // 0-1
+  const dC = Math.abs(a[1] - b[1]); // 0-0.4 typical
+  const dH = Math.min(Math.abs(a[2] - b[2]), 360 - Math.abs(a[2] - b[2])) / 180; // normalized
+
+  return Math.min(dL * 0.5 + dC * 2 + dH * 0.3, 1);
+}
+
+function avg(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function describePaletteChange(
+  _a: DesignFingerprint,
+  _b: DesignFingerprint,
+  distance: number,
+): string {
+  if (distance < 0.1) return "Color palettes are nearly identical";
+  if (distance < 0.3) return "Minor palette variations";
+  return "Significant palette divergence";
+}
+
+function buildSummary(
+  dimensions: Record<string, DimensionDelta>,
+  distance: number,
+): string {
+  if (distance < 0.05) return "These projects share the same design language.";
+  if (distance < 0.15)
+    return "Minor design differences — likely the same system with small customizations.";
+  if (distance < 0.3)
+    return "Moderate divergence — shared foundation but notable differences.";
+  if (distance < 0.5)
+    return "Significant divergence — different design decisions across multiple dimensions.";
+
+  // Identify the biggest divergence
+  const sorted = Object.entries(dimensions).sort(
+    ([, a], [, b]) => b.distance - a.distance,
+  );
+  const biggest = sorted[0];
+  if (biggest) {
+    return `Fundamentally different design languages. Largest gap: ${biggest[0]} (${(biggest[1].distance * 100).toFixed(0)}%).`;
+  }
+  return "Fundamentally different design languages.";
+}
+
+export { embeddingDistance } from "./embedding.js";

--- a/packages/ghost-core/src/fingerprint/describe.ts
+++ b/packages/ghost-core/src/fingerprint/describe.ts
@@ -1,0 +1,165 @@
+import type { DesignFingerprint } from "../types.js";
+
+/**
+ * Render a DesignFingerprint as a standardized natural language description.
+ * This text is fed to embedding models to produce semantic vectors.
+ *
+ * The description is structured to emphasize design-relevant signals
+ * and minimize noise from identifiers or timestamps.
+ */
+export function describeFingerprint(fp: DesignFingerprint): string {
+  const sections: string[] = [];
+
+  // Palette
+  sections.push(describePalette(fp));
+
+  // Spacing
+  sections.push(describeSpacing(fp));
+
+  // Typography
+  sections.push(describeTypography(fp));
+
+  // Surfaces
+  sections.push(describeSurfaces(fp));
+
+  // Architecture
+  sections.push(describeArchitecture(fp));
+
+  return sections.filter(Boolean).join(" ");
+}
+
+function describePalette(fp: DesignFingerprint): string {
+  const parts: string[] = [];
+
+  const { palette } = fp;
+
+  if (palette.dominant.length > 0) {
+    const colors = palette.dominant
+      .map((c) => {
+        const oklch = c.oklch
+          ? `oklch(${c.oklch[0]}, ${c.oklch[1]}, ${c.oklch[2]})`
+          : c.value;
+        return `${c.role}: ${oklch}`;
+      })
+      .join(", ");
+    parts.push(`Dominant colors: ${colors}.`);
+  }
+
+  if (palette.semantic.length > 0) {
+    const roles = palette.semantic
+      .map((c) => {
+        const oklch = c.oklch
+          ? `oklch(${c.oklch[0]}, ${c.oklch[1]}, ${c.oklch[2]})`
+          : c.value;
+        return `${c.role}: ${oklch}`;
+      })
+      .join(", ");
+    parts.push(`Semantic colors: ${roles}.`);
+  }
+
+  if (palette.neutrals.count > 0) {
+    parts.push(`${palette.neutrals.count}-step neutral gray ramp.`);
+  }
+
+  parts.push(
+    `${palette.saturationProfile} saturation profile, ${palette.contrast} contrast.`,
+  );
+
+  return parts.join(" ");
+}
+
+function describeSpacing(fp: DesignFingerprint): string {
+  const { spacing } = fp;
+  const parts: string[] = [];
+
+  if (spacing.scale.length > 0) {
+    parts.push(`Spacing scale: ${spacing.scale.join(", ")}px.`);
+  } else {
+    parts.push("No spacing scale detected.");
+  }
+
+  if (spacing.baseUnit) {
+    parts.push(`Base unit: ${spacing.baseUnit}px.`);
+  }
+
+  const regularity =
+    spacing.regularity > 0.8
+      ? "highly regular"
+      : spacing.regularity > 0.4
+        ? "moderately regular"
+        : "irregular";
+  parts.push(`Scale is ${regularity}.`);
+
+  return parts.join(" ");
+}
+
+function describeTypography(fp: DesignFingerprint): string {
+  const { typography } = fp;
+  const parts: string[] = [];
+
+  if (typography.families.length > 0) {
+    parts.push(`Font families: ${typography.families.join(", ")}.`);
+  }
+
+  if (typography.sizeRamp.length > 0) {
+    const min = typography.sizeRamp[0];
+    const max = typography.sizeRamp[typography.sizeRamp.length - 1];
+    parts.push(
+      `Type scale: ${typography.sizeRamp.length} sizes from ${min}px to ${max}px.`,
+    );
+  }
+
+  const weightEntries = Object.entries(typography.weightDistribution);
+  if (weightEntries.length > 0) {
+    const weights = weightEntries
+      .map(([w, count]) => `${w} (${count}x)`)
+      .join(", ");
+    parts.push(`Font weights: ${weights}.`);
+  }
+
+  parts.push(`Line height: ${typography.lineHeightPattern}.`);
+
+  return parts.join(" ");
+}
+
+function describeSurfaces(fp: DesignFingerprint): string {
+  const { surfaces } = fp;
+  const parts: string[] = [];
+
+  if (surfaces.borderRadii.length > 0) {
+    parts.push(
+      `Border radii: ${surfaces.borderRadii.map((r) => `${r}px`).join(", ")}.`,
+    );
+  } else {
+    parts.push("No border radii detected.");
+  }
+
+  parts.push(`Shadow complexity: ${surfaces.shadowComplexity}.`);
+  parts.push(`Border usage: ${surfaces.borderUsage}.`);
+
+  return parts.join(" ");
+}
+
+function describeArchitecture(fp: DesignFingerprint): string {
+  const { architecture } = fp;
+  const parts: string[] = [];
+
+  const pct = Math.round(architecture.tokenization * 100);
+  parts.push(`${pct}% tokenized.`);
+
+  if (architecture.methodology.length > 0) {
+    parts.push(`CSS methodology: ${architecture.methodology.join(", ")}.`);
+  }
+
+  parts.push(`${architecture.componentCount} components.`);
+
+  const cats = Object.entries(architecture.componentCategories);
+  if (cats.length > 0) {
+    const catStr = cats.map(([k, v]) => `${k} (${v})`).join(", ");
+    parts.push(`Categories: ${catStr}.`);
+  }
+
+  parts.push(`Naming: ${architecture.namingPattern}.`);
+
+  return parts.join(" ");
+}

--- a/packages/ghost-core/src/fingerprint/embed-api.ts
+++ b/packages/ghost-core/src/fingerprint/embed-api.ts
@@ -1,0 +1,98 @@
+import type { DesignFingerprint, EmbeddingConfig } from "../types.js";
+import { describeFingerprint } from "./describe.js";
+
+/**
+ * Generate a semantic embedding for a fingerprint using an external API.
+ *
+ * Converts the structured fingerprint into a natural language description,
+ * then sends it to an embedding model. The resulting vector captures semantic
+ * similarity — two projects using `bg-slate-900` and `--color-gray-900: #0f172a`
+ * will land nearby because the model understands they express the same intent.
+ *
+ * Supported providers:
+ *   - openai: Uses text-embedding-3-small (default). Set OPENAI_API_KEY env var.
+ *   - voyage: Uses voyage-3 (default). Set VOYAGE_API_KEY env var.
+ */
+export async function computeSemanticEmbedding(
+  fingerprint: DesignFingerprint,
+  config: EmbeddingConfig,
+): Promise<number[]> {
+  const text = describeFingerprint(fingerprint);
+
+  switch (config.provider) {
+    case "openai":
+      return embedViaOpenAI(text, config);
+    case "voyage":
+      return embedViaVoyage(text, config);
+    default:
+      throw new Error(`Unknown embedding provider: ${config.provider}`);
+  }
+}
+
+async function embedViaOpenAI(
+  text: string,
+  config: EmbeddingConfig,
+): Promise<number[]> {
+  const apiKey = config.apiKey ?? process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "OpenAI API key required for embeddings. Set OPENAI_API_KEY env var or embedding.apiKey in config.",
+    );
+  }
+
+  const model = config.model ?? "text-embedding-3-small";
+
+  const response = await fetch("https://api.openai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ input: text, model }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`OpenAI embedding API error (${response.status}): ${body}`);
+  }
+
+  const data = (await response.json()) as {
+    data: { embedding: number[] }[];
+  };
+
+  return data.data[0].embedding;
+}
+
+async function embedViaVoyage(
+  text: string,
+  config: EmbeddingConfig,
+): Promise<number[]> {
+  const apiKey = config.apiKey ?? process.env.VOYAGE_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Voyage API key required for embeddings. Set VOYAGE_API_KEY env var or embedding.apiKey in config.",
+    );
+  }
+
+  const model = config.model ?? "voyage-3";
+
+  const response = await fetch("https://api.voyageai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ input: [text], model }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Voyage embedding API error (${response.status}): ${body}`);
+  }
+
+  const data = (await response.json()) as {
+    data: { embedding: number[] }[];
+  };
+
+  return data.data[0].embedding;
+}

--- a/packages/ghost-core/src/fingerprint/embedding.ts
+++ b/packages/ghost-core/src/fingerprint/embedding.ts
@@ -1,0 +1,179 @@
+import type { DesignFingerprint } from "../types.js";
+
+type FingerprintInput = Omit<DesignFingerprint, "embedding">;
+
+// Fixed embedding size for comparability
+const EMBEDDING_SIZE = 64;
+
+/**
+ * Compute a deterministic numeric embedding from a structured fingerprint.
+ * This ensures fingerprints from different sources (LLM, registry, extraction)
+ * produce comparable vectors.
+ *
+ * Dimensions (64 total):
+ *  [0-11]   Palette: dominant colors OKLCH (up to 4 colors x 3 channels)
+ *  [12-17]  Palette: neutral ramp features (count, min/max lightness, spread)
+ *  [18-20]  Palette: qualitative (saturation profile, contrast, semantic count)
+ *  [21-30]  Spacing: scale features (count, min, max, regularity, base unit, distribution)
+ *  [31-40]  Typography: families count, size ramp features, weight distribution
+ *  [41-48]  Surfaces: radii features, shadow complexity, border usage
+ *  [49-63]  Architecture: tokenization, component count, methodology, categories
+ */
+export function computeEmbedding(fingerprint: FingerprintInput): number[] {
+  const vec: number[] = new Array(EMBEDDING_SIZE).fill(0);
+  let i = 0;
+
+  // --- Palette: dominant colors (12 dims) ---
+  const dominantSlots = 4;
+  for (let s = 0; s < dominantSlots; s++) {
+    const color = fingerprint.palette.dominant[s];
+    if (color?.oklch) {
+      vec[i++] = color.oklch[0]; // L (0-1)
+      vec[i++] = color.oklch[1]; // C (0-0.4 typical)
+      vec[i++] = color.oklch[2] / 360; // H normalized to 0-1
+    } else {
+      i += 3;
+    }
+  }
+
+  // --- Palette: neutral ramp (6 dims) ---
+  vec[i++] = Math.min(fingerprint.palette.neutrals.count / 10, 1);
+  // Parse lightness from neutral steps (use oklch if available from semantic colors)
+  const neutralCount = fingerprint.palette.neutrals.count;
+  vec[i++] = neutralCount > 0 ? 1 : 0; // has neutrals
+  vec[i++] = Math.min(neutralCount / 20, 1); // ramp density
+  i += 3; // reserved for neutral lightness range
+
+  // --- Palette: qualitative (3 dims) ---
+  vec[i++] =
+    fingerprint.palette.saturationProfile === "vibrant"
+      ? 1
+      : fingerprint.palette.saturationProfile === "mixed"
+        ? 0.5
+        : 0;
+  vec[i++] =
+    fingerprint.palette.contrast === "high"
+      ? 1
+      : fingerprint.palette.contrast === "moderate"
+        ? 0.5
+        : 0;
+  vec[i++] = Math.min(fingerprint.palette.semantic.length / 10, 1);
+
+  // --- Spacing (10 dims) ---
+  const spacing = fingerprint.spacing;
+  vec[i++] = Math.min(spacing.scale.length / 10, 1);
+  vec[i++] = spacing.scale.length > 0 ? Math.min(spacing.scale[0] / 100, 1) : 0;
+  vec[i++] =
+    spacing.scale.length > 0
+      ? Math.min(spacing.scale[spacing.scale.length - 1] / 100, 1)
+      : 0;
+  vec[i++] = spacing.regularity;
+  vec[i++] = spacing.baseUnit ? Math.min(spacing.baseUnit / 16, 1) : 0;
+  // Distribution: quartile features
+  const spacingMid =
+    spacing.scale.length > 0
+      ? spacing.scale[Math.floor(spacing.scale.length / 2)] / 100
+      : 0;
+  vec[i++] = Math.min(spacingMid, 1);
+  i += 4; // reserved
+
+  // --- Typography (10 dims) ---
+  const typo = fingerprint.typography;
+  vec[i++] = Math.min(typo.families.length / 5, 1);
+  vec[i++] = Math.min(typo.sizeRamp.length / 10, 1);
+  // Size range
+  vec[i++] = typo.sizeRamp.length > 0 ? Math.min(typo.sizeRamp[0] / 100, 1) : 0;
+  vec[i++] =
+    typo.sizeRamp.length > 0
+      ? Math.min(typo.sizeRamp[typo.sizeRamp.length - 1] / 100, 1)
+      : 0;
+  // Weight distribution entropy
+  const weights = Object.values(typo.weightDistribution);
+  const totalWeights = weights.reduce((a, b) => a + b, 0);
+  vec[i++] =
+    totalWeights > 0
+      ? -weights.reduce((ent, w) => {
+          const p = w / totalWeights;
+          return p > 0 ? ent + p * Math.log2(p) : ent;
+        }, 0) / Math.log2(Math.max(weights.length, 2))
+      : 0;
+  // Line height
+  vec[i++] =
+    typo.lineHeightPattern === "tight"
+      ? 0
+      : typo.lineHeightPattern === "normal"
+        ? 0.5
+        : 1;
+  i += 4; // reserved
+
+  // --- Surfaces (8 dims) ---
+  const surfaces = fingerprint.surfaces;
+  vec[i++] = Math.min(surfaces.borderRadii.length / 5, 1);
+  vec[i++] =
+    surfaces.borderRadii.length > 0
+      ? Math.min(surfaces.borderRadii[0] / 32, 1)
+      : 0;
+  vec[i++] =
+    surfaces.borderRadii.length > 0
+      ? Math.min(surfaces.borderRadii[surfaces.borderRadii.length - 1] / 32, 1)
+      : 0;
+  vec[i++] =
+    surfaces.shadowComplexity === "layered"
+      ? 1
+      : surfaces.shadowComplexity === "subtle"
+        ? 0.5
+        : 0;
+  vec[i++] =
+    surfaces.borderUsage === "heavy"
+      ? 1
+      : surfaces.borderUsage === "moderate"
+        ? 0.5
+        : 0;
+  i += 3; // reserved
+
+  // --- Architecture (15 dims) ---
+  const arch = fingerprint.architecture;
+  vec[i++] = arch.tokenization;
+  vec[i++] = Math.min(arch.componentCount / 50, 1);
+  // Methodology encoding
+  vec[i++] = arch.methodology.includes("tailwind") ? 1 : 0;
+  vec[i++] = arch.methodology.includes("css-custom-properties") ? 1 : 0;
+  vec[i++] = arch.methodology.includes("scss") ? 1 : 0;
+  vec[i++] = arch.methodology.includes("css-modules") ? 1 : 0;
+  // Category diversity
+  const catCount = Object.keys(arch.componentCategories).length;
+  vec[i++] = Math.min(catCount / 10, 1);
+  // Naming pattern
+  vec[i++] =
+    arch.namingPattern === "kebab-case"
+      ? 0
+      : arch.namingPattern === "camelCase"
+        ? 0.33
+        : arch.namingPattern === "PascalCase"
+          ? 0.67
+          : 1;
+
+  return vec;
+}
+
+/**
+ * Cosine similarity between two embedding vectors (0 = identical, 1 = orthogonal)
+ */
+export function embeddingDistance(a: number[], b: number[]): number {
+  const len = Math.min(a.length, b.length);
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < len; i++) {
+    dotProduct += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+
+  const magnitude = Math.sqrt(normA) * Math.sqrt(normB);
+  if (magnitude === 0) return 1;
+
+  // Convert similarity (1 = identical) to distance (0 = identical)
+  return 1 - dotProduct / magnitude;
+}

--- a/packages/ghost-core/src/fingerprint/from-registry.ts
+++ b/packages/ghost-core/src/fingerprint/from-registry.ts
@@ -1,0 +1,253 @@
+import type {
+  ColorRamp,
+  CSSToken,
+  DesignFingerprint,
+  ResolvedRegistry,
+  SemanticColor,
+} from "../types.js";
+import {
+  classifyContrast,
+  classifySaturation,
+  colorToSemanticColor,
+} from "./colors.js";
+import { computeEmbedding } from "./embedding.js";
+
+const SEMANTIC_ROLES: Record<string, string> = {
+  "--background-default": "surface",
+  "--background-alt": "surface-alt",
+  "--background-accent": "accent",
+  "--text-default": "text",
+  "--text-muted": "text-muted",
+  "--text-inverse": "text-inverse",
+  "--text-danger": "danger",
+  "--border-default": "border",
+  "--border-strong": "border-strong",
+};
+
+function resolveTokenValue(token: CSSToken): string {
+  return token.resolvedValue ?? token.value;
+}
+
+function extractSemanticColors(tokens: CSSToken[]): SemanticColor[] {
+  const colors: SemanticColor[] = [];
+  for (const token of tokens) {
+    const role = SEMANTIC_ROLES[token.name];
+    if (role) {
+      colors.push(colorToSemanticColor(role, resolveTokenValue(token)));
+    }
+  }
+  return colors;
+}
+
+function extractDominantColors(tokens: CSSToken[]): SemanticColor[] {
+  // Dominant = non-neutral, non-text semantic colors
+  const dominantRoles = ["accent", "danger"];
+  const all = extractSemanticColors(tokens);
+  const dominant = all.filter((c) => dominantRoles.includes(c.role));
+  // If no explicit dominant, use first non-neutral color
+  if (dominant.length === 0 && all.length > 0) {
+    return [all[0]];
+  }
+  return dominant;
+}
+
+function extractNeutralRamp(tokens: CSSToken[]): ColorRamp {
+  const grayTokens = tokens
+    .filter(
+      (t) =>
+        t.name.startsWith("--color-gray-") ||
+        t.name === "--color-white" ||
+        t.name === "--color-black",
+    )
+    .map((t) => resolveTokenValue(t))
+    .filter((v) => !v.startsWith("var("));
+
+  return { steps: grayTokens, count: grayTokens.length };
+}
+
+function extractSpacing(tokens: CSSToken[]): {
+  scale: number[];
+  regularity: number;
+  baseUnit: number | null;
+} {
+  const spacingValues: number[] = [];
+  for (const token of tokens) {
+    if (token.category === "spacing") {
+      const num = Number.parseFloat(resolveTokenValue(token));
+      if (!Number.isNaN(num)) spacingValues.push(num);
+    }
+  }
+
+  spacingValues.sort((a, b) => a - b);
+  const unique = [...new Set(spacingValues)];
+
+  // Detect base unit (GCD-like)
+  let baseUnit: number | null = null;
+  if (unique.length >= 2) {
+    const diffs = unique.slice(1).map((v, i) => v - unique[i]);
+    const minDiff = Math.min(...diffs.filter((d) => d > 0));
+    if (minDiff > 0) baseUnit = minDiff;
+  }
+
+  // Regularity: how well does the scale follow a consistent step pattern?
+  let regularity = 0;
+  if (baseUnit && unique.length >= 2) {
+    const expectedSteps = unique.map((v) => Math.round(v / baseUnit));
+    const isRegular = expectedSteps.every(
+      (s, i) =>
+        i === 0 ||
+        s === expectedSteps[i - 1] + 1 ||
+        s === expectedSteps[i - 1] * 2,
+    );
+    regularity = isRegular ? 1 : 0.5;
+  }
+
+  return { scale: unique, regularity, baseUnit };
+}
+
+function extractBorderRadii(tokens: CSSToken[]): number[] {
+  const radii: number[] = [];
+  for (const token of tokens) {
+    if (token.category === "radius") {
+      const num = Number.parseFloat(resolveTokenValue(token));
+      if (!Number.isNaN(num)) radii.push(num);
+    }
+  }
+  return [...new Set(radii)].sort((a, b) => a - b);
+}
+
+function classifyShadowComplexity(
+  tokens: CSSToken[],
+): "none" | "subtle" | "layered" {
+  const shadowTokens = tokens.filter((t) => t.category === "shadow");
+  if (shadowTokens.length === 0) return "none";
+
+  const hasMultipleLayers = shadowTokens.some((t) => {
+    const val = resolveTokenValue(t);
+    // Count comma-separated shadow layers
+    return val.split(",").length > 1;
+  });
+
+  return hasMultipleLayers ? "layered" : "subtle";
+}
+
+function extractTypography(tokens: CSSToken[]): {
+  families: string[];
+  sizeRamp: number[];
+  weightDistribution: Record<number, number>;
+} {
+  const families: string[] = [];
+  const sizes: number[] = [];
+  const weights: Record<number, number> = {};
+
+  for (const token of tokens) {
+    if (token.category === "font") {
+      const val = resolveTokenValue(token);
+      if (
+        token.name.includes("family") ||
+        (/[a-zA-Z]/.test(val) && !val.startsWith("var("))
+      ) {
+        families.push(val);
+      }
+    }
+    if (token.category === "typography") {
+      const num = Number.parseFloat(resolveTokenValue(token));
+      if (!Number.isNaN(num)) {
+        if (token.name.includes("weight")) {
+          weights[num] = (weights[num] ?? 0) + 1;
+        } else {
+          sizes.push(num);
+        }
+      }
+    }
+  }
+
+  return {
+    families: [...new Set(families)],
+    sizeRamp: [...new Set(sizes)].sort((a, b) => a - b),
+    weightDistribution: weights,
+  };
+}
+
+export function fingerprintFromRegistry(
+  registry: ResolvedRegistry,
+): DesignFingerprint {
+  const tokens = registry.tokens;
+  const rootTokens = tokens.filter(
+    (t) => t.selector === ":root" || t.selector === "@theme",
+  );
+
+  const semanticColors = extractSemanticColors(rootTokens);
+  const allColors = [...semanticColors, ...extractDominantColors(tokens)];
+
+  const uiItems = registry.items.filter((i) => i.type === "registry:ui");
+  const categories: Record<string, number> = {};
+  for (const item of uiItems) {
+    for (const cat of item.categories ?? ["uncategorized"]) {
+      categories[cat] = (categories[cat] ?? 0) + 1;
+    }
+  }
+
+  const typography = extractTypography(tokens);
+  const spacing = extractSpacing(tokens);
+
+  const fingerprint: Omit<DesignFingerprint, "embedding"> = {
+    id: registry.name,
+    source: "registry",
+    timestamp: new Date().toISOString(),
+
+    palette: {
+      dominant: extractDominantColors(tokens),
+      neutrals: extractNeutralRamp(tokens),
+      semantic: semanticColors,
+      saturationProfile: classifySaturation(allColors),
+      contrast: classifyContrast(allColors),
+    },
+
+    spacing,
+
+    typography: {
+      families: typography.families,
+      sizeRamp: typography.sizeRamp,
+      weightDistribution: typography.weightDistribution,
+      lineHeightPattern: "normal", // default for registry
+    },
+
+    surfaces: {
+      borderRadii: extractBorderRadii(tokens),
+      shadowComplexity: classifyShadowComplexity(tokens),
+      borderUsage:
+        tokens.filter((t) => t.category === "border").length > 3
+          ? "heavy"
+          : tokens.filter((t) => t.category === "border").length > 0
+            ? "moderate"
+            : "minimal",
+    },
+
+    architecture: {
+      tokenization: 1, // registry is fully tokenized by definition
+      methodology: ["css-custom-properties"],
+      componentCount: uiItems.length,
+      componentCategories: categories,
+      namingPattern: detectNamingPattern(uiItems.map((i) => i.name)),
+    },
+  };
+
+  return {
+    ...fingerprint,
+    embedding: computeEmbedding(fingerprint),
+  };
+}
+
+function detectNamingPattern(names: string[]): string {
+  if (names.length === 0) return "unknown";
+
+  const allKebab = names.every((n) => /^[a-z][a-z0-9-]*$/.test(n));
+  const allCamel = names.every((n) => /^[a-z][a-zA-Z0-9]*$/.test(n));
+  const allPascal = names.every((n) => /^[A-Z][a-zA-Z0-9]*$/.test(n));
+
+  if (allKebab) return "kebab-case";
+  if (allPascal) return "PascalCase";
+  if (allCamel) return "camelCase";
+  return "mixed";
+}

--- a/packages/ghost-core/src/fingerprint/index.ts
+++ b/packages/ghost-core/src/fingerprint/index.ts
@@ -1,4 +1,6 @@
 export { colorToSemanticColor, parseColorToOklch } from "./colors.js";
 export { compareFingerprints } from "./compare.js";
+export { describeFingerprint } from "./describe.js";
+export { computeSemanticEmbedding } from "./embed-api.js";
 export { computeEmbedding, embeddingDistance } from "./embedding.js";
 export { fingerprintFromRegistry } from "./from-registry.js";

--- a/packages/ghost-core/src/fingerprint/index.ts
+++ b/packages/ghost-core/src/fingerprint/index.ts
@@ -1,0 +1,4 @@
+export { colorToSemanticColor, parseColorToOklch } from "./colors.js";
+export { compareFingerprints } from "./compare.js";
+export { computeEmbedding, embeddingDistance } from "./embedding.js";
+export { fingerprintFromRegistry } from "./from-registry.js";

--- a/packages/ghost-core/src/index.ts
+++ b/packages/ghost-core/src/index.ts
@@ -1,23 +1,49 @@
 export { defineConfig, loadConfig } from "./config.js";
+export { detectExtractors, extract } from "./extractors/index.js";
+export {
+  compareFingerprints,
+  computeEmbedding,
+  embeddingDistance,
+  fingerprintFromRegistry,
+} from "./fingerprint/index.js";
+export { createProvider } from "./llm/index.js";
+export { profile, profileRegistry } from "./profile.js";
 export { formatReport as formatCLIReport } from "./reporters/cli.js";
+export {
+  formatComparison,
+  formatComparisonJSON,
+  formatFingerprint,
+  formatFingerprintJSON,
+} from "./reporters/fingerprint.js";
 export { formatReport as formatJSONReport } from "./reporters/json.js";
 export { parseCSS } from "./resolvers/css.js";
 export { resolveRegistry } from "./resolvers/registry.js";
 export { scan } from "./scan.js";
 export { scanVisual } from "./scanners/visual.js";
 export type {
+  ColorRamp,
   CSSToken,
+  DesignFingerprint,
   DesignSystemConfig,
   DesignSystemReport,
+  DimensionDelta,
   DriftReport,
   DriftSummary,
+  ExtractedFile,
+  ExtractedMaterial,
+  Extractor,
+  ExtractorOptions,
+  FingerprintComparison,
   GhostConfig,
+  LLMConfig,
+  LLMProvider,
   Registry,
   RegistryFile,
   RegistryItem,
   ResolvedRegistry,
   RuleSeverity,
   ScanOptions,
+  SemanticColor,
   StructureDrift,
   TokenCategory,
   ValueDrift,

--- a/packages/ghost-core/src/index.ts
+++ b/packages/ghost-core/src/index.ts
@@ -3,6 +3,8 @@ export { detectExtractors, extract } from "./extractors/index.js";
 export {
   compareFingerprints,
   computeEmbedding,
+  computeSemanticEmbedding,
+  describeFingerprint,
   embeddingDistance,
   fingerprintFromRegistry,
 } from "./fingerprint/index.js";
@@ -29,6 +31,7 @@ export type {
   DimensionDelta,
   DriftReport,
   DriftSummary,
+  EmbeddingConfig,
   ExtractedFile,
   ExtractedMaterial,
   Extractor,

--- a/packages/ghost-core/src/llm/anthropic.ts
+++ b/packages/ghost-core/src/llm/anthropic.ts
@@ -1,0 +1,78 @@
+import type {
+  DesignFingerprint,
+  ExtractedMaterial,
+  LLMProvider,
+} from "../types.js";
+import { buildFingerprintPrompt } from "./prompt.js";
+import { summarizeMaterial } from "./summarize.js";
+
+interface AnthropicClient {
+  messages: {
+    create(opts: {
+      model: string;
+      max_tokens: number;
+      messages: { role: string; content: string }[];
+    }): Promise<{ content: { type: string; text?: string }[] }>;
+  };
+}
+
+export function createAnthropicProvider(options: {
+  apiKey?: string;
+  model?: string;
+}): LLMProvider {
+  const apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  const model = options.model ?? "claude-sonnet-4-20250514";
+
+  if (!apiKey) {
+    throw new Error(
+      "Anthropic API key required. Set ANTHROPIC_API_KEY env var or llm.apiKey in config.",
+    );
+  }
+
+  return {
+    name: "anthropic",
+
+    async interpret(
+      material: ExtractedMaterial,
+      projectId: string,
+    ): Promise<DesignFingerprint> {
+      // Dynamic import — @anthropic-ai/sdk is an optional peer dependency
+      let sdk: { default: new (opts: { apiKey: string }) => AnthropicClient };
+      try {
+        sdk = await (Function(
+          'return import("@anthropic-ai/sdk")',
+        )() as Promise<typeof sdk>);
+      } catch {
+        throw new Error(
+          "Anthropic SDK not installed. Run: pnpm add @anthropic-ai/sdk",
+        );
+      }
+
+      const client = new sdk.default({ apiKey });
+
+      const summarized = summarizeMaterial(material);
+      const prompt = buildFingerprintPrompt(projectId, summarized);
+
+      const response = await client.messages.create({
+        model,
+        max_tokens: 4096,
+        messages: [{ role: "user", content: prompt }],
+      });
+
+      const firstBlock = response.content[0] as { type: string; text?: string };
+      const text = firstBlock.type === "text" ? (firstBlock.text ?? "") : "";
+
+      // Parse JSON from response (handle potential markdown wrapping)
+      const jsonMatch = text.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error("Failed to extract JSON from LLM response");
+      }
+
+      const fingerprint: DesignFingerprint = JSON.parse(jsonMatch[0]);
+      fingerprint.source = "llm";
+      fingerprint.timestamp = new Date().toISOString();
+
+      return fingerprint;
+    },
+  };
+}

--- a/packages/ghost-core/src/llm/index.ts
+++ b/packages/ghost-core/src/llm/index.ts
@@ -1,0 +1,25 @@
+import type { LLMConfig, LLMProvider } from "../types.js";
+import { createAnthropicProvider } from "./anthropic.js";
+import { createOpenAIProvider } from "./openai.js";
+
+export function createProvider(config: LLMConfig): LLMProvider {
+  switch (config.provider) {
+    case "anthropic":
+      return createAnthropicProvider({
+        apiKey: config.apiKey,
+        model: config.model,
+      });
+    case "openai":
+      return createOpenAIProvider({
+        apiKey: config.apiKey,
+        model: config.model,
+      });
+    default:
+      throw new Error(`Unknown LLM provider: ${config.provider}`);
+  }
+}
+
+export { createAnthropicProvider } from "./anthropic.js";
+export { createOpenAIProvider } from "./openai.js";
+export { buildFingerprintPrompt, FINGERPRINT_SCHEMA } from "./prompt.js";
+export { summarizeMaterial } from "./summarize.js";

--- a/packages/ghost-core/src/llm/openai.ts
+++ b/packages/ghost-core/src/llm/openai.ts
@@ -1,0 +1,87 @@
+import type {
+  DesignFingerprint,
+  ExtractedMaterial,
+  LLMProvider,
+} from "../types.js";
+import { buildFingerprintPrompt } from "./prompt.js";
+import { summarizeMaterial } from "./summarize.js";
+
+interface OpenAIClient {
+  chat: {
+    completions: {
+      create(opts: {
+        model: string;
+        max_tokens: number;
+        response_format: { type: string };
+        messages: { role: string; content: string }[];
+      }): Promise<{
+        choices: { message?: { content?: string } }[];
+      }>;
+    };
+  };
+}
+
+export function createOpenAIProvider(options: {
+  apiKey?: string;
+  model?: string;
+}): LLMProvider {
+  const apiKey = options.apiKey ?? process.env.OPENAI_API_KEY;
+  const model = options.model ?? "gpt-4o";
+
+  if (!apiKey) {
+    throw new Error(
+      "OpenAI API key required. Set OPENAI_API_KEY env var or llm.apiKey in config.",
+    );
+  }
+
+  return {
+    name: "openai",
+
+    async interpret(
+      material: ExtractedMaterial,
+      projectId: string,
+    ): Promise<DesignFingerprint> {
+      // Dynamic import — openai is an optional peer dependency
+      let sdk: { default: new (opts: { apiKey: string }) => OpenAIClient };
+      try {
+        sdk = await (Function('return import("openai")')() as Promise<
+          typeof sdk
+        >);
+      } catch {
+        throw new Error("OpenAI SDK not installed. Run: pnpm add openai");
+      }
+
+      const client = new sdk.default({ apiKey });
+
+      const summarized = summarizeMaterial(material);
+      const prompt = buildFingerprintPrompt(projectId, summarized);
+
+      const response = await client.chat.completions.create({
+        model,
+        max_tokens: 4096,
+        response_format: { type: "json_object" },
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a design system analyst. Always respond with valid JSON.",
+          },
+          { role: "user", content: prompt },
+        ],
+      });
+
+      const text = response.choices[0]?.message?.content ?? "";
+
+      const jsonMatch = text.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error("Failed to extract JSON from LLM response");
+      }
+
+      const fingerprint: DesignFingerprint = JSON.parse(jsonMatch[0]);
+      fingerprint.source = "llm";
+      fingerprint.timestamp = new Date().toISOString();
+
+      return fingerprint;
+    },
+  };
+}

--- a/packages/ghost-core/src/llm/prompt.ts
+++ b/packages/ghost-core/src/llm/prompt.ts
@@ -1,0 +1,82 @@
+/**
+ * Prompt templates for LLM-based fingerprint generation.
+ */
+
+export const FINGERPRINT_SCHEMA = `{
+  "id": "string — project/repo identifier",
+  "source": "llm",
+  "timestamp": "string — ISO 8601",
+
+  "palette": {
+    "dominant": [{ "role": "string (primary, secondary, accent, etc.)", "value": "string (resolved color)", "oklch": [L, C, H] }],
+    "neutrals": { "steps": ["string — color values lightest to darkest"], "count": "number" },
+    "semantic": [{ "role": "string (surface, danger, warning, success, info, text, border, etc.)", "value": "string", "oklch": [L, C, H] }],
+    "saturationProfile": "muted | vibrant | mixed",
+    "contrast": "high | moderate | low"
+  },
+
+  "spacing": {
+    "scale": [4, 8, 12, 16, 24, 32],
+    "regularity": "number 0-1 — how consistent is the spacing scale",
+    "baseUnit": "number | null — detected base unit in px (e.g. 4, 8)"
+  },
+
+  "typography": {
+    "families": ["string — font family names"],
+    "sizeRamp": [12, 14, 16, 18, 24, 32],
+    "weightDistribution": { "400": 5, "700": 3 },
+    "lineHeightPattern": "tight | normal | loose"
+  },
+
+  "surfaces": {
+    "borderRadii": [4, 8, 12],
+    "shadowComplexity": "none | subtle | layered",
+    "borderUsage": "minimal | moderate | heavy"
+  },
+
+  "architecture": {
+    "tokenization": "number 0-1 — how much of the styling uses design tokens vs hardcoded values",
+    "methodology": ["string — e.g. tailwind, css-custom-properties, scss, css-modules"],
+    "componentCount": "number",
+    "componentCategories": { "input": 3, "layout": 2, "feedback": 1 },
+    "namingPattern": "kebab-case | camelCase | PascalCase | mixed"
+  }
+}`;
+
+export function buildFingerprintPrompt(
+  projectId: string,
+  summarizedMaterial: string,
+): string {
+  return `You are a design system analyst. Analyze the following extracted design material from a software project and produce a structured design fingerprint.
+
+## Task
+
+Examine the CSS tokens, Tailwind classes, component code, and configuration to determine the project's visual language. Output a JSON object matching the schema below.
+
+## Guidelines
+
+- **Palette**: Identify the dominant brand colors, neutral ramp (grays), and semantic colors (success, danger, warning, info, surface, text, border). Convert all colors to OKLCH for the oklch field. If a color is expressed as a CSS variable reference that cannot be resolved, note the variable name in the value field and omit oklch.
+- **Spacing**: Extract the spacing scale from tokens, Tailwind config, or class usage patterns. Detect the base unit (commonly 4px or 8px). Rate regularity from 0 (chaotic) to 1 (perfectly consistent scale).
+- **Typography**: List font families, the size ramp, weight distribution (how many usages of each weight), and whether line heights are tight (<1.3), normal (1.3-1.6), or loose (>1.6).
+- **Surfaces**: Extract border radii values, classify shadow complexity (none/subtle/layered based on number of shadow layers), and border usage frequency.
+- **Architecture**: Estimate tokenization (0 = all hardcoded, 1 = all tokenized), identify the CSS methodology, count components, categorize them, and detect the naming convention.
+
+When Tailwind classes are present, interpret them as design decisions:
+- \`bg-slate-900\` → dark surface color
+- \`rounded-lg\` → border radius ~8px
+- \`text-sm\` → font size ~14px
+- \`p-4\` → padding 16px (4 × 4px base)
+- \`font-semibold\` → weight 600
+
+## Output Format
+
+Return ONLY a valid JSON object matching this schema (no markdown, no explanation):
+
+${FINGERPRINT_SCHEMA}
+
+Set "id" to "${projectId}".
+
+## Extracted Material
+
+${summarizedMaterial}`;
+}

--- a/packages/ghost-core/src/llm/summarize.ts
+++ b/packages/ghost-core/src/llm/summarize.ts
@@ -1,0 +1,141 @@
+import type { ExtractedMaterial } from "../types.js";
+
+/**
+ * Pre-summarize extracted material to fit within LLM context budgets.
+ * Targets ~3-5K tokens of input by extracting key signals rather than
+ * sending raw file contents.
+ */
+export function summarizeMaterial(material: ExtractedMaterial): string {
+  const sections: string[] = [];
+
+  sections.push(`## Project Metadata`);
+  sections.push(`Framework: ${material.metadata.framework ?? "unknown"}`);
+  sections.push(
+    `Component Library: ${material.metadata.componentLibrary ?? "none detected"}`,
+  );
+  sections.push(`Token Count: ${material.metadata.tokenCount}`);
+  sections.push(`Component Count: ${material.metadata.componentCount}`);
+
+  // Summarize CSS tokens and values
+  if (material.styleFiles.length > 0) {
+    sections.push(`\n## Style Files (${material.styleFiles.length})`);
+    for (const file of material.styleFiles) {
+      sections.push(`\n### ${file.path}`);
+      sections.push(summarizeStyleFile(file.content));
+    }
+  }
+
+  // Summarize config files
+  if (material.configFiles.length > 0) {
+    sections.push(`\n## Config Files (${material.configFiles.length})`);
+    for (const file of material.configFiles) {
+      sections.push(`\n### ${file.path}`);
+      // Config files are usually small enough to include
+      sections.push(truncate(file.content, 2000));
+    }
+  }
+
+  // Summarize component files
+  if (material.componentFiles.length > 0) {
+    sections.push(`\n## Components (${material.componentFiles.length})`);
+    for (const file of material.componentFiles) {
+      sections.push(`\n### ${file.path}`);
+      sections.push(summarizeComponent(file.content));
+    }
+  }
+
+  return sections.join("\n");
+}
+
+function summarizeStyleFile(content: string): string {
+  const lines: string[] = [];
+
+  // Extract custom property declarations
+  const tokenLines = content.match(/--[\w-]+\s*:\s*[^;]+/g);
+  if (tokenLines) {
+    lines.push("Custom Properties:");
+    for (const line of tokenLines.slice(0, 50)) {
+      lines.push(`  ${line.trim()}`);
+    }
+    if (tokenLines.length > 50) {
+      lines.push(`  ... and ${tokenLines.length - 50} more`);
+    }
+  }
+
+  // Extract @theme blocks
+  const themeMatch = content.match(/@theme\s*\{[^}]*\}/s);
+  if (themeMatch) {
+    lines.push(`\n@theme block:\n${truncate(themeMatch[0], 1000)}`);
+  }
+
+  // Extract @tailwind directives
+  const tailwindDirectives = content.match(/@tailwind\s+\w+/g);
+  if (tailwindDirectives) {
+    lines.push(`\nTailwind directives: ${tailwindDirectives.join(", ")}`);
+  }
+
+  // Extract @apply usages
+  const applyUsages = content.match(/@apply\s+[^;]+/g);
+  if (applyUsages) {
+    lines.push(`\n@apply usages (${applyUsages.length}):`);
+    for (const usage of applyUsages.slice(0, 20)) {
+      lines.push(`  ${usage.trim()}`);
+    }
+  }
+
+  return lines.join("\n") || "(no style signals detected)";
+}
+
+function summarizeComponent(content: string): string {
+  const lines: string[] = [];
+
+  // Extract className usages
+  const classNames = new Set<string>();
+  const classRegex =
+    /(?:className|class)\s*=\s*(?:"([^"]+)"|'([^']+)'|\{[^}]*["'`]([^"'`]+)["'`])/g;
+  for (
+    let match = classRegex.exec(content);
+    match !== null;
+    match = classRegex.exec(content)
+  ) {
+    const value = match[1] ?? match[2] ?? match[3];
+    if (value) {
+      for (const cls of value.split(/\s+/)) {
+        if (cls) classNames.add(cls);
+      }
+    }
+  }
+
+  if (classNames.size > 0) {
+    const sorted = [...classNames].sort();
+    lines.push(`Classes (${sorted.length}): ${sorted.slice(0, 30).join(", ")}`);
+    if (sorted.length > 30) {
+      lines.push(`  ... and ${sorted.length - 30} more`);
+    }
+  }
+
+  // Extract imports for library detection
+  const imports = content.match(/import\s+.*from\s+["'][^"']+["']/g);
+  if (imports) {
+    lines.push(`Imports: ${imports.slice(0, 10).join("; ")}`);
+  }
+
+  // Component signature (function/const name)
+  const componentMatch = content.match(
+    /(?:export\s+(?:default\s+)?)?(?:function|const)\s+(\w+)/,
+  );
+  if (componentMatch) {
+    lines.push(`Export: ${componentMatch[1]}`);
+  }
+
+  // Line count as complexity signal
+  const lineCount = content.split("\n").length;
+  lines.push(`Lines: ${lineCount}`);
+
+  return lines.join("\n") || "(no signals detected)";
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength)}\n... (truncated)`;
+}

--- a/packages/ghost-core/src/profile.ts
+++ b/packages/ghost-core/src/profile.ts
@@ -1,0 +1,124 @@
+import { extract } from "./extractors/index.js";
+import { computeEmbedding } from "./fingerprint/embedding.js";
+import { fingerprintFromRegistry } from "./fingerprint/from-registry.js";
+import { createProvider } from "./llm/index.js";
+import { resolveRegistry } from "./resolvers/registry.js";
+import type { DesignFingerprint, GhostConfig } from "./types.js";
+
+/**
+ * Profile a repository — extract design material and produce a fingerprint.
+ *
+ * If LLM config is present, uses LLM to interpret the extracted material.
+ * Otherwise, attempts a deterministic fingerprint from CSS tokens.
+ */
+export async function profile(
+  config: GhostConfig,
+  cwd: string = process.cwd(),
+): Promise<DesignFingerprint> {
+  const material = await extract(cwd, {
+    ignore: config.ignore,
+    extractorNames: config.extractors,
+    componentDir: config.designSystems?.[0]?.componentDir,
+    styleEntry: config.designSystems?.[0]?.styleEntry,
+  });
+
+  if (config.llm) {
+    const provider = createProvider(config.llm);
+    const projectId = config.designSystems?.[0]?.name ?? "project";
+    const fingerprint = await provider.interpret(material, projectId);
+
+    // Always recompute embedding deterministically for comparability
+    fingerprint.embedding = computeEmbedding(fingerprint);
+
+    return fingerprint;
+  }
+
+  // Deterministic fallback — if we have a registry, use it
+  if (config.designSystems?.[0]?.registry) {
+    const registry = await resolveRegistry(config.designSystems[0].registry);
+    return fingerprintFromRegistry(registry);
+  }
+
+  // Deterministic extraction-only fingerprint (limited but functional)
+  return fingerprintFromExtraction(material, cwd);
+}
+
+/**
+ * Profile a registry deterministically — no LLM needed.
+ */
+export async function profileRegistry(
+  registryPath: string,
+): Promise<DesignFingerprint> {
+  const registry = await resolveRegistry(registryPath);
+  return fingerprintFromRegistry(registry);
+}
+
+/**
+ * Build a basic fingerprint from extracted material without LLM.
+ * Less accurate than LLM interpretation but works offline.
+ */
+function fingerprintFromExtraction(
+  material: ReturnType<typeof extract> extends Promise<infer T> ? T : never,
+  _cwd: string,
+): DesignFingerprint {
+  // Extract basic signals from CSS
+  const tokenCount = material.metadata.tokenCount;
+  const componentCount = material.metadata.componentCount;
+
+  // Rough tokenization estimate: ratio of tokens to total style declarations
+  let totalDeclarations = 0;
+  for (const file of material.styleFiles) {
+    const matches = file.content.match(/[a-z-]+\s*:/g);
+    if (matches) totalDeclarations += matches.length;
+  }
+  const tokenization =
+    totalDeclarations > 0 ? Math.min(tokenCount / totalDeclarations, 1) : 0;
+
+  const fingerprint: Omit<DesignFingerprint, "embedding"> = {
+    id: "project",
+    source: "extraction",
+    timestamp: new Date().toISOString(),
+
+    palette: {
+      dominant: [],
+      neutrals: { steps: [], count: 0 },
+      semantic: [],
+      saturationProfile: "mixed",
+      contrast: "moderate",
+    },
+
+    spacing: {
+      scale: [],
+      regularity: 0,
+      baseUnit: null,
+    },
+
+    typography: {
+      families: [],
+      sizeRamp: [],
+      weightDistribution: {},
+      lineHeightPattern: "normal",
+    },
+
+    surfaces: {
+      borderRadii: [],
+      shadowComplexity: "none",
+      borderUsage: "minimal",
+    },
+
+    architecture: {
+      tokenization,
+      methodology: material.metadata.framework
+        ? [material.metadata.framework]
+        : [],
+      componentCount,
+      componentCategories: {},
+      namingPattern: "unknown",
+    },
+  };
+
+  return {
+    ...fingerprint,
+    embedding: computeEmbedding(fingerprint),
+  };
+}

--- a/packages/ghost-core/src/profile.ts
+++ b/packages/ghost-core/src/profile.ts
@@ -1,15 +1,37 @@
 import { extract } from "./extractors/index.js";
+import { computeSemanticEmbedding } from "./fingerprint/embed-api.js";
 import { computeEmbedding } from "./fingerprint/embedding.js";
 import { fingerprintFromRegistry } from "./fingerprint/from-registry.js";
 import { createProvider } from "./llm/index.js";
 import { resolveRegistry } from "./resolvers/registry.js";
-import type { DesignFingerprint, GhostConfig } from "./types.js";
+import type {
+  DesignFingerprint,
+  EmbeddingConfig,
+  GhostConfig,
+} from "./types.js";
+
+/**
+ * Compute the embedding for a fingerprint.
+ * Uses semantic embedding API if configured, otherwise falls back to deterministic.
+ */
+async function embedFingerprint(
+  fingerprint: DesignFingerprint,
+  embeddingConfig?: EmbeddingConfig,
+): Promise<number[]> {
+  if (embeddingConfig) {
+    return computeSemanticEmbedding(fingerprint, embeddingConfig);
+  }
+  return computeEmbedding(fingerprint);
+}
 
 /**
  * Profile a repository — extract design material and produce a fingerprint.
  *
  * If LLM config is present, uses LLM to interpret the extracted material.
  * Otherwise, attempts a deterministic fingerprint from CSS tokens.
+ *
+ * If embedding config is present, uses an embedding API for the vector.
+ * Otherwise, falls back to a deterministic 64-dim feature vector.
  */
 export async function profile(
   config: GhostConfig,
@@ -27,8 +49,10 @@ export async function profile(
     const projectId = config.designSystems?.[0]?.name ?? "project";
     const fingerprint = await provider.interpret(material, projectId);
 
-    // Always recompute embedding deterministically for comparability
-    fingerprint.embedding = computeEmbedding(fingerprint);
+    fingerprint.embedding = await embedFingerprint(
+      fingerprint,
+      config.embedding,
+    );
 
     return fingerprint;
   }
@@ -36,31 +60,40 @@ export async function profile(
   // Deterministic fallback — if we have a registry, use it
   if (config.designSystems?.[0]?.registry) {
     const registry = await resolveRegistry(config.designSystems[0].registry);
-    return fingerprintFromRegistry(registry);
+    const fingerprint = fingerprintFromRegistry(registry);
+    fingerprint.embedding = await embedFingerprint(
+      fingerprint,
+      config.embedding,
+    );
+    return fingerprint;
   }
 
   // Deterministic extraction-only fingerprint (limited but functional)
-  return fingerprintFromExtraction(material, cwd);
+  return fingerprintFromExtraction(material, config.embedding);
 }
 
 /**
  * Profile a registry deterministically — no LLM needed.
+ * Optionally uses embedding API if config provided.
  */
 export async function profileRegistry(
   registryPath: string,
+  embeddingConfig?: EmbeddingConfig,
 ): Promise<DesignFingerprint> {
   const registry = await resolveRegistry(registryPath);
-  return fingerprintFromRegistry(registry);
+  const fingerprint = fingerprintFromRegistry(registry);
+  fingerprint.embedding = await embedFingerprint(fingerprint, embeddingConfig);
+  return fingerprint;
 }
 
 /**
  * Build a basic fingerprint from extracted material without LLM.
  * Less accurate than LLM interpretation but works offline.
  */
-function fingerprintFromExtraction(
+async function fingerprintFromExtraction(
   material: ReturnType<typeof extract> extends Promise<infer T> ? T : never,
-  _cwd: string,
-): DesignFingerprint {
+  embeddingConfig?: EmbeddingConfig,
+): Promise<DesignFingerprint> {
   // Extract basic signals from CSS
   const tokenCount = material.metadata.tokenCount;
   const componentCount = material.metadata.componentCount;
@@ -74,7 +107,7 @@ function fingerprintFromExtraction(
   const tokenization =
     totalDeclarations > 0 ? Math.min(tokenCount / totalDeclarations, 1) : 0;
 
-  const fingerprint: Omit<DesignFingerprint, "embedding"> = {
+  const partial: Omit<DesignFingerprint, "embedding"> = {
     id: "project",
     source: "extraction",
     timestamp: new Date().toISOString(),
@@ -117,8 +150,13 @@ function fingerprintFromExtraction(
     },
   };
 
-  return {
-    ...fingerprint,
-    embedding: computeEmbedding(fingerprint),
+  const fingerprint: DesignFingerprint = {
+    ...partial,
+    embedding: computeEmbedding(partial),
   };
+
+  // Upgrade to semantic embedding if configured
+  fingerprint.embedding = await embedFingerprint(fingerprint, embeddingConfig);
+
+  return fingerprint;
 }

--- a/packages/ghost-core/src/reporters/fingerprint.ts
+++ b/packages/ghost-core/src/reporters/fingerprint.ts
@@ -1,0 +1,144 @@
+import type { DesignFingerprint, FingerprintComparison } from "../types.js";
+
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+const YELLOW = "\x1b[33m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+
+const useColor =
+  process.env.NO_COLOR === undefined && process.stdout.isTTY !== false;
+
+function c(code: string, text: string): string {
+  return useColor ? `${code}${text}${RESET}` : text;
+}
+
+export function formatFingerprint(fp: DesignFingerprint): string {
+  const lines: string[] = [];
+
+  lines.push(c(BOLD, `Design Fingerprint: ${fp.id}`));
+  lines.push(c(DIM, `Source: ${fp.source} | ${fp.timestamp}`));
+  lines.push("");
+
+  // Palette
+  lines.push(c(BOLD, "Palette"));
+  if (fp.palette.dominant.length > 0) {
+    lines.push(
+      `  Dominant:    ${fp.palette.dominant.map((co) => `${co.role} (${co.value})`).join(", ")}`,
+    );
+  }
+  if (fp.palette.semantic.length > 0) {
+    lines.push(
+      `  Semantic:    ${fp.palette.semantic.map((co) => co.role).join(", ")}`,
+    );
+  }
+  lines.push(`  Neutrals:    ${fp.palette.neutrals.count} steps`);
+  lines.push(`  Saturation:  ${fp.palette.saturationProfile}`);
+  lines.push(`  Contrast:    ${fp.palette.contrast}`);
+  lines.push("");
+
+  // Spacing
+  lines.push(c(BOLD, "Spacing"));
+  lines.push(
+    `  Scale:       ${fp.spacing.scale.length > 0 ? fp.spacing.scale.join(", ") : "(none detected)"}`,
+  );
+  lines.push(
+    `  Base Unit:   ${fp.spacing.baseUnit ? `${fp.spacing.baseUnit}px` : "(none)"}`,
+  );
+  lines.push(`  Regularity:  ${(fp.spacing.regularity * 100).toFixed(0)}%`);
+  lines.push("");
+
+  // Typography
+  lines.push(c(BOLD, "Typography"));
+  lines.push(
+    `  Families:    ${fp.typography.families.length > 0 ? fp.typography.families.join(", ") : "(none detected)"}`,
+  );
+  lines.push(
+    `  Size Ramp:   ${fp.typography.sizeRamp.length > 0 ? fp.typography.sizeRamp.join(", ") : "(none detected)"}`,
+  );
+  lines.push(`  Line Height: ${fp.typography.lineHeightPattern}`);
+  lines.push("");
+
+  // Surfaces
+  lines.push(c(BOLD, "Surfaces"));
+  lines.push(
+    `  Radii:       ${fp.surfaces.borderRadii.length > 0 ? fp.surfaces.borderRadii.map((r) => `${r}px`).join(", ") : "(none)"}`,
+  );
+  lines.push(`  Shadows:     ${fp.surfaces.shadowComplexity}`);
+  lines.push(`  Borders:     ${fp.surfaces.borderUsage}`);
+  lines.push("");
+
+  // Architecture
+  lines.push(c(BOLD, "Architecture"));
+  lines.push(
+    `  Tokenization: ${(fp.architecture.tokenization * 100).toFixed(0)}%`,
+  );
+  lines.push(
+    `  Methodology:  ${fp.architecture.methodology.join(", ") || "(unknown)"}`,
+  );
+  lines.push(`  Components:   ${fp.architecture.componentCount}`);
+  const cats = Object.entries(fp.architecture.componentCategories);
+  if (cats.length > 0) {
+    lines.push(
+      `  Categories:   ${cats.map(([k, v]) => `${k} (${v})`).join(", ")}`,
+    );
+  }
+  lines.push(`  Naming:       ${fp.architecture.namingPattern}`);
+  lines.push("");
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function formatComparison(comp: FingerprintComparison): string {
+  const lines: string[] = [];
+
+  lines.push(c(BOLD, `Comparison: ${comp.source.id} vs ${comp.target.id}`));
+  lines.push("");
+
+  // Overall distance
+  const distPct = (comp.distance * 100).toFixed(1);
+  const distColor =
+    comp.distance < 0.1 ? GREEN : comp.distance < 0.3 ? YELLOW : RED;
+  lines.push(`Overall Distance: ${c(distColor, `${distPct}%`)}`);
+  lines.push("");
+
+  // Per-dimension breakdown
+  lines.push(c(BOLD, "Dimensions"));
+  for (const [key, delta] of Object.entries(comp.dimensions)) {
+    const pct = (delta.distance * 100).toFixed(1);
+    const color =
+      delta.distance < 0.1 ? GREEN : delta.distance < 0.3 ? YELLOW : RED;
+    lines.push(
+      `  ${key.padEnd(14)} ${c(color, `${pct}%`.padStart(6))}  ${c(DIM, delta.description)}`,
+    );
+  }
+  lines.push("");
+
+  // Summary
+  if (comp.summary) {
+    lines.push(c(DIM, comp.summary));
+    lines.push("");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function formatFingerprintJSON(fp: DesignFingerprint): string {
+  return JSON.stringify(fp, null, 2);
+}
+
+export function formatComparisonJSON(comp: FingerprintComparison): string {
+  // Omit full fingerprints from JSON comparison to keep it concise
+  return JSON.stringify(
+    {
+      source: comp.source.id,
+      target: comp.target.id,
+      distance: comp.distance,
+      dimensions: comp.dimensions,
+      summary: comp.summary,
+    },
+    null,
+    2,
+  );
+}

--- a/packages/ghost-core/src/scan.ts
+++ b/packages/ghost-core/src/scan.ts
@@ -24,6 +24,12 @@ export async function scan(
   let totalTokensScanned = 0;
   let totalComponentsScanned = 0;
 
+  if (!config.designSystems?.length) {
+    throw new Error(
+      "scan() requires at least one design system in config.designSystems",
+    );
+  }
+
   for (const ds of config.designSystems) {
     const registry = await resolveRegistry(ds.registry);
 

--- a/packages/ghost-core/src/types.ts
+++ b/packages/ghost-core/src/types.ts
@@ -88,6 +88,7 @@ export interface GhostConfig {
   ignore: string[];
   visual?: VisualScanConfig;
   llm?: LLMConfig;
+  embedding?: EmbeddingConfig;
   extractors?: string[];
 }
 
@@ -187,6 +188,12 @@ export interface Extractor {
 
 export interface LLMConfig {
   provider: "anthropic" | "openai";
+  model?: string;
+  apiKey?: string;
+}
+
+export interface EmbeddingConfig {
+  provider: "openai" | "voyage";
   model?: string;
   apiKey?: string;
 }

--- a/packages/ghost-core/src/types.ts
+++ b/packages/ghost-core/src/types.ts
@@ -82,11 +82,137 @@ export interface VisualScanConfig {
 }
 
 export interface GhostConfig {
-  designSystems: DesignSystemConfig[];
+  designSystems?: DesignSystemConfig[];
   scan: ScanOptions;
   rules: Record<string, RuleSeverity>;
   ignore: string[];
   visual?: VisualScanConfig;
+  llm?: LLMConfig;
+  extractors?: string[];
+}
+
+// --- Fingerprint types ---
+
+export interface SemanticColor {
+  role: string;
+  value: string;
+  oklch?: [number, number, number];
+}
+
+export interface ColorRamp {
+  steps: string[];
+  count: number;
+}
+
+export interface DesignFingerprint {
+  id: string;
+  source: "registry" | "extraction" | "llm";
+  timestamp: string;
+
+  palette: {
+    dominant: SemanticColor[];
+    neutrals: ColorRamp;
+    semantic: SemanticColor[];
+    saturationProfile: "muted" | "vibrant" | "mixed";
+    contrast: "high" | "moderate" | "low";
+  };
+
+  spacing: {
+    scale: number[];
+    regularity: number;
+    baseUnit: number | null;
+  };
+
+  typography: {
+    families: string[];
+    sizeRamp: number[];
+    weightDistribution: Record<number, number>;
+    lineHeightPattern: "tight" | "normal" | "loose";
+  };
+
+  surfaces: {
+    borderRadii: number[];
+    shadowComplexity: "none" | "subtle" | "layered";
+    borderUsage: "minimal" | "moderate" | "heavy";
+  };
+
+  architecture: {
+    tokenization: number;
+    methodology: string[];
+    componentCount: number;
+    componentCategories: Record<string, number>;
+    namingPattern: string;
+  };
+
+  embedding: number[];
+}
+
+// --- Extractor types ---
+
+export interface ExtractedFile {
+  path: string;
+  content: string;
+  type: "css" | "scss" | "tailwind-config" | "component" | "config" | "other";
+}
+
+export interface ExtractedMaterial {
+  styleFiles: ExtractedFile[];
+  componentFiles: ExtractedFile[];
+  configFiles: ExtractedFile[];
+  metadata: {
+    framework: string | null;
+    componentLibrary: string | null;
+    tokenCount: number;
+    componentCount: number;
+  };
+}
+
+export interface ExtractorOptions {
+  ignore?: string[];
+  maxFiles?: number;
+  componentDir?: string;
+  styleEntry?: string;
+}
+
+export interface Extractor {
+  name: string;
+  detect: (cwd: string) => Promise<boolean>;
+  extract: (
+    cwd: string,
+    options?: ExtractorOptions,
+  ) => Promise<ExtractedMaterial>;
+}
+
+// --- LLM types ---
+
+export interface LLMConfig {
+  provider: "anthropic" | "openai";
+  model?: string;
+  apiKey?: string;
+}
+
+export interface LLMProvider {
+  name: string;
+  interpret: (
+    material: ExtractedMaterial,
+    schema: string,
+  ) => Promise<DesignFingerprint>;
+}
+
+// --- Comparison types ---
+
+export interface DimensionDelta {
+  dimension: string;
+  distance: number;
+  description: string;
+}
+
+export interface FingerprintComparison {
+  source: DesignFingerprint;
+  target: DesignFingerprint;
+  distance: number;
+  dimensions: Record<string, DimensionDelta>;
+  summary: string;
 }
 
 // --- Drift report types ---


### PR DESCRIPTION
## Summary

- Introduces `ghost profile` and `ghost compare` commands that fingerprint a project's design language (palette, spacing, typography, surfaces, architecture) without requiring a registry
- Adds an extractor plugin system (Tailwind MVP + CSS fallback) for framework-agnostic material gathering
- Integrates optional LLM interpretation (Anthropic/OpenAI) for rich fingerprint generation and optional semantic embeddings (OpenAI/Voyage) for similarity clustering
- Includes deterministic 64-dim embedding vector fallback and deterministic registry fingerprinting (no LLM needed for shadcn registries)
- Existing `ghost scan` is fully preserved — `designSystems` is now optional in config

## What changed

- **Fingerprint engine** (`fingerprint/`): profile, compare, describe, embed, and registry-based fingerprinting
- **Extractors** (`extractors/`): pluggable Tailwind and CSS extractors for gathering design materials
- **LLM layer** (`llm/`): Anthropic and OpenAI providers with structured prompts for fingerprint generation and summarization
- **CLI** (`ghost-cli`): new `profile` and `compare` subcommands
- **Types/config**: expanded `GhostConfig` and new fingerprint types

## Test plan

- [ ] Run `ghost profile` on a Tailwind project and verify fingerprint output
- [ ] Run `ghost profile` on a plain CSS project (fallback extractor)
- [ ] Run `ghost compare` between two fingerprints and verify distance scores
- [ ] Run `ghost scan` to confirm existing behavior is unaffected
- [ ] Test with and without LLM API keys to verify deterministic fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)