### PR TITLE
Fix SPA routing on GitHub Pages

### DIFF
--- a/packages/ghost-ui/src/main.tsx
+++ b/packages/ghost-ui/src/main.tsx
@@ -6,7 +6,7 @@ import "./styles/main.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.VITE_BASE_PATH || "/"}>
       <App />
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- Set `basename` on `BrowserRouter` using `VITE_BASE_PATH` so React Router resolves all routes relative to `/ghost/`
- Without this, navigating to Home or any route on `block.github.io/ghost/` would resolve against `/` instead of `/ghost/`

## Test plan
- [x] Deploy and verify https://block.github.io/ghost/ loads the home page
- [x] Verify navigation between Home, Docs, and Components works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)