### PR TITLE
Fix radar chart clipping Architecture label

### DIFF
--- a/packages/ghost-ui/src/app/docs/concepts/page.tsx
+++ b/packages/ghost-ui/src/app/docs/concepts/page.tsx
@@ -211,7 +211,7 @@ function RadarChart({
   const maxR = 110;
 
   return (
-    <svg viewBox="0 0 300 300" className="w-full max-w-[320px] mx-auto">
+    <svg viewBox="-20 0 340 300" className="w-full max-w-[320px] mx-auto">
       {/* Grid rings */}
       {[0.25, 0.5, 0.75, 1].map((s) => (
         <polygon


### PR DESCRIPTION
## Summary
- Widen SVG viewBox on the concepts page radar chart to prevent the "Architecture" label from being clipped on the left edge

## Test plan
- [ ] Verify the "Architecture" label is fully visible on the concepts page radar chart
- [ ] Confirm other labels remain correctly positioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)