### PR TITLE
Fix CI: add missing postcss dependency

### DIFF
--- a/packages/ghost-ui/package.json
+++ b/packages/ghost-ui/package.json
@@ -92,6 +92,7 @@
     "@types/react": "19.1.2",
     "@types/react-dom": "19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "postcss": "^8.5.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "shadcn": "4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.4.1
         version: 4.7.0(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      postcss:
+        specifier: ^8.5.8
+        version: 8.5.8
       react:
         specifier: 19.1.0
         version: 19.1.0


### PR DESCRIPTION
## Summary
- `postcss` is imported by `scripts/build-base-vars.mjs` but was missing from `package.json`
- Resolved locally via pnpm hoisting but failed in CI with `ERR_MODULE_NOT_FOUND`
- Added `postcss` as a devDependency to `@ghost/ui`

## Test plan
- [x] `pnpm --filter @ghost/ui build:base` succeeds locally
- [x] CI `build:registry` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)