### PR TITLE
Enhance cycloid animation transitions

### DIFF
--- a/packages/ghost-ui/src/app/components/page.tsx
+++ b/packages/ghost-ui/src/app/components/page.tsx
@@ -124,13 +124,11 @@ function ComponentPill({ slug, name }: { slug: string; name: string }) {
   return (
     <Link
       to={`/components/${slug}`}
-      className="component-card group relative inline-block rounded-full border border-border-card hover:border-foreground/25 bg-card px-4 py-1.5 transition-colors duration-300"
+      className="component-card group relative inline-block overflow-hidden rounded-full border border-border-card hover:border-foreground/25 bg-card px-4 py-1.5 transition-colors duration-300"
     >
-      <span className="relative inline-block">
-        <span className="relative z-10 text-sm font-medium transition-colors duration-300 group-hover:text-background">
-          {name}
-        </span>
-        <span className="absolute inset-0 bg-foreground origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out rounded-full" />
+      <span className="absolute inset-0 bg-foreground origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out" />
+      <span className="relative z-10 text-sm font-medium transition-colors duration-300 group-hover:text-background">
+        {name}
       </span>
     </Link>
   );

--- a/packages/ghost-ui/src/app/components/page.tsx
+++ b/packages/ghost-ui/src/app/components/page.tsx
@@ -1,12 +1,62 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { AnimatedPageHeader } from "@/components/docs/animated-page-header";
 import { SectionWrapper } from "@/components/docs/wrappers";
 import { useStaggerReveal } from "@/hooks/use-scroll-reveal";
-import { categories, getComponentsByCategory } from "@/lib/component-registry";
+import {
+  categories,
+  getAllComponents,
+  getComponentsByCategory,
+} from "@/lib/component-registry";
+
+/* ── Fuzzy match ─────────────────────────────────────────────────────── */
+
+function fuzzyMatch(query: string, target: string): number {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+
+  // exact substring match scores highest
+  if (t.includes(q)) return 1;
+
+  // character-by-character fuzzy: every query char must appear in order
+  let qi = 0;
+  let score = 0;
+  let lastIdx = -1;
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      // bonus for consecutive matches
+      score += ti === lastIdx + 1 ? 2 : 1;
+      lastIdx = ti;
+      qi++;
+    }
+  }
+
+  // all query characters must be found
+  if (qi < q.length) return 0;
+
+  // normalise to 0–1 range (below 1 so substring match always wins)
+  return (score / (q.length * 2)) * 0.9;
+}
+
+/* ── Page ─────────────────────────────────────────────────────────────── */
 
 export default function ComponentsIndex() {
+  const [query, setQuery] = useState("");
+  const allComponents = useMemo(() => getAllComponents(), []);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return null;
+    return allComponents
+      .map((c) => ({ ...c, score: fuzzyMatch(query, c.name) }))
+      .filter((c) => c.score > 0)
+      .sort((a, b) => b.score - a.score);
+  }, [query, allComponents]);
+
+  const isSearching = query.trim().length > 0;
+
   return (
     <SectionWrapper>
       <AnimatedPageHeader
@@ -15,23 +65,78 @@ export default function ComponentsIndex() {
         description="Production-ready building blocks. Every component follows Ghost UI — pill-first, monochromatic, accessible."
       />
 
-      <div className="grid gap-12 pb-16">
-        {categories.map((cat) => {
-          const items = getComponentsByCategory(cat.slug);
-          if (items.length === 0) return null;
-          return (
-            <CategorySection
-              key={cat.slug}
-              name={cat.name}
-              description={cat.description}
-              items={items}
-            />
-          );
-        })}
+      {/* Search */}
+      <div className="mb-10">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search components…"
+          className="w-full max-w-md rounded-full border border-border-card bg-card px-5 py-2.5 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-foreground/25 transition-colors duration-200"
+        />
       </div>
+
+      {/* Search results */}
+      {isSearching && (
+        <div className="pb-16">
+          {filtered && filtered.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {filtered.map((item) => (
+                <ComponentPill
+                  key={item.slug}
+                  slug={item.slug}
+                  name={item.name}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No components match "{query}"
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Category sections */}
+      {!isSearching && (
+        <div className="grid gap-10 pb-16">
+          {categories.map((cat) => {
+            const items = getComponentsByCategory(cat.slug);
+            if (items.length === 0) return null;
+            return (
+              <CategorySection
+                key={cat.slug}
+                name={cat.name}
+                description={cat.description}
+                items={items}
+              />
+            );
+          })}
+        </div>
+      )}
     </SectionWrapper>
   );
 }
+
+/* ── Pill ─────────────────────────────────────────────────────────────── */
+
+function ComponentPill({ slug, name }: { slug: string; name: string }) {
+  return (
+    <Link
+      to={`/components/${slug}`}
+      className="component-card group relative inline-block rounded-full border border-border-card hover:border-foreground/25 bg-card px-4 py-1.5 transition-colors duration-300"
+    >
+      <span className="relative inline-block">
+        <span className="relative z-10 text-sm font-medium transition-colors duration-300 group-hover:text-background">
+          {name}
+        </span>
+        <span className="absolute inset-0 bg-foreground origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out rounded-full" />
+      </span>
+    </Link>
+  );
+}
+
+/* ── Category section ─────────────────────────────────────────────────── */
 
 function CategorySection({
   name,
@@ -56,16 +161,10 @@ function CategorySection({
       >
         {name}
       </h2>
-      <p className="text-sm text-muted-foreground mb-5">{description}</p>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+      <p className="text-sm text-muted-foreground mb-4">{description}</p>
+      <div className="flex flex-wrap gap-2">
         {items.map((item) => (
-          <Link
-            key={item.slug}
-            to={`/components/${item.slug}`}
-            className="component-card group rounded-[var(--radius-card-sm)] border border-border-card bg-card p-4 transition-all duration-200 hover:scale-[1.03] hover:shadow-elevated"
-          >
-            <span className="text-sm font-medium">{item.name}</span>
-          </Link>
+          <ComponentPill key={item.slug} slug={item.slug} name={item.name} />
         ))}
       </div>
     </div>

--- a/packages/ghost-ui/src/app/docs/concepts/page.tsx
+++ b/packages/ghost-ui/src/app/docs/concepts/page.tsx
@@ -1,328 +1,865 @@
 "use client";
 
-import { Link } from "react-router";
+import gsap from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { useEffect, useRef, useState } from "react";
 import { AnimatedPageHeader } from "@/components/docs/animated-page-header";
-import { DocProse } from "@/components/docs/doc-prose";
-import { DocSection, DocsPageLayout } from "@/components/docs/docs-page-layout";
+import { SectionWrapper } from "@/components/docs/wrappers";
+import { cn } from "@/lib/utils";
+
+gsap.registerPlugin(ScrollTrigger);
+
+/* ─────────────────────────── Chapter wrapper ─────────────────────────── */
+
+function Chapter({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const items = el.querySelectorAll(".reveal");
+    if (items.length === 0) return;
+
+    gsap.set(items, { y: 40, opacity: 0 });
+
+    const trigger = ScrollTrigger.create({
+      trigger: el,
+      start: "top 85%",
+      once: true,
+      onEnter: () => {
+        gsap.to(items, {
+          y: 0,
+          opacity: 1,
+          duration: 0.8,
+          stagger: 0.1,
+          ease: "power2.out",
+          onComplete: () => {
+            gsap.set(items, { clearProps: "transform,opacity" });
+          },
+        });
+      },
+    });
+
+    return () => trigger.kill();
+  }, []);
+
+  return (
+    <section
+      ref={ref}
+      className={cn("relative py-16 md:py-24 lg:py-32", className)}
+    >
+      {children}
+    </section>
+  );
+}
+
+function ChapterLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="reveal font-display uppercase text-muted-foreground mb-3"
+      style={{
+        fontSize: "var(--label-font-size)",
+        letterSpacing: "var(--label-letter-spacing)",
+      }}
+    >
+      {children}
+    </p>
+  );
+}
+
+function ChapterTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h2
+      className="reveal font-display font-black tracking-[-0.04em] leading-[0.92] mb-4"
+      style={{ fontSize: "var(--heading-sub-font-size)" }}
+    >
+      {children}
+    </h2>
+  );
+}
+
+function ChapterLead({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="reveal max-w-[52ch] text-muted-foreground leading-relaxed text-lg mb-10">
+      {children}
+    </p>
+  );
+}
+
+/* ─────────────────────── 1. The Problem ──────────────────────────────── */
+
+function DriftSpotlight() {
+  const [revealed, setRevealed] = useState(false);
+
+  return (
+    <div className="reveal">
+      <div className="grid grid-cols-2 gap-4 md:gap-6">
+        {/* "Parent" button */}
+        <div className="rounded-[var(--radius-card-sm)] border border-border-card bg-card p-6 md:p-8 flex flex-col items-center gap-4">
+          <span className="text-xs font-mono text-muted-foreground">
+            Parent registry
+          </span>
+          <div className="w-full flex justify-center">
+            <div className="h-11 px-6 rounded-[8px] bg-foreground text-background flex items-center justify-center text-sm font-semibold">
+              Submit
+            </div>
+          </div>
+          <code className="text-xs text-muted-foreground font-mono">
+            radius: 8px · padding: 24px
+          </code>
+        </div>
+
+        {/* "Consumer" button — subtly drifted */}
+        <div className="rounded-[var(--radius-card-sm)] border border-border-card bg-card p-6 md:p-8 flex flex-col items-center gap-4">
+          <span className="text-xs font-mono text-muted-foreground">
+            Your app
+          </span>
+          <div className="w-full flex justify-center">
+            <div className="h-11 px-5 rounded-[6px] bg-foreground text-background flex items-center justify-center text-sm font-semibold">
+              Submit
+            </div>
+          </div>
+          <code className="text-xs text-muted-foreground font-mono">
+            radius: 6px · padding: 20px
+          </code>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setRevealed((r) => !r)}
+        className="mt-4 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+      >
+        {revealed ? "Hide difference" : "Spot the difference?"}
+      </button>
+
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-500",
+          revealed ? "max-h-24 opacity-100 mt-3" : "max-h-0 opacity-0",
+        )}
+      >
+        <div className="rounded-lg bg-muted/50 border border-border-card px-4 py-3 text-sm text-muted-foreground">
+          <span className="font-semibold text-foreground">border-radius</span>{" "}
+          changed from <code className="font-mono">8px</code> to{" "}
+          <code className="font-mono">6px</code>. Tiny? Yes. But multiply this
+          by 50 components across 3 apps, and your design system dissolves.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────── 2. The Fingerprint — Radar ─────────────────────── */
+
+const RADAR_CATEGORIES = [
+  { label: "Palette", angle: -90 },
+  { label: "Spacing", angle: -18 },
+  { label: "Typography", angle: 54 },
+  { label: "Surfaces", angle: 126 },
+  { label: "Architecture", angle: 198 },
+];
+
+function polarToCartesian(
+  angleDeg: number,
+  radius: number,
+  cx: number,
+  cy: number,
+) {
+  const rad = (angleDeg * Math.PI) / 180;
+  return { x: cx + radius * Math.cos(rad), y: cy + radius * Math.sin(rad) };
+}
+
+function radarPath(
+  values: number[],
+  maxRadius: number,
+  cx: number,
+  cy: number,
+) {
+  return values
+    .map((v, i) => {
+      const { x, y } = polarToCartesian(
+        RADAR_CATEGORIES[i].angle,
+        v * maxRadius,
+        cx,
+        cy,
+      );
+      return `${i === 0 ? "M" : "L"} ${x} ${y}`;
+    })
+    .join(" ")
+    .concat(" Z");
+}
+
+function RadarChart({
+  parentValues,
+  childValues,
+  animated,
+}: {
+  parentValues: number[];
+  childValues: number[];
+  animated: boolean;
+}) {
+  const cx = 150;
+  const cy = 150;
+  const maxR = 110;
+
+  return (
+    <svg viewBox="0 0 300 300" className="w-full max-w-[320px] mx-auto">
+      {/* Grid rings */}
+      {[0.25, 0.5, 0.75, 1].map((s) => (
+        <polygon
+          key={s}
+          points={RADAR_CATEGORIES.map((c) => {
+            const { x, y } = polarToCartesian(c.angle, s * maxR, cx, cy);
+            return `${x},${y}`;
+          }).join(" ")}
+          fill="none"
+          className="stroke-border-card"
+          strokeWidth={0.5}
+        />
+      ))}
+
+      {/* Axis lines */}
+      {RADAR_CATEGORIES.map((c) => {
+        const { x, y } = polarToCartesian(c.angle, maxR, cx, cy);
+        return (
+          <line
+            key={c.label}
+            x1={cx}
+            y1={cy}
+            x2={x}
+            y2={y}
+            className="stroke-border-card"
+            strokeWidth={0.5}
+          />
+        );
+      })}
+
+      {/* Parent shape */}
+      <path
+        d={radarPath(parentValues, maxR, cx, cy)}
+        className="fill-foreground/5 stroke-foreground"
+        strokeWidth={1.5}
+        style={{
+          transition: animated ? "d 0.8s ease-out" : "none",
+        }}
+      />
+
+      {/* Child shape */}
+      <path
+        d={radarPath(childValues, maxR, cx, cy)}
+        className="fill-muted-foreground/8 stroke-muted-foreground"
+        strokeWidth={1.5}
+        strokeDasharray="4 3"
+        style={{
+          transition: animated ? "d 0.8s ease-out" : "none",
+        }}
+      />
+
+      {/* Labels */}
+      {RADAR_CATEGORIES.map((c) => {
+        const { x, y } = polarToCartesian(c.angle, maxR + 18, cx, cy);
+        return (
+          <text
+            key={c.label}
+            x={x}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="central"
+            className="fill-muted-foreground text-[10px] font-mono"
+          >
+            {c.label}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}
+
+function FingerprintSection() {
+  const [animated, setAnimated] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const trigger = ScrollTrigger.create({
+      trigger: el,
+      start: "top 75%",
+      once: true,
+      onEnter: () => setAnimated(true),
+    });
+
+    return () => trigger.kill();
+  }, []);
+
+  const parent = [0.85, 0.7, 0.8, 0.65, 0.75];
+  const child = animated ? [0.78, 0.6, 0.75, 0.5, 0.7] : parent;
+
+  return (
+    <div ref={ref} className="reveal">
+      <div className="grid md:grid-cols-2 gap-8 items-center">
+        <RadarChart
+          parentValues={parent}
+          childValues={child}
+          animated={animated}
+        />
+        <div>
+          <div className="space-y-3">
+            {RADAR_CATEGORIES.map((c, i) => {
+              const delta = Math.abs(
+                parent[i] - (animated ? child[1] : parent[i]),
+              );
+              return (
+                <div key={c.label} className="flex items-center gap-3">
+                  <span className="text-sm font-mono w-28 text-muted-foreground">
+                    {c.label}
+                  </span>
+                  <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-foreground transition-all duration-1000"
+                      style={{
+                        width: `${(animated ? [0.78, 0.6, 0.75, 0.5, 0.7][i] : parent[i]) * 100}%`,
+                      }}
+                    />
+                  </div>
+                  {animated && (
+                    <span className="text-xs font-mono text-muted-foreground w-8 text-right">
+                      {Math.round([0.78, 0.6, 0.75, 0.5, 0.7][i] * 100)}%
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <p className="mt-6 text-sm text-muted-foreground leading-relaxed">
+            <span className="inline-block w-3 h-0.5 bg-foreground mr-2 translate-y-[-2px]" />
+            Parent&nbsp;&nbsp;
+            <span className="inline-block w-3 h-0.5 bg-muted-foreground mr-2 translate-y-[-2px] border-t border-dashed border-muted-foreground" />
+            Your system
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────── 3. The Scan — Three lenses ─────────────────────── */
+
+type ScanLens = "values" | "structure" | "visual";
+
+const SCAN_LENSES: {
+  id: ScanLens;
+  name: string;
+  what: string;
+  catches: string;
+  visual: React.ReactNode;
+}[] = [
+  {
+    id: "values",
+    name: "Values",
+    what: "Compares design tokens against the parent registry.",
+    catches:
+      "Hardcoded colors, overridden tokens, missing tokens — the invisible constants that quietly diverge.",
+    visual: (
+      <div className="space-y-2 font-mono text-xs">
+        <div className="flex items-center gap-2">
+          <span className="w-4 h-4 rounded bg-foreground border border-border-card" />
+          <span className="text-muted-foreground">
+            --primary:{" "}
+            <span className="line-through opacity-50">oklch(0.7 0.15 250)</span>
+          </span>
+          <span className="text-foreground">oklch(0.65 0.12 245)</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="w-4 h-4 rounded bg-red-200 border border-border-card" />
+          <span className="text-red-400">
+            #ef4444 ← hardcoded, should be a token
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="w-4 h-4 rounded border border-dashed border-muted-foreground" />
+          <span className="text-muted-foreground">
+            --accent: <span className="italic">missing</span>
+          </span>
+        </div>
+      </div>
+    ),
+  },
+  {
+    id: "structure",
+    name: "Structure",
+    what: "Diffs component files between your code and the parent.",
+    catches:
+      "Added props, removed variants, altered APIs — changes to what components can do.",
+    visual: (
+      <div className="font-mono text-xs space-y-1">
+        <div className="text-muted-foreground">Button.tsx</div>
+        <div className="pl-3 border-l-2 border-green-400/50 text-green-400/80">
+          + variant: "ghost" | "outline" |{" "}
+          <span className="font-bold">"brand"</span>
+        </div>
+        <div className="pl-3 border-l-2 border-muted-foreground/30 text-muted-foreground/50">
+          &nbsp; size: "sm" | "md" | "lg"
+        </div>
+        <div className="pl-3 border-l-2 border-red-400/50 text-red-400/80">
+          - loading?: boolean
+        </div>
+      </div>
+    ),
+  },
+  {
+    id: "visual",
+    name: "Visual",
+    what: "Renders components and performs pixel-level comparison.",
+    catches:
+      "Subtle rendering differences from CSS specificity, font rendering, or layout shifts — things code diffs miss.",
+    visual: (
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-20 rounded-lg bg-muted/50 border border-border-card flex items-center justify-center text-xs text-muted-foreground">
+          Expected
+        </div>
+        <div className="text-muted-foreground text-lg">→</div>
+        <div className="flex-1 h-20 rounded-lg bg-muted/50 border border-border-card flex items-center justify-center relative overflow-hidden">
+          <span className="text-xs text-muted-foreground">Actual</span>
+          <div className="absolute inset-0 bg-red-400/10 mix-blend-multiply" />
+          <div className="absolute top-3 right-4 w-8 h-3 rounded bg-red-400/30" />
+        </div>
+      </div>
+    ),
+  },
+];
+
+function ScanSection() {
+  const [active, setActive] = useState<ScanLens>("values");
+  const lens = SCAN_LENSES.find((l) => l.id === active)!;
+
+  return (
+    <div className="reveal">
+      {/* Tab bar */}
+      <div className="flex gap-1 rounded-full bg-muted/50 border border-border-card p-1 w-fit mb-8">
+        {SCAN_LENSES.map((l) => (
+          <button
+            key={l.id}
+            type="button"
+            onClick={() => setActive(l.id)}
+            className={cn(
+              "px-4 py-1.5 rounded-full text-sm font-medium transition-all duration-200 cursor-pointer",
+              active === l.id
+                ? "bg-foreground text-background shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {l.name}
+          </button>
+        ))}
+      </div>
+
+      {/* Content card */}
+      <div className="rounded-[var(--radius-card-sm)] border border-border-card bg-card p-6 md:p-8">
+        <div className="grid md:grid-cols-2 gap-8">
+          <div>
+            <h4 className="font-display font-semibold text-foreground mb-2">
+              {lens.name} scan
+            </h4>
+            <p className="text-sm text-muted-foreground leading-relaxed mb-3">
+              {lens.what}
+            </p>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              <span className="font-semibold text-foreground">Catches: </span>
+              {lens.catches}
+            </p>
+          </div>
+          <div className="rounded-lg bg-muted/30 border border-border-card p-4">
+            {lens.visual}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────── 4. The Conversation — Stances ──────────────────────── */
+
+function StanceBubble({
+  symbol,
+  label,
+  speaker,
+  message,
+  align,
+}: {
+  symbol: string;
+  label: string;
+  speaker: string;
+  message: string;
+  align: "left" | "right";
+}) {
+  return (
+    <div
+      className={cn(
+        "reveal flex gap-4 max-w-lg",
+        align === "right" && "ml-auto flex-row-reverse",
+      )}
+    >
+      <div className="flex-shrink-0 w-10 h-10 rounded-full border border-border-card bg-card flex items-center justify-center font-mono text-lg">
+        {symbol}
+      </div>
+      <div
+        className={cn(
+          "rounded-[var(--radius-card-sm)] border border-border-card bg-card px-5 py-4",
+          align === "right" && "text-right",
+        )}
+      >
+        <div className="flex items-center gap-2 mb-1">
+          <span className="font-display font-semibold text-sm">{label}</span>
+          <span className="text-xs text-muted-foreground font-mono">
+            {speaker}
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {message}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────── 5. The Fleet — Constellation ────────────────────── */
+
+function ConstellationDot({
+  x,
+  y,
+  label,
+  size,
+}: {
+  x: number;
+  y: number;
+  label: string;
+  size: number;
+}) {
+  return (
+    <g>
+      <circle cx={x} cy={y} r={size} className="fill-foreground/80" />
+      <circle
+        cx={x}
+        cy={y}
+        r={size + 6}
+        className="fill-foreground/5 stroke-foreground/20"
+        strokeWidth={0.5}
+      />
+      <text
+        x={x}
+        y={y + size + 16}
+        textAnchor="middle"
+        className="fill-muted-foreground text-[10px] font-mono"
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+
+function FleetConstellation() {
+  const systems = [
+    { x: 100, y: 90, label: "Core", size: 7 },
+    { x: 135, y: 110, label: "Marketing", size: 5 },
+    { x: 115, y: 135, label: "Mobile", size: 5 },
+    { x: 230, y: 160, label: "Legacy", size: 4 },
+    { x: 250, y: 100, label: "Checkout", size: 5 },
+  ];
+
+  // Draw lines between close systems
+  const connections: [number, number][] = [
+    [0, 1],
+    [0, 2],
+    [1, 2],
+    [3, 4],
+  ];
+
+  return (
+    <svg viewBox="0 0 340 220" className="w-full max-w-[440px] mx-auto">
+      {/* Connections */}
+      {connections.map(([a, b]) => (
+        <line
+          key={`${a}-${b}`}
+          x1={systems[a].x}
+          y1={systems[a].y}
+          x2={systems[b].x}
+          y2={systems[b].y}
+          className="stroke-border-card"
+          strokeWidth={0.75}
+          strokeDasharray="3 3"
+        />
+      ))}
+
+      {/* Cluster labels */}
+      <text
+        x={116}
+        y={62}
+        textAnchor="middle"
+        className="fill-muted-foreground/50 text-[9px] font-mono uppercase"
+      >
+        Cluster A
+      </text>
+      <text
+        x={240}
+        y={80}
+        textAnchor="middle"
+        className="fill-muted-foreground/50 text-[9px] font-mono uppercase"
+      >
+        Cluster B
+      </text>
+
+      {/* Systems */}
+      {systems.map((s) => (
+        <ConstellationDot key={s.label} {...s} />
+      ))}
+    </svg>
+  );
+}
+
+/* ═══════════════════════════ Main page ════════════════════════════════ */
 
 export default function ConceptsPage() {
   return (
-    <DocsPageLayout>
+    <SectionWrapper>
       <AnimatedPageHeader
-        kicker="Docs"
-        title="Core Concepts"
-        description="The ideas behind Ghost — fingerprints, drift detection, evolution tracking, and fleet observability."
+        kicker="Concepts"
+        title="How Ghost Works"
+        description="Design systems drift silently. Ghost gives you the language — and the tools — to see it, measure it, and decide what to do about it."
       />
 
-      <DocProse>
-        <DocSection title="Design Fingerprints">
-          <p>
-            A fingerprint is a <strong>64-dimensional numeric vector</strong>{" "}
-            that captures the identity of a design system. Ghost extracts this
-            deterministically from a shadcn-compatible registry, or optionally
-            via LLM interpretation of raw CSS and component files.
-          </p>
-          <p>The 64 dimensions are grouped into five categories:</p>
-          <table>
-            <thead>
-              <tr>
-                <th>Dimensions</th>
-                <th>Category</th>
-                <th>What it captures</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>0 &ndash; 20</td>
-                <td>
-                  <strong>Palette</strong>
-                </td>
-                <td>
-                  Dominant colors (OKLCH), neutral ramp, semantic color
-                  coverage, saturation profile, contrast level
-                </td>
-              </tr>
-              <tr>
-                <td>21 &ndash; 30</td>
-                <td>
-                  <strong>Spacing</strong>
-                </td>
-                <td>
-                  Scale values, regularity score, base unit detection,
-                  distribution pattern
-                </td>
-              </tr>
-              <tr>
-                <td>31 &ndash; 40</td>
-                <td>
-                  <strong>Typography</strong>
-                </td>
-                <td>
-                  Font families, size ramp, weight distribution, line height
-                  pattern
-                </td>
-              </tr>
-              <tr>
-                <td>41 &ndash; 48</td>
-                <td>
-                  <strong>Surfaces</strong>
-                </td>
-                <td>Border radii, shadow complexity, border usage frequency</td>
-              </tr>
-              <tr>
-                <td>49 &ndash; 63</td>
-                <td>
-                  <strong>Architecture</strong>
-                </td>
-                <td>
-                  Tokenization ratio, methodology (BEM, CSS-in-JS, etc.),
-                  component count, naming patterns
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <p>
-            Fingerprints are compared using a <strong>weighted distance</strong>{" "}
-            metric: palette contributes 30%, spacing and typography 20% each,
-            surfaces 15%, and architecture 15%. This weighting reflects how
-            strongly each dimension affects the perceived identity of a design
-            system.
-          </p>
-        </DocSection>
+      {/* ── Chapter 1: The Problem ──────────────────────────────────── */}
+      <Chapter className="border-t border-border/40">
+        <ChapterLabel>Chapter 1</ChapterLabel>
+        <ChapterTitle>The Problem</ChapterTitle>
+        <ChapterLead>
+          Design systems don't break loudly. They erode — a color changed here,
+          a radius tweaked there. Six months later, your "shared" system is
+          three different systems wearing the same name.
+        </ChapterLead>
+        <DriftSpotlight />
+        <p className="reveal mt-8 text-sm text-muted-foreground max-w-[52ch] leading-relaxed">
+          This is <strong className="text-foreground">drift</strong>. It's the
+          gap between what your design system says and what your apps actually
+          render. Ghost exists to make that gap visible.
+        </p>
+      </Chapter>
 
-        <DocSection title="Drift Detection">
-          <p>
-            Drift is what happens when a consumer design system diverges from
-            its parent. Ghost detects drift through three complementary scan
-            modes:
-          </p>
+      {/* ── Chapter 2: The Fingerprint ────────────────────────────── */}
+      <Chapter className="border-t border-border/40">
+        <ChapterLabel>Chapter 2</ChapterLabel>
+        <ChapterTitle>The Fingerprint</ChapterTitle>
+        <ChapterLead>
+          Ghost reads your design system and turns it into a shape — a
+          64-dimensional numeric vector we call a fingerprint. Similar systems
+          make similar shapes. Different ones don't.
+        </ChapterLead>
+        <FingerprintSection />
+        <div className="reveal mt-10 grid sm:grid-cols-5 gap-4">
+          {[
+            { cat: "Palette", pct: "30%", desc: "Colors, neutrals, contrast" },
+            { cat: "Spacing", pct: "20%", desc: "Scale, rhythm, base unit" },
+            { cat: "Typography", pct: "20%", desc: "Families, sizes, weights" },
+            { cat: "Surfaces", pct: "15%", desc: "Radii, shadows, borders" },
+            { cat: "Architecture", pct: "15%", desc: "Tokens, methodology" },
+          ].map((c) => (
+            <div
+              key={c.cat}
+              className="group rounded-lg border border-border-card hover:border-foreground/25 bg-card p-4 text-center transition-colors duration-300"
+            >
+              <div className="font-mono text-lg font-bold text-foreground">
+                {c.pct}
+              </div>
+              <div className="relative inline-block font-display text-sm font-semibold mt-1">
+                <span className="relative z-10 transition-colors duration-300 group-hover:text-background">
+                  {c.cat}
+                </span>
+                <span className="absolute inset-0 bg-foreground origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out" />
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">{c.desc}</div>
+            </div>
+          ))}
+        </div>
+        <p className="reveal mt-6 text-sm text-muted-foreground max-w-[52ch] leading-relaxed">
+          These weights reflect visual impact — palette matters most because
+          color is the first thing people notice. When comparing two
+          fingerprints, Ghost uses these weights to compute a single distance
+          score.
+        </p>
+      </Chapter>
 
-          <h3>Values Scan</h3>
-          <p>
-            Parses your CSS and compares design tokens against the parent
-            registry. Detects three kinds of issues:
-          </p>
-          <ul>
-            <li>
-              <strong>Hardcoded colors</strong> &mdash; raw hex/rgb values that
-              should be tokens
-            </li>
-            <li>
-              <strong>Token overrides</strong> &mdash; tokens whose values
-              differ from the parent
-            </li>
-            <li>
-              <strong>Missing tokens</strong> &mdash; tokens the parent defines
-              that you don&rsquo;t have
-            </li>
-          </ul>
+      {/* ── Chapter 3: The Scan ───────────────────────────────────── */}
+      <Chapter className="border-t border-border/40">
+        <ChapterLabel>Chapter 3</ChapterLabel>
+        <ChapterTitle>The Scan</ChapterTitle>
+        <ChapterLead>
+          Once Ghost knows what your system looks like, it can check for drift.
+          Three complementary scans — like three different lenses on the same
+          microscope — each catch different kinds of divergence.
+        </ChapterLead>
+        <ScanSection />
+        <p className="reveal mt-8 text-sm text-muted-foreground max-w-[52ch] leading-relaxed">
+          Run all three with{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+            ghost scan
+          </code>{" "}
+          or pick one with{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+            ghost scan --values
+          </code>
+          . Each scan produces a structured report you can pipe into CI.
+        </p>
+      </Chapter>
 
-          <h3>Structure Scan</h3>
-          <p>
-            Diffs component files between your implementation and the parent
-            registry. Changes are classified as:
-          </p>
-          <ul>
-            <li>
-              <strong>Cosmetic</strong> &mdash; formatting, whitespace,
-              non-functional
-            </li>
-            <li>
-              <strong>Additive</strong> &mdash; new props, variants, or features
-              added on top
-            </li>
-            <li>
-              <strong>Breaking</strong> &mdash; removed or altered behaviour
-              that diverges from the parent API
-            </li>
-          </ul>
+      {/* ── Chapter 4: The Conversation ───────────────────────────── */}
+      <Chapter className="border-t border-border/40">
+        <ChapterLabel>Chapter 4</ChapterLabel>
+        <ChapterTitle>The Conversation</ChapterTitle>
+        <ChapterLead>
+          Not all drift is bad. Sometimes you changed that color on purpose.
+          Ghost tracks your intent through stances — a way to say "yes, I know,
+          and here's why."
+        </ChapterLead>
+        <div className="space-y-4">
+          <StanceBubble
+            symbol="="
+            label="Aligned"
+            speaker="ghost ack --aligned"
+            message="We're tracking the parent. If this drifted, it's a bug — fix it."
+            align="left"
+          />
+          <StanceBubble
+            symbol="*"
+            label="Accepted"
+            speaker="ghost ack --accepted"
+            message="We know this is different. We've reviewed it. It's a known trade-off, not an oversight."
+            align="right"
+          />
+          <StanceBubble
+            symbol="~"
+            label="Diverging"
+            speaker="ghost diverge"
+            message="This is ours now. We own it. Stop measuring it against the parent."
+            align="left"
+          />
+        </div>
+        <p className="reveal mt-10 text-sm text-muted-foreground max-w-[52ch] leading-relaxed">
+          Stances are stored per-dimension in{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+            .ghost-sync.json
+          </code>
+          , with optional reasoning. Over time, Ghost tracks whether you're
+          converging toward your parent, diverging away, staying stable, or
+          oscillating.
+        </p>
+      </Chapter>
 
-          <h3>Visual Scan</h3>
-          <p>
-            Renders components using Playwright and performs pixel-level
-            comparison with pixelmatch. This catches drift that token and
-            structure scans miss — subtle rendering differences from CSS
-            specificity, font rendering, or layout shifts. Requires Playwright
-            to be installed.
-          </p>
-        </DocSection>
+      {/* ── Chapter 5: The Fleet ──────────────────────────────────── */}
+      <Chapter className="border-t border-border/40">
+        <ChapterLabel>Chapter 5</ChapterLabel>
+        <ChapterTitle>The Fleet</ChapterTitle>
+        <ChapterLead>
+          When your org has multiple design systems — a core plus product forks
+          — Ghost zooms out. It shows you who's a twin, who's the outlier, and
+          how the whole family is evolving.
+        </ChapterLead>
+        <div className="reveal rounded-[var(--radius-card-sm)] border border-border-card bg-card p-6 md:p-8">
+          <FleetConstellation />
+          <div className="grid sm:grid-cols-3 gap-4 mt-6 pt-6 border-t border-border-card">
+            <div className="text-center">
+              <div className="font-mono text-sm font-bold text-foreground">
+                Pairwise distance
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                How far apart every pair of systems is
+              </p>
+            </div>
+            <div className="text-center">
+              <div className="font-mono text-sm font-bold text-foreground">
+                Clustering
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                Natural families that emerge from similarity
+              </p>
+            </div>
+            <div className="text-center">
+              <div className="font-mono text-sm font-bold text-foreground">
+                3D projection
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                PCA down to three axes, rendered in Three.js
+              </p>
+            </div>
+          </div>
+        </div>
+        <p className="reveal mt-8 text-sm text-muted-foreground max-w-[52ch] leading-relaxed">
+          Run{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+            ghost fleet
+          </code>{" "}
+          with multiple registries to see the full picture, or{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+            ghost viz
+          </code>{" "}
+          to explore it interactively in 3D.
+        </p>
+      </Chapter>
 
-        <DocSection title="Evolution Tracking">
-          <p>
-            Not all drift is bad. Ghost distinguishes between{" "}
-            <strong>accidental drift</strong> (bugs, oversight) and{" "}
-            <strong>intentional divergence</strong> (brand requirements, product
-            needs). The evolution system tracks this through{" "}
-            <strong>stances</strong>:
-          </p>
-          <table>
-            <thead>
-              <tr>
-                <th>Stance</th>
-                <th>Symbol</th>
-                <th>Meaning</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Aligned</strong>
-                </td>
-                <td>
-                  <code>=</code>
-                </td>
-                <td>
-                  Tracking the parent. Any drift in this dimension is
-                  unintentional and should be fixed.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Accepted</strong>
-                </td>
-                <td>
-                  <code>*</code>
-                </td>
-                <td>
-                  Known divergence that has been reviewed and acknowledged. Not
-                  ideal, but understood.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Diverging</strong>
-                </td>
-                <td>
-                  <code>~</code>
-                </td>
-                <td>
-                  Intentionally different. This dimension is owned locally and
-                  should not be measured against the parent.
-                </td>
-              </tr>
-            </tbody>
-          </table>
+      {/* ── Closing ───────────────────────────────────────────────── */}
+      <Chapter className="border-t border-border/40">
+        <ChapterLabel>That's Ghost</ChapterLabel>
+        <ChapterTitle>Fingerprint. Scan. Decide. Repeat.</ChapterTitle>
+        <ChapterLead>
+          Ghost doesn't tell you what to do — it gives you the information to
+          decide. Align, accept, or diverge. The choice is yours. The visibility
+          is Ghost's job.
+        </ChapterLead>
+        <div className="reveal grid sm:grid-cols-4 gap-4">
+          {[
+            {
+              file: "ghost.config.ts",
+              desc: "How to detect drift",
+            },
+            {
+              file: ".ghost-fingerprint.json",
+              desc: "What the system looks like",
+            },
+            {
+              file: ".ghost-sync.json",
+              desc: "How you intend to diverge",
+            },
+            {
+              file: ".ghost/history.jsonl",
+              desc: "How the system evolved",
+            },
+          ].map((a) => (
+            <div
+              key={a.file}
+              className="group rounded-lg border border-border-card hover:border-foreground/25 bg-card p-4 transition-colors duration-300"
+            >
+              <span className="relative inline-block">
+                <code className="relative z-10 text-xs font-mono font-semibold transition-colors duration-300 group-hover:text-background">
+                  {a.file}
+                </code>
+                <span className="absolute inset-0 bg-foreground origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out" />
+              </span>
+              <p className="text-xs text-muted-foreground mt-2">{a.desc}</p>
+            </div>
+          ))}
+        </div>
+      </Chapter>
 
-          <p>
-            Stances are stored in <code>.ghost-sync.json</code> per dimension,
-            with optional reasoning. Use{" "}
-            <Link to="/docs/cli" className="font-semibold">
-              <code>ghost ack</code>
-            </Link>{" "}
-            to record a stance and <code>ghost diverge</code> as a shorthand for
-            marking intentional splits.
-          </p>
-
-          <h3>History &amp; Temporal Analysis</h3>
-          <p>
-            Every time you generate a fingerprint, Ghost appends an entry to{" "}
-            <code>.ghost/history.jsonl</code> — an append-only log of your
-            design system&rsquo;s evolution over time. When comparing
-            fingerprints with <code>--temporal</code>, Ghost computes:
-          </p>
-          <ul>
-            <li>
-              <strong>Drift velocity</strong> &mdash; how fast each dimension is
-              changing per time period
-            </li>
-            <li>
-              <strong>Trajectory</strong> &mdash; whether the system is{" "}
-              <em>converging</em> toward the parent, <em>diverging</em> away,{" "}
-              <em>stable</em>, or <em>oscillating</em>
-            </li>
-            <li>
-              <strong>Exceeded bounds</strong> &mdash; dimensions that have
-              drifted beyond the tolerance threshold (default: 0.05)
-            </li>
-          </ul>
-        </DocSection>
-
-        <DocSection title="Fleet Observability">
-          <p>
-            When your organisation has multiple design systems (a core system
-            plus product-specific forks), Ghost provides{" "}
-            <strong>fleet-level analysis</strong>:
-          </p>
-          <ul>
-            <li>
-              <strong>Pairwise distances</strong> &mdash; how far apart every
-              pair of systems is across all dimensions
-            </li>
-            <li>
-              <strong>Centroid</strong> &mdash; the average position of all
-              systems in the 64-dimensional space
-            </li>
-            <li>
-              <strong>Clustering</strong> &mdash; k-means grouping to identify
-              natural families of design systems
-            </li>
-            <li>
-              <strong>3D visualization</strong> &mdash; <code>ghost viz</code>{" "}
-              projects fingerprints into 3D via PCA for an interactive Three.js
-              view
-            </li>
-          </ul>
-        </DocSection>
-
-        <DocSection title="Artifacts">
-          <p>Ghost produces and consumes several file artifacts:</p>
-          <table>
-            <thead>
-              <tr>
-                <th>File</th>
-                <th>Purpose</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  <code>ghost.config.ts</code>
-                </td>
-                <td>
-                  Project configuration — design systems, scan settings, rules
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <code>.ghost-fingerprint.json</code>
-                </td>
-                <td>
-                  Publishable fingerprint artifact (created with{" "}
-                  <code>--emit</code>)
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <code>.ghost-sync.json</code>
-                </td>
-                <td>
-                  Per-dimension stances and reasoning for evolution tracking
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <code>.ghost/history.jsonl</code>
-                </td>
-                <td>Append-only fingerprint history for temporal analysis</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <hr />
-
-          <p>
-            Ready to try it?{" "}
-            <Link to="/docs/getting-started" className="font-semibold">
-              Getting Started
-            </Link>{" "}
-            walks through setup step by step. See the{" "}
-            <Link to="/docs/cli" className="font-semibold">
-              CLI Reference
-            </Link>{" "}
-            for every command and flag.
-          </p>
-        </DocSection>
-      </DocProse>
-    </DocsPageLayout>
+      {/* bottom spacer for dock */}
+      <div className="h-24" />
+    </SectionWrapper>
   );
 }

--- a/packages/ghost-ui/src/app/docs/page.tsx
+++ b/packages/ghost-ui/src/app/docs/page.tsx
@@ -14,6 +14,15 @@ import { AnimatedPageHeader } from "@/components/docs/animated-page-header";
 import { SectionWrapper } from "@/components/docs/wrappers";
 import { useStaggerReveal } from "@/hooks/use-scroll-reveal";
 
+const hero = {
+  name: "Core Concepts",
+  href: "/docs/concepts",
+  description:
+    "Fingerprints, drift detection, evolution tracking, and fleet observability — the ideas behind Ghost.",
+  hook: "Start here",
+  icon: <Fingerprint className="size-8" strokeWidth={1.5} />,
+};
+
 const sections: {
   name: string;
   href: string;
@@ -26,13 +35,6 @@ const sections: {
     description:
       "Install Ghost, create your first config, and run your first drift scan in under five minutes.",
     icon: <Rocket className="size-8" strokeWidth={1.5} />,
-  },
-  {
-    name: "Core Concepts",
-    href: "/docs/concepts",
-    description:
-      "Fingerprints, drift detection, evolution tracking, and fleet observability — the ideas behind Ghost.",
-    icon: <Fingerprint className="size-8" strokeWidth={1.5} />,
   },
   {
     name: "CLI Reference",
@@ -79,27 +81,57 @@ export default function DocsIndex() {
         description="Autonomous design drift detection for decentralised design ecosystems. Ghost fingerprints design systems, tracks their evolution, and surfaces divergence before it compounds."
       />
 
-      <div
-        ref={ref}
-        className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 pb-16 overflow-visible"
-      >
-        {sections.map((item) => (
-          <Link
-            key={item.href}
-            to={item.href}
-            className="doc-card group rounded-[var(--radius-card-sm)] border border-border-card bg-card p-10 transition-all duration-200 hover:scale-[1.03] hover:shadow-elevated"
-          >
-            <div className="mb-6 text-muted-foreground group-hover:text-foreground transition-colors duration-200">
-              {item.icon}
-            </div>
-            <span className="font-display text-lg font-bold tracking-tight">
-              {item.name}
+      <div ref={ref} className="pb-16 overflow-visible space-y-4">
+        {/* Hero card — full-width */}
+        <Link
+          to={hero.href}
+          className="doc-card group relative rounded-[var(--radius-card)] border border-border-card bg-card p-10 md:p-12 flex flex-col md:flex-row md:items-center gap-6 transition-all duration-200 hover:scale-[1.01] hover:shadow-elevated overflow-hidden"
+        >
+          <div className="flex-1">
+            <span
+              className="font-display uppercase text-muted-foreground"
+              style={{
+                fontSize: "var(--label-font-size)",
+                letterSpacing: "var(--label-letter-spacing)",
+              }}
+            >
+              {hero.hook}
             </span>
-            <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
-              {item.description}
+            <h3
+              className="font-display font-black tracking-[-0.04em] leading-[0.92] mt-2"
+              style={{ fontSize: "var(--heading-card-font-size)" }}
+            >
+              {hero.name}
+            </h3>
+            <p className="mt-3 max-w-[48ch] text-muted-foreground leading-relaxed">
+              {hero.description}
             </p>
-          </Link>
-        ))}
+          </div>
+          <div className="text-muted-foreground group-hover:text-foreground transition-colors duration-200 md:mr-4">
+            <Fingerprint className="size-16 md:size-20" strokeWidth={0.75} />
+          </div>
+        </Link>
+
+        {/* Rest of the grid */}
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {sections.map((item) => (
+            <Link
+              key={item.href}
+              to={item.href}
+              className="doc-card group rounded-[var(--radius-card-sm)] border border-border-card bg-card p-10 transition-all duration-200 hover:scale-[1.03] hover:shadow-elevated"
+            >
+              <div className="mb-6 text-muted-foreground group-hover:text-foreground transition-colors duration-200">
+                {item.icon}
+              </div>
+              <span className="font-display text-lg font-bold tracking-tight">
+                {item.name}
+              </span>
+              <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+                {item.description}
+              </p>
+            </Link>
+          ))}
+        </div>
       </div>
     </SectionWrapper>
   );

--- a/packages/ghost-ui/src/app/docs/page.tsx
+++ b/packages/ghost-ui/src/app/docs/page.tsx
@@ -85,7 +85,7 @@ export default function DocsIndex() {
         {/* Hero card — full-width */}
         <Link
           to={hero.href}
-          className="doc-card group relative rounded-[var(--radius-card)] border border-border-card bg-card p-10 md:p-12 flex flex-col md:flex-row md:items-center gap-6 transition-all duration-200 hover:scale-[1.01] hover:shadow-elevated overflow-hidden"
+          className="doc-card group relative rounded-[var(--radius-card)] border border-border-card hover:border-foreground/25 bg-card p-10 md:p-12 flex flex-col md:flex-row md:items-center gap-6 transition-colors duration-300 overflow-hidden"
         >
           <div className="flex-1">
             <span
@@ -101,7 +101,12 @@ export default function DocsIndex() {
               className="font-display font-black tracking-[-0.04em] leading-[0.92] mt-2"
               style={{ fontSize: "var(--heading-card-font-size)" }}
             >
-              {hero.name}
+              <span className="relative inline-block">
+                <span className="relative z-10 transition-colors duration-300 group-hover:text-background">
+                  {hero.name}
+                </span>
+                <span className="absolute inset-0 bg-foreground origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out" />
+              </span>
             </h3>
             <p className="mt-3 max-w-[48ch] text-muted-foreground leading-relaxed">
               {hero.description}
@@ -118,13 +123,16 @@ export default function DocsIndex() {
             <Link
               key={item.href}
               to={item.href}
-              className="doc-card group rounded-[var(--radius-card-sm)] border border-border-card bg-card p-10 transition-all duration-200 hover:scale-[1.03] hover:shadow-elevated"
+              className="doc-card group rounded-[var(--radius-card-sm)] border border-border-card hover:border-foreground/25 bg-card p-10 transition-colors duration-300"
             >
               <div className="mb-6 text-muted-foreground group-hover:text-foreground transition-colors duration-200">
                 {item.icon}
               </div>
-              <span className="font-display text-lg font-bold tracking-tight">
-                {item.name}
+              <span className="relative inline-block font-display text-lg font-bold tracking-tight">
+                <span className="relative z-10 transition-colors duration-300 group-hover:text-background">
+                  {item.name}
+                </span>
+                <span className="absolute inset-0 bg-foreground origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out" />
               </span>
               <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
                 {item.description}

--- a/packages/ghost-ui/src/components/docs/cycloid-canvas.tsx
+++ b/packages/ghost-ui/src/components/docs/cycloid-canvas.tsx
@@ -5,25 +5,28 @@ import { useEffect, useRef } from "react";
 const MAX_POINTS = 2000;
 const BASE_OPACITY = 0.15;
 const FADE_SEGMENTS = 32;
-const ANGLE_PER_MS = 0.0008; // fixed speed regardless of frame rate
+const ANGLE_PER_MS = 0.0012; // fixed speed regardless of frame rate
 const TRANSITION_MS = 800; // duration of lerp between shapes
 
-// Each entry: [r value, angle for one full closed shape]
-const RATIO_TABLE: [number, number][] = [
-  [0.2, 2 * Math.PI], // 4 petals
-  [0.25, 2 * Math.PI], // 3 petals
-  [0.3, 6 * Math.PI], // 7 petals over 3 revs
-  [1 / 3, 2 * Math.PI], // 2 petals
-  [0.4, 4 * Math.PI], // 3 petals over 2 revs
-  [0.5, 2 * Math.PI], // 1 petal (ellipse-like)
+// Curated sequence: builds from simple → complex → resolves back
+// Each entry: [r, d, revolution angle]
+const SEQUENCE: [number, number, number][] = [
+  [0.5, 0.35, 6 * Math.PI], // 1 petal — gentle ellipse opener
+  [1 / 3, 0.25, 6 * Math.PI], // 2 petals — symmetric, tighter
+  [0.25, 0.2, 6 * Math.PI], // 3 petals — opening up
+  [0.2, 0.16, 6 * Math.PI], // 4 petals — building density
+  [0.3, 0.27, 6 * Math.PI], // 7 petals — peak complexity
+  [0.4, 0.32, 6 * Math.PI], // 3 petals — unwinding
+  [1 / 3, 0.15, 6 * Math.PI], // 2 petals tight — settling
+  [0.25, 0.22, 6 * Math.PI], // 3 petals — gentle resolve
 ];
 
+let seqIndex = 0;
+
 function pickShape() {
-  const entry = RATIO_TABLE[Math.floor(Math.random() * RATIO_TABLE.length)];
-  const r = entry[0];
-  const revolution = entry[1];
-  const d = r * (0.3 + Math.random() * 0.7);
-  return { r, d, revolution };
+  const entry = SEQUENCE[seqIndex];
+  seqIndex = (seqIndex + 1) % SEQUENCE.length;
+  return { r: entry[0], d: entry[1], revolution: entry[2] };
 }
 
 function resolveColor(): string {
@@ -186,10 +189,14 @@ export function CycloidCanvas() {
   }, []);
 
   return (
-    <canvas
-      ref={canvasRef}
-      className="pointer-events-none absolute inset-0 h-full w-full"
-      aria-hidden="true"
-    />
+    <div className="pointer-events-none absolute inset-0 h-full w-full">
+      <div className="absolute left-1/2 top-0 h-full w-px bg-[var(--foreground)] opacity-[0.08]" />
+      <div className="absolute top-1/2 left-0 w-full h-px bg-[var(--foreground)] opacity-[0.08]" />
+      <canvas
+        ref={canvasRef}
+        className="absolute inset-0 h-full w-full"
+        aria-hidden="true"
+      />
+    </div>
   );
 }

--- a/packages/ghost-ui/src/components/docs/cycloid-canvas.tsx
+++ b/packages/ghost-ui/src/components/docs/cycloid-canvas.tsx
@@ -6,19 +6,21 @@ const MAX_POINTS = 2000;
 const BASE_OPACITY = 0.15;
 const FADE_SEGMENTS = 32;
 const ANGLE_PER_MS = 0.0012; // fixed speed regardless of frame rate
-const TRANSITION_MS = 800; // duration of lerp between shapes
+
+const DEG5 = (5 * Math.PI) / 180; // 5° in radians
 
 // Curated sequence: builds from simple → complex → resolves back
 // Each entry: [r, d, revolution angle]
+// Revolutions stagger by 5° each for visual variety
 const SEQUENCE: [number, number, number][] = [
   [0.5, 0.35, 6 * Math.PI], // 1 petal — gentle ellipse opener
-  [1 / 3, 0.25, 6 * Math.PI], // 2 petals — symmetric, tighter
-  [0.25, 0.2, 6 * Math.PI], // 3 petals — opening up
-  [0.2, 0.16, 6 * Math.PI], // 4 petals — building density
-  [0.3, 0.27, 6 * Math.PI], // 7 petals — peak complexity
-  [0.4, 0.32, 6 * Math.PI], // 3 petals — unwinding
-  [1 / 3, 0.15, 6 * Math.PI], // 2 petals tight — settling
-  [0.25, 0.22, 6 * Math.PI], // 3 petals — gentle resolve
+  [1 / 3, 0.25, 6 * Math.PI + DEG5], // 2 petals — symmetric, tighter
+  [0.25, 0.2, 6 * Math.PI + DEG5 * 2], // 3 petals — opening up
+  [0.2, 0.16, 6 * Math.PI + DEG5 * 3], // 4 petals — building density
+  [0.3, 0.27, 6 * Math.PI + DEG5 * 4], // 7 petals — peak complexity
+  [0.4, 0.32, 6 * Math.PI + DEG5 * 5], // 3 petals — unwinding
+  [1 / 3, 0.15, 6 * Math.PI + DEG5 * 6], // 2 petals tight — settling
+  [0.25, 0.22, 6 * Math.PI + DEG5 * 7], // 3 petals — gentle resolve
 ];
 
 let seqIndex = 0;
@@ -45,11 +47,9 @@ export function CycloidCanvas() {
     if (!ctx) return;
 
     // --- State ---
-    let prevShape = pickShape();
-    let nextShape = prevShape;
+    let shape = pickShape();
     let angle = 0;
     let shapeStartAngle = 0;
-    let transitionElapsed = TRANSITION_MS; // start fully settled
 
     const xs = new Float32Array(MAX_POINTS);
     const ys = new Float32Array(MAX_POINTS);
@@ -96,27 +96,14 @@ export function CycloidCanvas() {
       const cssW = canvas.width / dpr;
       const cssH = canvas.height / dpr;
 
-      // Check if we completed a full shape — begin transition to next
-      const activeRevolution = nextShape.revolution;
-      if (
-        transitionElapsed >= TRANSITION_MS &&
-        angle - shapeStartAngle >= activeRevolution
-      ) {
-        prevShape = nextShape;
-        nextShape = pickShape();
+      // Check if we completed a full shape — snap to next
+      if (angle - shapeStartAngle >= shape.revolution) {
+        shape = pickShape();
         shapeStartAngle = angle;
-        transitionElapsed = 0;
       }
 
-      // Advance transition timer
-      transitionElapsed = Math.min(transitionElapsed + dt, TRANSITION_MS);
-
-      // Interpolate params: brief lerp at start of each shape, then locked
-      const t = Math.min(transitionElapsed / TRANSITION_MS, 1);
-      // Smooth ease-in-out
-      const ease = t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
-      const r = prevShape.r + (nextShape.r - prevShape.r) * ease;
-      const d = prevShape.d + (nextShape.d - prevShape.d) * ease;
+      const r = shape.r;
+      const d = shape.d;
 
       // Advance angle at fixed rate
       const deltaAngle = ANGLE_PER_MS * dt;

--- a/packages/ghost-ui/src/components/docs/hero.tsx
+++ b/packages/ghost-ui/src/components/docs/hero.tsx
@@ -79,8 +79,14 @@ export function Hero() {
             perspective: "600px",
           }}
         >
-          <span className="hero-line block">Ghost UI</span>
+          <span className="hero-line block">Ghost</span>
         </h1>
+        <p
+          className="mt-4 text-center text-muted-foreground leading-relaxed whitespace-nowrap"
+          style={{ fontSize: "clamp(0.875rem, 1.5vw, 1.125rem)" }}
+        >
+          Design drift detection for decentralized systems.
+        </p>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Each cycloid shape now draws for 3 full revolutions with a 5° linear offset per step for visual variety
- Removed parameter interpolation (r/d lerp) that caused chaotic intermediate shapes during transitions — trail buffer now handles smooth visual crossfade naturally
- Card hover replaced with border-darken and redacted title highlight

## Test plan
- [x] Verify cycloid animation draws 3 revolutions per shape
- [x] Confirm smooth transitions between shapes (no rapid circle-drawing artifacts)
- [x] Check animation renders correctly in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)