### PR TITLE
Add dev-fonts.css for Cash Sans

### DIFF
--- a/packages/ghost-ui/src/styles/dev-fonts.css
+++ b/packages/ghost-ui/src/styles/dev-fonts.css
@@ -1,0 +1,30 @@
+/* ── Cash Sans (via block.xyz CDN) — dev site only ── */
+@font-face {
+  font-family: "Cash Sans";
+  src: url("https://cdn.block.xyz/fonts/cashsans/CashSans-Regular.woff2")
+    format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Cash Sans";
+  src: url("https://cdn.block.xyz/fonts/cashsans/CashSans-Medium.woff2")
+    format("woff2");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Cash Sans";
+  src: url("https://cdn.block.xyz/fonts/cashsans/CashSans-Bold.woff2")
+    format("woff2");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+:root {
+  --font-sans: "Cash Sans", system-ui, sans-serif;
+  --font-display: "Cash Sans", system-ui, sans-serif;
+}


### PR DESCRIPTION
## Summary

- Adds missing `dev-fonts.css` with Cash Sans `@font-face` declarations (CDN-loaded, dev site only)
- The import in `main.tsx` landed with #23 but the file itself was missed

## Test plan

- [x] Dev site loads with Cash Sans typeface applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)