### PR TITLE
Fix CI: add missing jiti dependency

### DIFF
--- a/packages/ghost-ui/package.json
+++ b/packages/ghost-ui/package.json
@@ -92,6 +92,7 @@
     "@types/react": "19.1.2",
     "@types/react-dom": "19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "jiti": "^2.6.1",
     "postcss": "^8.5.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.4.1
         version: 4.7.0(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       postcss:
         specifier: ^8.5.8
         version: 8.5.8


### PR DESCRIPTION
## Summary
- `jiti` is imported by `scripts/build-presets.mjs` but was missing from `package.json`
- Same hoisting issue as postcss (fixed in #19) — resolves locally but fails in CI

## Test plan
- [x] `pnpm --filter @ghost/ui build:registry` succeeds locally
- [x] CI `build:registry` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)