### PR TITLE
Add docs pages and generative cycloid hero canvas

### DIFF
--- a/packages/ghost-ui/src/App.tsx
+++ b/packages/ghost-ui/src/App.tsx
@@ -1,6 +1,11 @@
 import { Route, Routes } from "react-router";
 import ComponentPage from "@/app/components/[name]/page";
 import ComponentsIndex from "@/app/components/page";
+import CLIReferencePage from "@/app/docs/cli/page";
+import ConceptsPage from "@/app/docs/concepts/page";
+import GettingStartedPage from "@/app/docs/getting-started/page";
+import DocsIndex from "@/app/docs/page";
+import SelfHostingPage from "@/app/docs/self-hosting/page";
 import ColorsPage from "@/app/foundations/colors/page";
 import FoundationsIndex from "@/app/foundations/page";
 import TypographyPage from "@/app/foundations/typography/page";
@@ -20,6 +25,11 @@ export function App() {
       <main className="min-h-screen">
         <Routes>
           <Route index element={<HomePage />} />
+          <Route path="docs" element={<DocsIndex />} />
+          <Route path="docs/getting-started" element={<GettingStartedPage />} />
+          <Route path="docs/cli" element={<CLIReferencePage />} />
+          <Route path="docs/concepts" element={<ConceptsPage />} />
+          <Route path="docs/self-hosting" element={<SelfHostingPage />} />
           <Route path="components" element={<ComponentsIndex />} />
           <Route path="components/:name" element={<ComponentPage />} />
           <Route path="foundations" element={<FoundationsIndex />} />

--- a/packages/ghost-ui/src/app/docs/cli/page.tsx
+++ b/packages/ghost-ui/src/app/docs/cli/page.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { Link } from "react-router";
+import { AnimatedPageHeader } from "@/components/docs/animated-page-header";
+import { DocProse } from "@/components/docs/doc-prose";
+import { DocSection, DocsPageLayout } from "@/components/docs/docs-page-layout";
+
+function CommandSection({
+  name,
+  description,
+  usage,
+  flags,
+  example,
+}: {
+  name: string;
+  description: string;
+  usage: string;
+  flags: { flag: string; description: string }[];
+  example?: string;
+}) {
+  return (
+    <>
+      <h3>
+        <code>ghost {name}</code>
+      </h3>
+      <p>{description}</p>
+      <pre>
+        <code>{usage}</code>
+      </pre>
+      {flags.length > 0 && (
+        <table>
+          <thead>
+            <tr>
+              <th>Flag</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {flags.map((f) => (
+              <tr key={f.flag}>
+                <td>
+                  <code>{f.flag}</code>
+                </td>
+                <td>{f.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {example && (
+        <pre>
+          <code>{example}</code>
+        </pre>
+      )}
+    </>
+  );
+}
+
+export default function CLIReferencePage() {
+  return (
+    <DocsPageLayout>
+      <AnimatedPageHeader
+        kicker="Docs"
+        title="CLI Reference"
+        description="Every Ghost command, its flags, and example usage."
+      />
+
+      <DocProse>
+        <DocSection title="Overview">
+          <p>
+            All commands read <code>ghost.config.ts</code> from the current
+            directory by default. Override with{" "}
+            <code>--config path/to/config</code>.
+          </p>
+        </DocSection>
+
+        <DocSection title="Scanning & Profiling">
+          <CommandSection
+            name="scan"
+            description="Detect design drift by comparing your local components and tokens against the parent registry."
+            usage="ghost scan [options]"
+            flags={[
+              {
+                flag: "--config, -c",
+                description: "Path to ghost config file",
+              },
+              {
+                flag: "--format",
+                description: 'Output format: "cli" (default) or "json"',
+              },
+              { flag: "--no-color", description: "Disable colored output" },
+            ]}
+            example={`# Scan with default config
+ghost scan
+
+# JSON output for CI
+ghost scan --format json`}
+          />
+
+          <CommandSection
+            name="profile"
+            description="Generate a 64-dimensional fingerprint from your design system. Extracts palette, spacing, typography, surfaces, and architecture dimensions."
+            usage="ghost profile [options]"
+            flags={[
+              {
+                flag: "--config, -c",
+                description: "Path to ghost config file",
+              },
+              {
+                flag: "--registry, -r",
+                description:
+                  "Path or URL to a registry.json (overrides config)",
+              },
+              {
+                flag: "--output, -o",
+                description: "Write fingerprint to a file path",
+              },
+              {
+                flag: "--emit",
+                description: "Write .ghost-fingerprint.json to project root",
+              },
+              {
+                flag: "--format",
+                description: 'Output format: "cli" (default) or "json"',
+              },
+            ]}
+            example={`# Profile from config
+ghost profile
+
+# Profile a remote registry directly
+ghost profile -r https://ui.example.com/registry.json
+
+# Save for later comparison
+ghost profile --emit`}
+          />
+
+          <CommandSection
+            name="diff"
+            description="Compare local component implementations against the parent registry, showing line-level changes and drift classification."
+            usage="ghost diff [component] [options]"
+            flags={[
+              {
+                flag: "--config, -c",
+                description: "Path to ghost config file",
+              },
+              {
+                flag: "--format",
+                description: 'Output format: "cli" (default) or "json"',
+              },
+            ]}
+            example={`# Diff all components
+ghost diff
+
+# Diff a specific component
+ghost diff button`}
+          />
+        </DocSection>
+
+        <DocSection title="Comparison">
+          <CommandSection
+            name="compare"
+            description="Compare two fingerprint files with weighted distance calculation across all dimensions. Optionally includes temporal analysis showing drift velocity and trajectory."
+            usage="ghost compare <source> <target> [options]"
+            flags={[
+              {
+                flag: "--temporal",
+                description: "Include temporal analysis (velocity, trajectory)",
+              },
+              {
+                flag: "--history-dir",
+                description: "Path to .ghost/ history directory",
+              },
+              {
+                flag: "--format",
+                description: 'Output format: "cli" (default) or "json"',
+              },
+            ]}
+            example={`# Basic comparison
+ghost compare parent.json consumer.json
+
+# With temporal drift analysis
+ghost compare parent.json consumer.json --temporal`}
+          />
+
+          <CommandSection
+            name="fleet"
+            description="Compare multiple fingerprints for ecosystem-wide observability. Computes pairwise distances, centroid, and optional clustering."
+            usage="ghost fleet <fp1> <fp2> [fp3...] [options]"
+            flags={[
+              {
+                flag: "--cluster",
+                description: "Enable k-means clustering analysis",
+              },
+              {
+                flag: "--format",
+                description: 'Output format: "cli" (default) or "json"',
+              },
+            ]}
+            example={`# Compare three design systems
+ghost fleet ds-a.json ds-b.json ds-c.json
+
+# With clustering
+ghost fleet ds-a.json ds-b.json ds-c.json ds-d.json --cluster`}
+          />
+        </DocSection>
+
+        <DocSection title="Evolution & Intent">
+          <CommandSection
+            name="ack"
+            description="Acknowledge current drift by recording your intentional stance — aligned (tracking parent), accepted (known divergence), or diverging (intentional split). Updates .ghost-sync.json."
+            usage="ghost ack [options]"
+            flags={[
+              {
+                flag: "--config, -c",
+                description: "Path to ghost config file",
+              },
+              {
+                flag: "--dimension, -d",
+                description:
+                  "Specific dimension to acknowledge (e.g. palette, spacing)",
+              },
+              {
+                flag: "--stance",
+                description: '"aligned", "accepted", or "diverging"',
+              },
+              {
+                flag: "--reason",
+                description: "Explanation for this acknowledgment",
+              },
+              {
+                flag: "--format",
+                description: 'Output format: "cli" (default) or "json"',
+              },
+            ]}
+            example={`# Acknowledge all dimensions as aligned
+ghost ack --stance aligned --reason "Initial baseline"
+
+# Mark typography as intentionally diverging
+ghost ack -d typography --stance diverging --reason "Brand refresh requires different type scale"`}
+          />
+
+          <CommandSection
+            name="adopt"
+            description="Shift the parent baseline to a new fingerprint. Use this when the parent design system has been updated and you want to re-anchor your drift measurements."
+            usage="ghost adopt <source> [options]"
+            flags={[
+              {
+                flag: "--config, -c",
+                description: "Path to ghost config file",
+              },
+              {
+                flag: "--dimension, -d",
+                description: "Only adopt a specific dimension",
+              },
+              {
+                flag: "--format",
+                description: 'Output format: "cli" (default) or "json"',
+              },
+            ]}
+            example={`# Adopt a new parent fingerprint
+ghost adopt new-parent.json`}
+          />
+
+          <CommandSection
+            name="diverge"
+            description="Mark a specific dimension as intentionally diverging. A shorthand for ack --stance diverging that also records a reason."
+            usage="ghost diverge <dimension> [options]"
+            flags={[
+              {
+                flag: "--config, -c",
+                description: "Path to ghost config file",
+              },
+              {
+                flag: "--reason, -r",
+                description: "Why this dimension is diverging",
+              },
+              {
+                flag: "--format",
+                description: 'Output format: "cli" (default) or "json"',
+              },
+            ]}
+            example={`ghost diverge palette --reason "Dark-mode-first palette for this product"`}
+          />
+        </DocSection>
+
+        <DocSection title="Visualization">
+          <CommandSection
+            name="viz"
+            description="Launch an interactive 3D visualization of fingerprint embeddings using Three.js. Projects the 64-dimensional vectors into 3D space via PCA."
+            usage="ghost viz <fp1> <fp2> [fp3...] [options]"
+            flags={[
+              {
+                flag: "--port",
+                description: "HTTP server port (default: 3333)",
+              },
+              {
+                flag: "--no-open",
+                description: "Don't auto-open the browser",
+              },
+            ]}
+            example={`# Visualize two fingerprints
+ghost viz parent.json consumer.json
+
+# Visualize a fleet on a custom port
+ghost viz *.json --port 8080`}
+          />
+
+          <hr />
+
+          <p>
+            See{" "}
+            <Link to="/docs/concepts" className="font-semibold">
+              Core Concepts
+            </Link>{" "}
+            for the ideas behind these commands, or{" "}
+            <Link to="/docs/getting-started" className="font-semibold">
+              Getting Started
+            </Link>{" "}
+            for a guided walkthrough.
+          </p>
+        </DocSection>
+      </DocProse>
+    </DocsPageLayout>
+  );
+}

--- a/packages/ghost-ui/src/app/docs/concepts/page.tsx
+++ b/packages/ghost-ui/src/app/docs/concepts/page.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import { Link } from "react-router";
+import { AnimatedPageHeader } from "@/components/docs/animated-page-header";
+import { DocProse } from "@/components/docs/doc-prose";
+import { DocSection, DocsPageLayout } from "@/components/docs/docs-page-layout";
+
+export default function ConceptsPage() {
+  return (
+    <DocsPageLayout>
+      <AnimatedPageHeader
+        kicker="Docs"
+        title="Core Concepts"
+        description="The ideas behind Ghost — fingerprints, drift detection, evolution tracking, and fleet observability."
+      />
+
+      <DocProse>
+        <DocSection title="Design Fingerprints">
+          <p>
+            A fingerprint is a <strong>64-dimensional numeric vector</strong>{" "}
+            that captures the identity of a design system. Ghost extracts this
+            deterministically from a shadcn-compatible registry, or optionally
+            via LLM interpretation of raw CSS and component files.
+          </p>
+          <p>The 64 dimensions are grouped into five categories:</p>
+          <table>
+            <thead>
+              <tr>
+                <th>Dimensions</th>
+                <th>Category</th>
+                <th>What it captures</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>0 &ndash; 20</td>
+                <td>
+                  <strong>Palette</strong>
+                </td>
+                <td>
+                  Dominant colors (OKLCH), neutral ramp, semantic color
+                  coverage, saturation profile, contrast level
+                </td>
+              </tr>
+              <tr>
+                <td>21 &ndash; 30</td>
+                <td>
+                  <strong>Spacing</strong>
+                </td>
+                <td>
+                  Scale values, regularity score, base unit detection,
+                  distribution pattern
+                </td>
+              </tr>
+              <tr>
+                <td>31 &ndash; 40</td>
+                <td>
+                  <strong>Typography</strong>
+                </td>
+                <td>
+                  Font families, size ramp, weight distribution, line height
+                  pattern
+                </td>
+              </tr>
+              <tr>
+                <td>41 &ndash; 48</td>
+                <td>
+                  <strong>Surfaces</strong>
+                </td>
+                <td>Border radii, shadow complexity, border usage frequency</td>
+              </tr>
+              <tr>
+                <td>49 &ndash; 63</td>
+                <td>
+                  <strong>Architecture</strong>
+                </td>
+                <td>
+                  Tokenization ratio, methodology (BEM, CSS-in-JS, etc.),
+                  component count, naming patterns
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            Fingerprints are compared using a <strong>weighted distance</strong>{" "}
+            metric: palette contributes 30%, spacing and typography 20% each,
+            surfaces 15%, and architecture 15%. This weighting reflects how
+            strongly each dimension affects the perceived identity of a design
+            system.
+          </p>
+        </DocSection>
+
+        <DocSection title="Drift Detection">
+          <p>
+            Drift is what happens when a consumer design system diverges from
+            its parent. Ghost detects drift through three complementary scan
+            modes:
+          </p>
+
+          <h3>Values Scan</h3>
+          <p>
+            Parses your CSS and compares design tokens against the parent
+            registry. Detects three kinds of issues:
+          </p>
+          <ul>
+            <li>
+              <strong>Hardcoded colors</strong> &mdash; raw hex/rgb values that
+              should be tokens
+            </li>
+            <li>
+              <strong>Token overrides</strong> &mdash; tokens whose values
+              differ from the parent
+            </li>
+            <li>
+              <strong>Missing tokens</strong> &mdash; tokens the parent defines
+              that you don&rsquo;t have
+            </li>
+          </ul>
+
+          <h3>Structure Scan</h3>
+          <p>
+            Diffs component files between your implementation and the parent
+            registry. Changes are classified as:
+          </p>
+          <ul>
+            <li>
+              <strong>Cosmetic</strong> &mdash; formatting, whitespace,
+              non-functional
+            </li>
+            <li>
+              <strong>Additive</strong> &mdash; new props, variants, or features
+              added on top
+            </li>
+            <li>
+              <strong>Breaking</strong> &mdash; removed or altered behaviour
+              that diverges from the parent API
+            </li>
+          </ul>
+
+          <h3>Visual Scan</h3>
+          <p>
+            Renders components using Playwright and performs pixel-level
+            comparison with pixelmatch. This catches drift that token and
+            structure scans miss — subtle rendering differences from CSS
+            specificity, font rendering, or layout shifts. Requires Playwright
+            to be installed.
+          </p>
+        </DocSection>
+
+        <DocSection title="Evolution Tracking">
+          <p>
+            Not all drift is bad. Ghost distinguishes between{" "}
+            <strong>accidental drift</strong> (bugs, oversight) and{" "}
+            <strong>intentional divergence</strong> (brand requirements, product
+            needs). The evolution system tracks this through{" "}
+            <strong>stances</strong>:
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Stance</th>
+                <th>Symbol</th>
+                <th>Meaning</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <strong>Aligned</strong>
+                </td>
+                <td>
+                  <code>=</code>
+                </td>
+                <td>
+                  Tracking the parent. Any drift in this dimension is
+                  unintentional and should be fixed.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Accepted</strong>
+                </td>
+                <td>
+                  <code>*</code>
+                </td>
+                <td>
+                  Known divergence that has been reviewed and acknowledged. Not
+                  ideal, but understood.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Diverging</strong>
+                </td>
+                <td>
+                  <code>~</code>
+                </td>
+                <td>
+                  Intentionally different. This dimension is owned locally and
+                  should not be measured against the parent.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>
+            Stances are stored in <code>.ghost-sync.json</code> per dimension,
+            with optional reasoning. Use{" "}
+            <Link to="/docs/cli" className="font-semibold">
+              <code>ghost ack</code>
+            </Link>{" "}
+            to record a stance and <code>ghost diverge</code> as a shorthand for
+            marking intentional splits.
+          </p>
+
+          <h3>History &amp; Temporal Analysis</h3>
+          <p>
+            Every time you generate a fingerprint, Ghost appends an entry to{" "}
+            <code>.ghost/history.jsonl</code> — an append-only log of your
+            design system&rsquo;s evolution over time. When comparing
+            fingerprints with <code>--temporal</code>, Ghost computes:
+          </p>
+          <ul>
+            <li>
+              <strong>Drift velocity</strong> &mdash; how fast each dimension is
+              changing per time period
+            </li>
+            <li>
+              <strong>Trajectory</strong> &mdash; whether the system is{" "}
+              <em>converging</em> toward the parent, <em>diverging</em> away,{" "}
+              <em>stable</em>, or <em>oscillating</em>
+            </li>
+            <li>
+              <strong>Exceeded bounds</strong> &mdash; dimensions that have
+              drifted beyond the tolerance threshold (default: 0.05)
+            </li>
+          </ul>
+        </DocSection>
+
+        <DocSection title="Fleet Observability">
+          <p>
+            When your organisation has multiple design systems (a core system
+            plus product-specific forks), Ghost provides{" "}
+            <strong>fleet-level analysis</strong>:
+          </p>
+          <ul>
+            <li>
+              <strong>Pairwise distances</strong> &mdash; how far apart every
+              pair of systems is across all dimensions
+            </li>
+            <li>
+              <strong>Centroid</strong> &mdash; the average position of all
+              systems in the 64-dimensional space
+            </li>
+            <li>
+              <strong>Clustering</strong> &mdash; k-means grouping to identify
+              natural families of design systems
+            </li>
+            <li>
+              <strong>3D visualization</strong> &mdash; <code>ghost viz</code>{" "}
+              projects fingerprints into 3D via PCA for an interactive Three.js
+              view
+            </li>
+          </ul>
+        </DocSection>
+
+        <DocSection title="Artifacts">
+          <p>Ghost produces and consumes several file artifacts:</p>
+          <table>
+            <thead>
+              <tr>
+                <th>File</th>
+                <th>Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <code>ghost.config.ts</code>
+                </td>
+                <td>
+                  Project configuration — design systems, scan settings, rules
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>.ghost-fingerprint.json</code>
+                </td>
+                <td>
+                  Publishable fingerprint artifact (created with{" "}
+                  <code>--emit</code>)
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>.ghost-sync.json</code>
+                </td>
+                <td>
+                  Per-dimension stances and reasoning for evolution tracking
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>.ghost/history.jsonl</code>
+                </td>
+                <td>Append-only fingerprint history for temporal analysis</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <hr />
+
+          <p>
+            Ready to try it?{" "}
+            <Link to="/docs/getting-started" className="font-semibold">
+              Getting Started
+            </Link>{" "}
+            walks through setup step by step. See the{" "}
+            <Link to="/docs/cli" className="font-semibold">
+              CLI Reference
+            </Link>{" "}
+            for every command and flag.
+          </p>
+        </DocSection>
+      </DocProse>
+    </DocsPageLayout>
+  );
+}

--- a/packages/ghost-ui/src/app/docs/getting-started/page.tsx
+++ b/packages/ghost-ui/src/app/docs/getting-started/page.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { Link } from "react-router";
+import { AnimatedPageHeader } from "@/components/docs/animated-page-header";
+import { DocProse } from "@/components/docs/doc-prose";
+import { DocSection, DocsPageLayout } from "@/components/docs/docs-page-layout";
+
+export default function GettingStartedPage() {
+  return (
+    <DocsPageLayout>
+      <AnimatedPageHeader
+        kicker="Docs"
+        title="Getting Started"
+        description="Install Ghost, create a config, and run your first drift scan."
+      />
+
+      <DocProse>
+        <DocSection title="Installation">
+          <p>Add the core library and CLI to your project:</p>
+          <pre>
+            <code>pnpm add -D @ghost/core @ghost/cli</code>
+          </pre>
+          <p>
+            Or install globally to use <code>ghost</code> from anywhere:
+          </p>
+          <pre>
+            <code>pnpm add -g @ghost/cli</code>
+          </pre>
+        </DocSection>
+
+        <DocSection title="Create a Config">
+          <p>
+            Create a <code>ghost.config.ts</code> file in your project root.
+            This tells Ghost where your design system lives and what to scan:
+          </p>
+          <pre>
+            <code>
+              {`import { defineConfig } from "@ghost/core";
+
+export default defineConfig({
+  designSystems: [
+    {
+      name: "my-ds",
+      registry: "https://ui.example.com/registry.json",
+      componentDir: "src/components/ui",
+      styleEntry: "src/styles/globals.css",
+    },
+  ],
+  scan: {
+    values: true,      // detect token overrides & hardcoded colors
+    structure: true,   // diff component files against registry
+    visual: false,     // pixel-level comparison (requires Playwright)
+    analysis: false,   // LLM-aided interpretation
+  },
+  rules: {
+    "hardcoded-color": "error",
+    "token-override": "warn",
+    "missing-token": "warn",
+    "structural-divergence": "error",
+    "missing-component": "warn",
+  },
+});`}
+            </code>
+          </pre>
+        </DocSection>
+
+        <DocSection title="Configuration Reference">
+          <table>
+            <thead>
+              <tr>
+                <th>Option</th>
+                <th>Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <code>designSystems</code>
+                </td>
+                <td>array</td>
+                <td>
+                  One or more design systems to scan. Each needs a name,
+                  registry URL or path, component directory, and style entry
+                  point.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>parent</code>
+                </td>
+                <td>object</td>
+                <td>
+                  Parent baseline source. Type can be{" "}
+                  <code>&quot;default&quot;</code>, <code>&quot;url&quot;</code>
+                  , <code>&quot;path&quot;</code>, or{" "}
+                  <code>&quot;package&quot;</code>.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>scan</code>
+                </td>
+                <td>object</td>
+                <td>
+                  Toggle scan modes: <code>values</code>, <code>structure</code>
+                  , <code>visual</code>, <code>analysis</code>.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>rules</code>
+                </td>
+                <td>object</td>
+                <td>
+                  Set severity per rule: <code>&quot;error&quot;</code>,{" "}
+                  <code>&quot;warn&quot;</code>, or <code>&quot;off&quot;</code>
+                  .
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>ignore</code>
+                </td>
+                <td>string[]</td>
+                <td>Glob patterns for files to skip during scans.</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>visual</code>
+                </td>
+                <td>object</td>
+                <td>
+                  Visual scan settings: <code>threshold</code>,{" "}
+                  <code>viewport</code>, <code>timeout</code>,{" "}
+                  <code>outputDir</code>.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>llm</code>
+                </td>
+                <td>object</td>
+                <td>
+                  LLM provider config for analysis: <code>provider</code> (
+                  <code>&quot;anthropic&quot;</code> |{" "}
+                  <code>&quot;openai&quot;</code>), <code>model</code>,{" "}
+                  <code>apiKey</code>.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>embedding</code>
+                </td>
+                <td>object</td>
+                <td>
+                  Embedding provider for semantic fingerprints:{" "}
+                  <code>provider</code>, <code>model</code>, <code>apiKey</code>
+                  .
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </DocSection>
+
+        <DocSection title="Run Your First Scan">
+          <p>
+            With your config in place, run a drift scan to see how your local
+            components compare to the registry:
+          </p>
+          <pre>
+            <code>ghost scan</code>
+          </pre>
+          <p>
+            Ghost will check your values and structure against the parent
+            registry and print a report. Pass <code>--format json</code> for
+            machine-readable output.
+          </p>
+        </DocSection>
+
+        <DocSection title="Generate a Fingerprint">
+          <p>
+            A fingerprint is a 64-dimensional vector that captures your design
+            system's identity — palette, spacing, typography, surfaces, and
+            architecture:
+          </p>
+          <pre>
+            <code>ghost profile</code>
+          </pre>
+          <p>
+            This writes a fingerprint to stdout. Add <code>--emit</code> to save
+            a <code>.ghost-fingerprint.json</code> file for later comparison.
+          </p>
+        </DocSection>
+
+        <DocSection title="Compare Two Systems">
+          <p>
+            Once you have two fingerprint files, compare them to see exactly
+            where they diverge:
+          </p>
+          <pre>
+            <code>ghost compare parent.json consumer.json</code>
+          </pre>
+
+          <hr />
+
+          <p>
+            Next:{" "}
+            <Link to="/docs/concepts" className="font-semibold">
+              Core Concepts
+            </Link>{" "}
+            to understand fingerprints, drift, and evolution in depth. Or jump
+            to the{" "}
+            <Link to="/docs/cli" className="font-semibold">
+              CLI Reference
+            </Link>{" "}
+            for every command and flag.
+          </p>
+        </DocSection>
+      </DocProse>
+    </DocsPageLayout>
+  );
+}

--- a/packages/ghost-ui/src/app/docs/page.tsx
+++ b/packages/ghost-ui/src/app/docs/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import {
+  BookOpen,
+  Compass,
+  Fingerprint,
+  Layers,
+  Rocket,
+  Server,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { AnimatedPageHeader } from "@/components/docs/animated-page-header";
+import { SectionWrapper } from "@/components/docs/wrappers";
+import { useStaggerReveal } from "@/hooks/use-scroll-reveal";
+
+const sections: {
+  name: string;
+  href: string;
+  description: string;
+  icon: ReactNode;
+}[] = [
+  {
+    name: "Getting Started",
+    href: "/docs/getting-started",
+    description:
+      "Install Ghost, create your first config, and run your first drift scan in under five minutes.",
+    icon: <Rocket className="size-8" strokeWidth={1.5} />,
+  },
+  {
+    name: "Core Concepts",
+    href: "/docs/concepts",
+    description:
+      "Fingerprints, drift detection, evolution tracking, and fleet observability — the ideas behind Ghost.",
+    icon: <Fingerprint className="size-8" strokeWidth={1.5} />,
+  },
+  {
+    name: "CLI Reference",
+    href: "/docs/cli",
+    description:
+      "All nine commands — scan, profile, compare, diff, ack, adopt, diverge, fleet, and viz.",
+    icon: <BookOpen className="size-8" strokeWidth={1.5} />,
+  },
+  {
+    name: "Self-Hosting",
+    href: "/docs/self-hosting",
+    description:
+      "Run Ghost UI as your own design system documentation site with your registry and tokens.",
+    icon: <Server className="size-8" strokeWidth={1.5} />,
+  },
+  {
+    name: "Ghost UI",
+    href: "/components",
+    description:
+      "Browse the component catalogue — 49 primitives and 48 AI-native elements ready to use.",
+    icon: <Layers className="size-8" strokeWidth={1.5} />,
+  },
+  {
+    name: "Foundations",
+    href: "/foundations",
+    description:
+      "Color, typography, and the design tokens that underpin every Ghost UI component.",
+    icon: <Compass className="size-8" strokeWidth={1.5} />,
+  },
+];
+
+export default function DocsIndex() {
+  const ref = useStaggerReveal<HTMLDivElement>(".doc-card", {
+    stagger: 0.06,
+    y: 30,
+    duration: 0.7,
+  });
+
+  return (
+    <SectionWrapper>
+      <AnimatedPageHeader
+        kicker="Documentation"
+        title="Ghost"
+        description="Autonomous design drift detection for decentralised design ecosystems. Ghost fingerprints design systems, tracks their evolution, and surfaces divergence before it compounds."
+      />
+
+      <div
+        ref={ref}
+        className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 pb-16 overflow-visible"
+      >
+        {sections.map((item) => (
+          <Link
+            key={item.href}
+            to={item.href}
+            className="doc-card group rounded-[var(--radius-card-sm)] border border-border-card bg-card p-10 transition-all duration-200 hover:scale-[1.03] hover:shadow-elevated"
+          >
+            <div className="mb-6 text-muted-foreground group-hover:text-foreground transition-colors duration-200">
+              {item.icon}
+            </div>
+            <span className="font-display text-lg font-bold tracking-tight">
+              {item.name}
+            </span>
+            <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+              {item.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </SectionWrapper>
+  );
+}

--- a/packages/ghost-ui/src/app/docs/self-hosting/page.tsx
+++ b/packages/ghost-ui/src/app/docs/self-hosting/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { Link } from "react-router";
+import { AnimatedPageHeader } from "@/components/docs/animated-page-header";
+import { DocProse } from "@/components/docs/doc-prose";
+import { DocSection, DocsPageLayout } from "@/components/docs/docs-page-layout";
+
+export default function SelfHostingPage() {
+  return (
+    <DocsPageLayout>
+      <AnimatedPageHeader
+        kicker="Docs"
+        title="Self-Hosting"
+        description="Run Ghost UI as your own design system documentation site."
+      />
+
+      <DocProse>
+        <DocSection title="Overview">
+          <p>
+            Ghost UI is a standalone Vite + React app that serves as both a
+            reference design system and an interactive component catalogue. You
+            can fork it, swap in your own registry and tokens, and deploy it as
+            the documentation site for your design system.
+          </p>
+        </DocSection>
+
+        <DocSection title="Clone the Repository">
+          <pre>
+            <code>
+              {`git clone https://github.com/block/ghost.git
+cd ghost
+pnpm install`}
+            </code>
+          </pre>
+        </DocSection>
+
+        <DocSection title="Swap Your Registry">
+          <p>
+            Ghost UI reads from <code>packages/ghost-ui/registry.json</code> — a
+            shadcn-compatible registry that defines all components, styles, and
+            dependencies. Replace this with your own:
+          </p>
+          <pre>
+            <code>
+              {`# Replace the registry with your own
+cp path/to/your/registry.json packages/ghost-ui/registry.json
+
+# Or rebuild from your shadcn config
+cd packages/ghost-ui
+pnpm build:registry`}
+            </code>
+          </pre>
+          <p>
+            The registry format follows the{" "}
+            <strong>shadcn registry specification</strong> — each item has a
+            name, type, dependencies, and file contents. Ghost UI uses this to
+            render install commands, source previews, and dependency graphs.
+          </p>
+        </DocSection>
+
+        <DocSection title="Customise Theme Tokens">
+          <p>
+            Design tokens live in CSS custom properties. The main entry point is
+            the styles directory:
+          </p>
+          <pre>
+            <code>
+              {`packages/ghost-ui/src/styles/
+├── base.css          # CSS variable definitions (light + dark)
+├── globals.css       # Global resets and imports
+└── ...`}
+            </code>
+          </pre>
+          <p>
+            Edit <code>base.css</code> to change colours, spacing, border radii,
+            typography scales, and shadows. All components inherit from these
+            tokens — changes propagate everywhere automatically.
+          </p>
+
+          <h3>Theme Presets</h3>
+          <p>
+            Ghost UI ships with theme presets in{" "}
+            <code>src/lib/theme-presets.ts</code>. You can add your own brand
+            preset or modify existing ones. The live theme panel (accessible via
+            the UI) lets you experiment with token values in real time.
+          </p>
+        </DocSection>
+
+        <DocSection title="Update Component Demos">
+          <p>
+            Component demos live in <code>src/components/docs/primitives/</code>{" "}
+            and <code>src/components/docs/ai-elements/</code>. Each file exports
+            a default component that renders a demo for its corresponding UI
+            component.
+          </p>
+          <p>
+            The component registry in <code>src/lib/component-registry.ts</code>{" "}
+            maps component slugs to their metadata (name, category, description,
+            demo component). Add or remove entries here to control what appears
+            in the catalogue.
+          </p>
+        </DocSection>
+
+        <DocSection title="Fonts">
+          <p>
+            Ghost UI uses self-hosted HK Grotesk (WOFF2). Font files live in{" "}
+            <code>src/fonts/</code>. To use your own typeface:
+          </p>
+          <ol>
+            <li>Add your font files to the fonts directory</li>
+            <li>
+              Update the <code>@font-face</code> declarations in{" "}
+              <code>globals.css</code>
+            </li>
+            <li>
+              Update the <code>--font-display</code> and{" "}
+              <code>--font-body</code> CSS variables
+            </li>
+          </ol>
+        </DocSection>
+
+        <DocSection title="Development">
+          <pre>
+            <code>
+              {`# Start the dev server
+just dev
+# or: cd packages/ghost-ui && pnpm dev
+
+# The site is available at http://localhost:5173`}
+            </code>
+          </pre>
+        </DocSection>
+
+        <DocSection title="Build & Deploy">
+          <p>
+            Ghost UI builds to a static SPA that can be deployed to any static
+            hosting provider:
+          </p>
+          <pre>
+            <code>
+              {`# Build for production
+just build-ui
+# or: cd packages/ghost-ui && pnpm build
+
+# Output is in packages/ghost-ui/dist/`}
+            </code>
+          </pre>
+          <p>
+            The <code>dist/</code> directory contains a fully self-contained
+            SPA. Deploy it to Vercel, Netlify, Cloudflare Pages, GitHub Pages,
+            or any static file server.
+          </p>
+
+          <h3>Docker</h3>
+          <p>
+            For container deployments, serve the static output with any web
+            server:
+          </p>
+          <pre>
+            <code>
+              {`FROM nginx:alpine
+COPY packages/ghost-ui/dist/ /usr/share/nginx/html/
+# Configure SPA fallback for client-side routing
+RUN echo 'server { listen 80; location / { try_files $uri /index.html; } }' \\
+    > /etc/nginx/conf.d/default.conf`}
+            </code>
+          </pre>
+        </DocSection>
+
+        <DocSection title="Connect to Ghost">
+          <p>
+            Once your design system is running as a Ghost UI site, you can use
+            Ghost's core tooling to track drift between this parent and any
+            consumers:
+          </p>
+          <ol>
+            <li>
+              Publish your <code>registry.json</code> at a stable URL
+            </li>
+            <li>
+              In consumer projects, point <code>ghost.config.ts</code> to your
+              registry URL
+            </li>
+            <li>
+              Run <code>ghost scan</code> and <code>ghost profile</code> to
+              detect drift
+            </li>
+          </ol>
+
+          <hr />
+
+          <p>
+            See{" "}
+            <Link to="/docs/getting-started" className="font-semibold">
+              Getting Started
+            </Link>{" "}
+            for the consumer-side setup, or browse the{" "}
+            <Link to="/components" className="font-semibold">
+              Component Catalogue
+            </Link>{" "}
+            to see what ships out of the box.
+          </p>
+        </DocSection>
+      </DocProse>
+    </DocsPageLayout>
+  );
+}

--- a/packages/ghost-ui/src/components/docs/cycloid-canvas.tsx
+++ b/packages/ghost-ui/src/components/docs/cycloid-canvas.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const MAX_POINTS = 2000;
+const BASE_OPACITY = 0.15;
+const FADE_SEGMENTS = 32;
+const ANGLE_PER_MS = 0.0008; // fixed speed regardless of frame rate
+const TRANSITION_MS = 800; // duration of lerp between shapes
+
+// Each entry: [r value, angle for one full closed shape]
+const RATIO_TABLE: [number, number][] = [
+  [0.2, 2 * Math.PI], // 4 petals
+  [0.25, 2 * Math.PI], // 3 petals
+  [0.3, 6 * Math.PI], // 7 petals over 3 revs
+  [1 / 3, 2 * Math.PI], // 2 petals
+  [0.4, 4 * Math.PI], // 3 petals over 2 revs
+  [0.5, 2 * Math.PI], // 1 petal (ellipse-like)
+];
+
+function pickShape() {
+  const entry = RATIO_TABLE[Math.floor(Math.random() * RATIO_TABLE.length)];
+  const r = entry[0];
+  const revolution = entry[1];
+  const d = r * (0.3 + Math.random() * 0.7);
+  return { r, d, revolution };
+}
+
+function resolveColor(): string {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue("--foreground")
+    .trim();
+}
+
+export function CycloidCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // --- State ---
+    let prevShape = pickShape();
+    let nextShape = prevShape;
+    let angle = 0;
+    let shapeStartAngle = 0;
+    let transitionElapsed = TRANSITION_MS; // start fully settled
+
+    const xs = new Float32Array(MAX_POINTS);
+    const ys = new Float32Array(MAX_POINTS);
+    let head = 0;
+    let count = 0;
+
+    let color = resolveColor();
+    let rafId = 0;
+    let lastTime = 0;
+
+    // --- Sizing ---
+    const dpr = window.devicePixelRatio || 1;
+
+    function resize() {
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+    resize();
+
+    // --- Theme ---
+    const mo = new MutationObserver(() => {
+      color = resolveColor();
+    });
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    // --- Draw loop ---
+    function draw(time: number) {
+      if (!canvas || !ctx) return;
+
+      // Delta time for fixed speed
+      if (lastTime === 0) lastTime = time;
+      const dt = Math.min(time - lastTime, 50); // cap to avoid jumps
+      lastTime = time;
+
+      const cssW = canvas.width / dpr;
+      const cssH = canvas.height / dpr;
+
+      // Check if we completed a full shape — begin transition to next
+      const activeRevolution = nextShape.revolution;
+      if (
+        transitionElapsed >= TRANSITION_MS &&
+        angle - shapeStartAngle >= activeRevolution
+      ) {
+        prevShape = nextShape;
+        nextShape = pickShape();
+        shapeStartAngle = angle;
+        transitionElapsed = 0;
+      }
+
+      // Advance transition timer
+      transitionElapsed = Math.min(transitionElapsed + dt, TRANSITION_MS);
+
+      // Interpolate params: brief lerp at start of each shape, then locked
+      const t = Math.min(transitionElapsed / TRANSITION_MS, 1);
+      // Smooth ease-in-out
+      const ease = t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
+      const r = prevShape.r + (nextShape.r - prevShape.r) * ease;
+      const d = prevShape.d + (nextShape.d - prevShape.d) * ease;
+
+      // Advance angle at fixed rate
+      const deltaAngle = ANGLE_PER_MS * dt;
+
+      const R = 1;
+      const x = (R - r) * Math.cos(angle) + d * Math.cos(((R - r) / r) * angle);
+      const y = (R - r) * Math.sin(angle) - d * Math.sin(((R - r) / r) * angle);
+
+      xs[head] = x;
+      ys[head] = y;
+      head = (head + 1) % MAX_POINTS;
+      if (count < MAX_POINTS) count++;
+
+      angle += deltaAngle;
+
+      // Clear
+      ctx.clearRect(0, 0, cssW, cssH);
+
+      // Scale: fit normalized coords into a centered square
+      const drawSize = Math.min(cssW, cssH) * 1.8;
+      const scale = drawSize / 4;
+      const cx = cssW / 2;
+      const cy = cssH / 2;
+
+      // Draw trail as overlapping segments with graduated alpha
+      const oldest = count < MAX_POINTS ? 0 : head;
+      const segSize = Math.ceil(count / FADE_SEGMENTS);
+
+      ctx.lineWidth = 1.5;
+      ctx.lineJoin = "round";
+      ctx.lineCap = "round";
+      ctx.strokeStyle = color;
+
+      for (let s = 0; s < FADE_SEGMENTS; s++) {
+        const startI = s * segSize;
+        const endI = Math.min((s + 1) * segSize, count - 1);
+        if (startI >= count) break;
+
+        // Oldest segment = 0 alpha, newest = full alpha
+        const progress = (s + 0.5) / FADE_SEGMENTS;
+        ctx.globalAlpha = BASE_OPACITY * progress;
+
+        ctx.beginPath();
+
+        // Start from 1 point before for overlap (no gaps between segments)
+        const overlapStart = s === 0 ? startI : startI - 1;
+
+        for (let i = overlapStart; i <= endI; i++) {
+          const idx = (oldest + i) % MAX_POINTS;
+          const px = cx + xs[idx] * scale;
+          const py = cy + ys[idx] * scale;
+          if (i === overlapStart) ctx.moveTo(px, py);
+          else ctx.lineTo(px, py);
+        }
+
+        ctx.stroke();
+      }
+
+      ctx.globalAlpha = 1;
+      rafId = requestAnimationFrame(draw);
+    }
+
+    rafId = requestAnimationFrame(draw);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      ro.disconnect();
+      mo.disconnect();
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="pointer-events-none absolute inset-0 h-full w-full"
+      aria-hidden="true"
+    />
+  );
+}

--- a/packages/ghost-ui/src/components/docs/doc-prose.tsx
+++ b/packages/ghost-ui/src/components/docs/doc-prose.tsx
@@ -1,0 +1,43 @@
+import type { ComponentProps } from "react";
+import { cn } from "@/lib/utils";
+
+export function DocProse({
+  children,
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "pb-24",
+        // Headings
+        "[&_h2]:font-display [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:tracking-tight [&_h2]:mt-12 [&_h2]:mb-4",
+        "[&_h3]:font-display [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:tracking-tight [&_h3]:mt-8 [&_h3]:mb-3",
+        // Paragraphs
+        "[&_p]:text-muted-foreground [&_p]:leading-relaxed [&_p]:mb-4",
+        // Links
+        "[&_a]:text-foreground [&_a]:underline [&_a]:underline-offset-4 [&_a]:decoration-border-strong hover:[&_a]:decoration-foreground",
+        // Lists
+        "[&_ul]:text-muted-foreground [&_ul]:leading-relaxed [&_ul]:mb-4 [&_ul]:pl-6 [&_ul]:list-disc",
+        "[&_ol]:text-muted-foreground [&_ol]:leading-relaxed [&_ol]:mb-4 [&_ol]:pl-6 [&_ol]:list-decimal",
+        "[&_li]:mb-1.5",
+        // Code inline
+        "[&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-muted [&_:not(pre)>code]:px-1.5 [&_:not(pre)>code]:py-0.5 [&_:not(pre)>code]:text-sm [&_:not(pre)>code]:font-mono",
+        // Code blocks
+        "[&_pre]:rounded-lg [&_pre]:border [&_pre]:border-border-card [&_pre]:bg-muted/50 [&_pre]:p-4 [&_pre]:mb-4 [&_pre]:overflow-x-auto [&_pre]:text-sm [&_pre]:leading-relaxed [&_pre]:font-mono",
+        // Tables
+        "[&_table]:w-full [&_table]:mb-4 [&_table]:text-sm",
+        "[&_th]:text-left [&_th]:font-semibold [&_th]:text-foreground [&_th]:border-b [&_th]:border-border-strong [&_th]:pb-2 [&_th]:pr-4",
+        "[&_td]:text-muted-foreground [&_td]:border-b [&_td]:border-border-card [&_td]:py-2.5 [&_td]:pr-4 [&_td]:align-top",
+        // Horizontal rules
+        "[&_hr]:my-8 [&_hr]:border-border-card",
+        // Strong
+        "[&_strong]:text-foreground [&_strong]:font-semibold",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/ghost-ui/src/components/docs/dock.tsx
+++ b/packages/ghost-ui/src/components/docs/dock.tsx
@@ -2,6 +2,7 @@
 
 import type { LucideIcon } from "lucide-react";
 import {
+  BookOpen,
   Home,
   LayoutGrid,
   Monitor,
@@ -36,6 +37,7 @@ import { cn } from "@/lib/utils";
 
 const nav: { name: string; path: string; icon: LucideIcon }[] = [
   { name: "Home", path: "/", icon: Home },
+  { name: "Docs", path: "/docs", icon: BookOpen },
   { name: "Foundations", path: "/foundations", icon: Palette },
   { name: "Components", path: "/components", icon: LayoutGrid },
 ];
@@ -207,6 +209,54 @@ export function Dock() {
             >
               <Palette className="mr-2 size-4" />
               Typography
+            </CommandItem>
+          </CommandGroup>
+
+          <CommandGroup heading="Documentation">
+            <CommandItem
+              onSelect={() => {
+                navigate("/docs");
+                setSearchOpen(false);
+              }}
+            >
+              <BookOpen className="mr-2 size-4" />
+              Docs Overview
+            </CommandItem>
+            <CommandItem
+              onSelect={() => {
+                navigate("/docs/getting-started");
+                setSearchOpen(false);
+              }}
+            >
+              <BookOpen className="mr-2 size-4" />
+              Getting Started
+            </CommandItem>
+            <CommandItem
+              onSelect={() => {
+                navigate("/docs/cli");
+                setSearchOpen(false);
+              }}
+            >
+              <BookOpen className="mr-2 size-4" />
+              CLI Reference
+            </CommandItem>
+            <CommandItem
+              onSelect={() => {
+                navigate("/docs/concepts");
+                setSearchOpen(false);
+              }}
+            >
+              <BookOpen className="mr-2 size-4" />
+              Core Concepts
+            </CommandItem>
+            <CommandItem
+              onSelect={() => {
+                navigate("/docs/self-hosting");
+                setSearchOpen(false);
+              }}
+            >
+              <BookOpen className="mr-2 size-4" />
+              Self-Hosting
             </CommandItem>
           </CommandGroup>
 

--- a/packages/ghost-ui/src/components/docs/docs-page-layout.tsx
+++ b/packages/ghost-ui/src/components/docs/docs-page-layout.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Wrapper for doc pages that use the two-column section layout.
+ * Provides page-level padding matching SectionWrapper.
+ */
+export function DocsPageLayout({ children }: { children: ReactNode }) {
+  return <div className="relative py-6 md:py-8 px-6 lg:px-8">{children}</div>;
+}
+
+/**
+ * A single documentation section rendered as a two-column row on lg+.
+ *
+ * Left column: sticky section title (replaces inline <h2>).
+ * Right column: section content with DocProse-compatible styling.
+ */
+export function DocSection({
+  title,
+  children,
+  className,
+}: {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section
+      className={cn(
+        "grid grid-cols-1 lg:grid-cols-[12rem_1fr] xl:grid-cols-[14rem_1fr] gap-x-10 gap-y-0 border-t border-border/40 pt-8 pb-2 first:border-t-0 first:pt-0",
+        className,
+      )}
+    >
+      {/* Left: sticky title */}
+      <div className="lg:sticky lg:top-8 lg:self-start mb-4 lg:mb-0 lg:pt-0.5">
+        <p className="font-display text-sm tracking-tight !text-foreground">
+          {title}
+        </p>
+      </div>
+
+      {/* Right: content */}
+      <div className="min-w-0 max-w-[72ch]">{children}</div>
+    </section>
+  );
+}

--- a/packages/ghost-ui/src/components/docs/hero.tsx
+++ b/packages/ghost-ui/src/components/docs/hero.tsx
@@ -66,22 +66,6 @@ export function Hero() {
       {/* Subtle gradient overlay for depth */}
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-background/60" />
 
-      {/* Plus grid background */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-[0.07] dark:hidden"
-        style={{
-          backgroundImage: `url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M20 16v8M16 20h8' stroke='black' stroke-width='0.5' fill='none'/%3E%3C/svg%3E")`,
-          backgroundSize: "80px 80px",
-        }}
-      />
-      <div
-        className="pointer-events-none absolute inset-0 opacity-[0.07] hidden dark:block"
-        style={{
-          backgroundImage: `url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M20 16v8M16 20h8' stroke='white' stroke-width='0.5' fill='none'/%3E%3C/svg%3E")`,
-          backgroundSize: "80px 80px",
-        }}
-      />
-
       {/* Circle behind heading */}
       <div className="pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[min(70vw,600px)] aspect-square rounded-full border border-foreground/15" />
 

--- a/packages/ghost-ui/src/components/docs/hero.tsx
+++ b/packages/ghost-ui/src/components/docs/hero.tsx
@@ -3,6 +3,7 @@
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useEffect, useRef } from "react";
+import { CycloidCanvas } from "./cycloid-canvas";
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -66,8 +67,8 @@ export function Hero() {
       {/* Subtle gradient overlay for depth */}
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-background/60" />
 
-      {/* Circle behind heading */}
-      <div className="pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[min(70vw,600px)] aspect-square rounded-full border border-foreground/15" />
+      {/* Generative cycloid drawing */}
+      <CycloidCanvas />
 
       <div className="relative z-10 flex w-full flex-col items-center">
         <h1


### PR DESCRIPTION
## Summary
- Adds docs pages (getting started, CLI reference, concepts, self-hosting) with a two-column section layout
- Adds a generative cycloid canvas animation to the hero page

## Test plan
- [x] Verify docs pages render correctly with two-column layout
- [x] Confirm cycloid canvas animation runs smoothly on the hero page
- [x] Check responsive behavior on smaller viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)