### PR TITLE
Update hero tagline and unify card hover styles

### DIFF
--- a/packages/ghost-ui/src/app/foundations/page.tsx
+++ b/packages/ghost-ui/src/app/foundations/page.tsx
@@ -83,11 +83,14 @@ export default function FoundationsIndex() {
           <Link
             key={item.href}
             to={item.href}
-            className="foundation-card group rounded-[var(--radius-card-sm)] border border-border-card bg-card p-10 transition-all duration-200 hover:scale-[1.03] hover:shadow-elevated"
+            className="foundation-card group rounded-[var(--radius-card-sm)] border border-border-card hover:border-foreground/25 bg-card p-10 transition-colors duration-300"
           >
             <div className="mb-6">{item.visual}</div>
-            <span className="font-display text-lg font-bold tracking-tight">
-              {item.name}
+            <span className="relative inline-block font-display text-lg font-bold tracking-tight">
+              <span className="relative z-10 transition-colors duration-300 group-hover:text-background">
+                {item.name}
+              </span>
+              <span className="absolute inset-0 bg-foreground origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out" />
             </span>
             <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
               {item.description}

--- a/packages/ghost-ui/src/app/ui/page.tsx
+++ b/packages/ghost-ui/src/app/ui/page.tsx
@@ -111,11 +111,14 @@ export default function DesignLanguageIndex() {
           <Link
             key={item.href}
             to={item.href}
-            className="dl-card group rounded-[var(--radius-card-sm)] border border-border-card bg-card p-10 transition-all duration-200 hover:scale-[1.03] hover:shadow-elevated"
+            className="dl-card group rounded-[var(--radius-card-sm)] border border-border-card hover:border-foreground/25 bg-card p-10 transition-colors duration-300"
           >
             <div className="mb-6">{item.visual}</div>
-            <span className="font-display text-lg font-bold tracking-tight">
-              {item.name}
+            <span className="relative inline-block font-display text-lg font-bold tracking-tight">
+              <span className="relative z-10 transition-colors duration-300 group-hover:text-background">
+                {item.name}
+              </span>
+              <span className="absolute inset-0 bg-foreground origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out" />
             </span>
             <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
               {item.description}

--- a/packages/ghost-ui/src/app/ui/page.tsx
+++ b/packages/ghost-ui/src/app/ui/page.tsx
@@ -100,7 +100,7 @@ export default function DesignLanguageIndex() {
       <AnimatedPageHeader
         kicker="Design Language"
         title="Ghost UI"
-        description="A shared design language for our tools."
+        description="The shared design language across Ghost — foundations, primitives, and AI-native components."
       />
 
       <div

--- a/packages/ghost-ui/src/components/docs/dock.tsx
+++ b/packages/ghost-ui/src/components/docs/dock.tsx
@@ -37,7 +37,7 @@ import { cn } from "@/lib/utils";
 const nav: { name: string; path: string; icon: LucideIcon }[] = [
   { name: "Home", path: "/", icon: Home },
   { name: "Tools", path: "/tools", icon: Wrench },
-  { name: "Design Language", path: "/ui", icon: Palette },
+  { name: "UI", path: "/ui", icon: Palette },
 ];
 
 export function Dock() {

--- a/packages/ghost-ui/src/components/docs/hero.tsx
+++ b/packages/ghost-ui/src/components/docs/hero.tsx
@@ -3,18 +3,12 @@
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useEffect, useRef } from "react";
-import { getAllComponents } from "@/lib/component-registry";
 
 gsap.registerPlugin(ScrollTrigger);
 
 export function Hero() {
   const containerRef = useRef<HTMLElement>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
-  const statsRef = useRef<HTMLDivElement>(null);
-
-  const allComponents = getAllComponents();
-  const totalCount = allComponents.length;
-  const aiCount = allComponents.filter((c) => c.isAI).length;
 
   useEffect(() => {
     const ctx = gsap.context(() => {
@@ -31,13 +25,6 @@ export function Hero() {
           duration: 1.2,
           stagger: 0.12,
         });
-      }
-
-      // Animate stats bar
-      const stats = containerRef.current?.querySelector(".hero-stats");
-      if (stats) {
-        gsap.set(stats, { y: 20, opacity: 0 });
-        tl.to(stats, { y: 0, opacity: 1, duration: 0.8 }, "-=0.4");
       }
 
       // Parallax on scroll — heading moves up faster
@@ -116,18 +103,6 @@ export function Hero() {
         >
           tooling for decentralized design
         </p>
-        <div
-          ref={statsRef}
-          className="hero-stats mt-6 flex items-center justify-center gap-x-5 gap-y-2 flex-wrap text-sm text-muted-foreground"
-        >
-          <span>{totalCount} Components</span>
-          <span className="hidden h-3 w-px bg-border sm:block" aria-hidden />
-          <span>{aiCount} AI-Native</span>
-          <span className="hidden h-3 w-px bg-border sm:block" aria-hidden />
-          <span>5 Theme Presets</span>
-          <span className="hidden h-3 w-px bg-border sm:block" aria-hidden />
-          <span>shadcn Compatible</span>
-        </div>
       </div>
     </section>
   );

--- a/packages/ghost-ui/src/components/docs/hero.tsx
+++ b/packages/ghost-ui/src/components/docs/hero.tsx
@@ -3,12 +3,18 @@
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useEffect, useRef } from "react";
+import { getAllComponents } from "@/lib/component-registry";
 
 gsap.registerPlugin(ScrollTrigger);
 
 export function Hero() {
   const containerRef = useRef<HTMLElement>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
+  const statsRef = useRef<HTMLDivElement>(null);
+
+  const allComponents = getAllComponents();
+  const totalCount = allComponents.length;
+  const aiCount = allComponents.filter((c) => c.isAI).length;
 
   useEffect(() => {
     const ctx = gsap.context(() => {
@@ -25,6 +31,13 @@ export function Hero() {
           duration: 1.2,
           stagger: 0.12,
         });
+      }
+
+      // Animate stats bar
+      const stats = containerRef.current?.querySelector(".hero-stats");
+      if (stats) {
+        gsap.set(stats, { y: 20, opacity: 0 });
+        tl.to(stats, { y: 0, opacity: 1, duration: 0.8 }, "-=0.4");
       }
 
       // Parallax on scroll — heading moves up faster
@@ -101,8 +114,20 @@ export function Hero() {
           className="mt-4 text-center text-muted-foreground leading-relaxed whitespace-nowrap"
           style={{ fontSize: "clamp(0.875rem, 1.5vw, 1.125rem)" }}
         >
-          design infrastructure for decentralized systems.
+          tooling for decentralized design
         </p>
+        <div
+          ref={statsRef}
+          className="hero-stats mt-6 flex items-center justify-center gap-x-5 gap-y-2 flex-wrap text-sm text-muted-foreground"
+        >
+          <span>{totalCount} Components</span>
+          <span className="hidden h-3 w-px bg-border sm:block" aria-hidden />
+          <span>{aiCount} AI-Native</span>
+          <span className="hidden h-3 w-px bg-border sm:block" aria-hidden />
+          <span>5 Theme Presets</span>
+          <span className="hidden h-3 w-px bg-border sm:block" aria-hidden />
+          <span>shadcn Compatible</span>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Hero subheading changed to "tooling for decentralized design"
- Dock nav label renamed from "Design Language" to "UI"
- UI page description updated
- Card hover style unified across Tools, UI, and Foundations pages (sliding title fill instead of scale+shadow)

## Test plan
- [x] Homepage: new subheading renders, animations intact
- [x] Dock: "UI" label, tooltip, active state on `/ui` routes
- [x] Card hover on Tools, UI, and Foundations pages all match
- [x] Mobile: layout unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)