### PR TITLE
Add registry build step to Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Build registry
+        run: pnpm --filter @ghost/ui build:registry
       - name: Build Ghost UI
         run: pnpm --filter @ghost/ui build
         env:


### PR DESCRIPTION
## Summary
- Adds `build:registry` step before the Vite build in the GitHub Pages workflow
- Ensures deployed site serves fresh registry JSONs at `/ghost/r/*.json`
- Enables `shadcn add` to install components directly from the live registry

## Test plan
- [x] Verify deployment succeeds with the new step
- [x] Confirm registry JSON is accessible at https://block.github.io/ghost/r/button.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)