### PR TITLE
fix: serve registry.json on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,6 +28,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build registry
         run: pnpm --filter @ghost/ui build:registry
+      - name: Copy registry.json to public for static serving
+        run: cp packages/ghost-ui/registry.json packages/ghost-ui/public/registry.json
       - name: Build Ghost UI
         run: pnpm --filter @ghost/ui build
         env:


### PR DESCRIPTION
## Problem

`registry.json` returns 404 at `https://block.github.io/ghost/registry.json`.

The `build:registry` step generates `registry.json` at the package root (`packages/ghost-ui/registry.json`), but Vite only copies files from `public/` into `dist/`. Without an explicit copy step, `registry.json` is never included in the Pages deployment artifact.

The individual component files (`public/r/*.json`) are served correctly because `shadcn build` outputs them directly into `public/r/`.

## Fix

Adds a `cp` step between `build:registry` and the Vite build so `registry.json` lands in `public/` and Vite picks it up automatically.

## Verification

- Reproduced locally: `VITE_BASE_PATH=/ghost/ pnpm --filter @ghost/ui build` → `dist/registry.json` is present after the copy step, absent without it.
- Confirmed the latest successful deploy (run `24144692488`, commit `8095a88`) does NOT include this step in the logs.
- Confirmed `curl -I https://block.github.io/ghost/registry.json` returns 404 today.

## Impact

Downstream consumers (e.g. `components.json` pointing at the ghost-ui registry) can use the canonical Pages URL instead of `raw.githubusercontent.com` workarounds.