### PR TITLE
Enhanced component documentation pages

### DIFF
--- a/packages/ghost-ui/src/app/components/[name]/page.tsx
+++ b/packages/ghost-ui/src/app/components/[name]/page.tsx
@@ -5,6 +5,7 @@ import {
   getComponent,
   getComponentsByCategory,
 } from "@/lib/component-registry";
+import { getComponentDoc } from "@/lib/component-docs";
 import { getComponentSpec } from "@/lib/component-source";
 
 // ── Import demo source files as raw strings at build time ──
@@ -42,6 +43,7 @@ export default function ComponentPage() {
 
   const demoSource = getDemoSource(component.slug, component.demoSource);
   const spec = getComponentSpec(component.slug);
+  const docs = getComponentDoc(name);
 
   return (
     <ComponentPageShell
@@ -51,6 +53,7 @@ export default function ComponentPage() {
       spec={spec}
       prev={prev ? { slug: prev.slug, name: prev.name } : null}
       next={next ? { slug: next.slug, name: next.name } : null}
+      docs={docs}
     />
   );
 }

--- a/packages/ghost-ui/src/app/components/[name]/page.tsx
+++ b/packages/ghost-ui/src/app/components/[name]/page.tsx
@@ -1,11 +1,11 @@
 import { Navigate, useParams } from "react-router";
 import { ComponentPageShell } from "@/components/docs/component-page-shell";
+import { getComponentDoc } from "@/lib/component-docs";
 import {
   getCategory,
   getComponent,
   getComponentsByCategory,
 } from "@/lib/component-registry";
-import { getComponentDoc } from "@/lib/component-docs";
 import { getComponentSpec } from "@/lib/component-source";
 
 // ── Import demo source files as raw strings at build time ──

--- a/packages/ghost-ui/src/components/docs/component-page-shell.tsx
+++ b/packages/ghost-ui/src/components/docs/component-page-shell.tsx
@@ -15,11 +15,12 @@ import {
   CodeBlockCopyButton,
   CodeBlockHeader,
 } from "@/components/ai-elements/code-block";
-import { DemoLoader } from "@/components/docs/demo-loader";
+import { DemoLoader, ExampleLoader } from "@/components/docs/demo-loader";
 import { ComponentErrorBoundary } from "@/components/docs/error-boundary";
 import { SectionWrapper } from "@/components/docs/wrappers";
 import { Button } from "@/components/ui/button";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import type { ComponentDoc } from "@/lib/component-docs";
 import { ComponentEntry } from "@/lib/component-registry";
 import type { ComponentSpec } from "@/lib/component-source";
 import { cn } from "@/lib/utils";
@@ -101,6 +102,7 @@ export function ComponentPageShell({
   spec,
   prev,
   next,
+  docs,
 }: {
   component: ComponentEntry;
   categoryName: string;
@@ -108,6 +110,7 @@ export function ComponentPageShell({
   spec: ComponentSpec | null;
   prev: { slug: string; name: string } | null;
   next: { slug: string; name: string } | null;
+  docs?: ComponentDoc;
 }) {
   const [activeTab, setActiveTab] = useState<"preview" | "source" | "demo">(
     "preview",
@@ -177,6 +180,14 @@ export function ComponentPageShell({
           >
             {component.name}
           </h1>
+          {docs?.description && (
+            <p
+              className="mt-3 text-muted-foreground leading-relaxed"
+              style={{ fontSize: "clamp(0.875rem, 1.5vw, 1rem)" }}
+            >
+              {docs.description}
+            </p>
+          )}
         </div>
 
         <div className="shell-content space-y-6">
@@ -207,6 +218,21 @@ export function ComponentPageShell({
               />
             </Button>
           </div>
+
+          {docs?.usage && (
+            <div className="rounded-lg border overflow-hidden">
+              <CodeBlock code={docs.usage} language="tsx">
+                <CodeBlockHeader>
+                  <span className="text-xs font-mono text-muted-foreground">
+                    Usage
+                  </span>
+                  <CodeBlockActions>
+                    <CodeBlockCopyButton />
+                  </CodeBlockActions>
+                </CodeBlockHeader>
+              </CodeBlock>
+            </div>
+          )}
 
           {/* ── Tabs: Preview / Source / Demo Code ── */}
           <div>
@@ -371,6 +397,107 @@ export function ComponentPageShell({
               )}
             </div>
           </div>
+
+          {docs && docs.props.length > 0 && (
+            <div className="border rounded-lg divide-y divide-border/50">
+              <div className="px-4 py-3">
+                <h2
+                  className="font-display uppercase text-muted-foreground"
+                  style={{
+                    fontSize: "var(--label-font-size)",
+                    letterSpacing: "var(--label-letter-spacing)",
+                    fontWeight: "var(--label-font-weight)",
+                  }}
+                >
+                  Props
+                </h2>
+              </div>
+              <div className="px-4 py-1">
+                {docs.props.map((prop) => (
+                  <SpecRow key={prop.name} label={prop.name} mono>
+                    <div className="flex flex-col gap-0.5">
+                      <code className="text-xs text-muted-foreground">
+                        {prop.type}
+                      </code>
+                      {prop.default && (
+                        <span className="text-xs text-muted-foreground">
+                          Default: <code className="font-mono">{prop.default}</code>
+                        </span>
+                      )}
+                      <span className="text-sm">{prop.description}</span>
+                    </div>
+                  </SpecRow>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {docs && docs.composedWith.length > 0 && (
+            <div className="border rounded-lg divide-y divide-border/50">
+              <div className="px-4 py-3">
+                <h2
+                  className="font-display uppercase text-muted-foreground"
+                  style={{
+                    fontSize: "var(--label-font-size)",
+                    letterSpacing: "var(--label-letter-spacing)",
+                    fontWeight: "var(--label-font-weight)",
+                  }}
+                >
+                  Works With
+                </h2>
+              </div>
+              <div className="px-4 py-3">
+                <div className="flex flex-wrap gap-1.5">
+                  {docs.composedWith.map((slug) => (
+                    <Link
+                      key={slug}
+                      to={`/ui/components/${slug}`}
+                      className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono transition-colors hover:bg-accent hover:text-accent-foreground"
+                    >
+                      {slug}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {docs && docs.examples.length > 0 && (
+            <div className="space-y-6">
+              <h2
+                className="font-display uppercase text-muted-foreground"
+                style={{
+                  fontSize: "var(--label-font-size)",
+                  letterSpacing: "var(--label-letter-spacing)",
+                  fontWeight: "var(--label-font-weight)",
+                }}
+              >
+                Examples
+              </h2>
+              {docs.examples.map((example) => (
+                <div key={example.name} className="space-y-3">
+                  <div>
+                    <h3 className="text-sm font-medium">{example.title}</h3>
+                    {example.description && (
+                      <p className="text-xs text-muted-foreground">
+                        {example.description}
+                      </p>
+                    )}
+                  </div>
+                  <div className="rounded-lg border p-6">
+                    <ComponentErrorBoundary
+                      name={`${component.slug}-${example.name}`}
+                    >
+                      <ExampleLoader
+                        componentSlug={component.slug}
+                        exampleName={example.name}
+                      />
+                    </ComponentErrorBoundary>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
 
           {/* ── Prev / Next ── */}
           <div className="flex items-center justify-between border-t pt-6 pb-16">

--- a/packages/ghost-ui/src/components/docs/component-page-shell.tsx
+++ b/packages/ghost-ui/src/components/docs/component-page-shell.tsx
@@ -135,7 +135,7 @@ export function ComponentPageShell({
     return () => ctx.revert();
   }, [component.slug]);
 
-  const installCommand = `npx shadcn@latest add ${component.slug}`;
+  const installCommand = `npx shadcn@latest add --registry https://block.github.io/ghost/r/registry.json ${component.slug}`;
 
   // Filter exports to only component names (capitalized), exclude variant exports
   const componentExports =
@@ -144,8 +144,36 @@ export function ComponentPageShell({
     ) ?? [];
 
   return (
+    <>
+      {/* ── Prev / Next (floating sides, xl+) ── */}
+      {prev && (
+        <Link
+          to={`/ui/components/${prev.slug}`}
+          className="hidden xl:flex fixed left-6 top-1/2 -translate-y-1/2 z-40 group flex-col items-start gap-2 text-muted-foreground hover:text-foreground transition-colors duration-200"
+        >
+          <span className="flex size-10 items-center justify-center rounded-full border bg-background/80 backdrop-blur-sm group-hover:border-foreground/25 transition-all duration-200 shadow-sm">
+            <NavigationBackIcon className="size-4 transition-transform group-hover:-translate-x-0.5" />
+          </span>
+          <span className="text-xs font-medium max-w-[6rem] leading-tight text-left">
+            {prev.name}
+          </span>
+        </Link>
+      )}
+      {next && (
+        <Link
+          to={`/ui/components/${next.slug}`}
+          className="hidden xl:flex fixed right-6 top-1/2 -translate-y-1/2 z-40 group flex-col items-end gap-2 text-muted-foreground hover:text-foreground transition-colors duration-200"
+        >
+          <span className="flex size-10 items-center justify-center rounded-full border bg-background/80 backdrop-blur-sm group-hover:border-foreground/25 transition-all duration-200 shadow-sm">
+            <NavigationBackIcon className="size-4 rotate-180 transition-transform group-hover:translate-x-0.5" />
+          </span>
+          <span className="text-xs font-medium max-w-[6rem] leading-tight text-right">
+            {next.name}
+          </span>
+        </Link>
+      )}
     <SectionWrapper>
-      <div ref={shellRef}>
+      <div ref={shellRef} className="mx-auto max-w-3xl">
         {/* ── Header ── */}
         <div className="shell-header pt-6 pb-4 sm:pt-8 sm:pb-6">
           <div className="flex items-center gap-3 mb-3">
@@ -166,11 +194,6 @@ export function ComponentPageShell({
               >
                 {categoryName}
               </span>
-              {component.isAI && (
-                <span className="inline-flex items-center rounded-full bg-foreground text-background px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider">
-                  AI
-                </span>
-              )}
             </div>
           </div>
 
@@ -499,8 +522,8 @@ export function ComponentPageShell({
             </div>
           )}
 
-          {/* ── Prev / Next ── */}
-          <div className="flex items-center justify-between border-t pt-6 pb-16">
+          {/* ── Prev / Next (bottom, below xl) ── */}
+          <div className="flex items-center justify-between border-t pt-6 pb-16 xl:hidden">
             {prev ? (
               <Link
                 to={`/ui/components/${prev.slug}`}
@@ -536,8 +559,12 @@ export function ComponentPageShell({
               <div />
             )}
           </div>
+
+          {/* spacer for bottom nav hidden on xl */}
+          <div className="hidden xl:block pb-16" />
         </div>
       </div>
     </SectionWrapper>
+    </>
   );
 }

--- a/packages/ghost-ui/src/components/docs/component-page-shell.tsx
+++ b/packages/ghost-ui/src/components/docs/component-page-shell.tsx
@@ -172,259 +172,19 @@ export function ComponentPageShell({
           </span>
         </Link>
       )}
-    <SectionWrapper>
-      <div ref={shellRef} className="mx-auto max-w-3xl">
-        {/* ── Header ── */}
-        <div className="shell-header pt-6 pb-4 sm:pt-8 sm:pb-6">
-          <div className="flex items-center gap-3 mb-3">
-            <Link
-              to="/ui/components"
-              className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <NavigationBackIcon className="size-4" />
-            </Link>
-            <div className="flex items-center gap-2">
-              <span
-                className="font-display uppercase text-muted-foreground"
-                style={{
-                  fontSize: "var(--label-font-size)",
-                  letterSpacing: "var(--label-letter-spacing)",
-                  fontWeight: "var(--label-font-weight)",
-                }}
+      <SectionWrapper>
+        <div ref={shellRef} className="mx-auto max-w-3xl">
+          {/* ── Header ── */}
+          <div className="shell-header pt-6 pb-4 sm:pt-8 sm:pb-6">
+            <div className="flex items-center gap-3 mb-3">
+              <Link
+                to="/ui/components"
+                className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
-                {categoryName}
-              </span>
-            </div>
-          </div>
-
-          <h1
-            className="font-display font-black tracking-[-0.04em] leading-[0.9]"
-            style={{ fontSize: "clamp(2rem, 5vw, 3.5rem)" }}
-          >
-            {component.name}
-          </h1>
-          {docs?.description && (
-            <p
-              className="mt-3 text-muted-foreground leading-relaxed"
-              style={{ fontSize: "clamp(0.875rem, 1.5vw, 1rem)" }}
-            >
-              {docs.description}
-            </p>
-          )}
-        </div>
-
-        <div className="shell-content space-y-6">
-          {/* ── Install ── */}
-          <div className="flex items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2">
-            <DownloadIcon className="size-3.5 shrink-0 text-muted-foreground" />
-            <code className="flex-1 text-[13px] font-mono truncate text-muted-foreground">
-              {installCommand}
-            </code>
-            <Button
-              appearance="icon"
-              variant="ghost"
-              size="icon-xs"
-              className="relative shrink-0 cursor-pointer"
-              onClick={() => copyToClipboard(installCommand)}
-            >
-              <CopyIcon
-                className={cn(
-                  "absolute size-3.5 transition duration-200",
-                  isCopied ? "scale-0" : "scale-100",
-                )}
-              />
-              <CheckIcon
-                className={cn(
-                  "absolute size-3.5 transition duration-200",
-                  !isCopied ? "scale-0" : "scale-100",
-                )}
-              />
-            </Button>
-          </div>
-
-          {docs?.usage && (
-            <div className="rounded-lg border overflow-hidden">
-              <CodeBlock code={docs.usage} language="tsx">
-                <CodeBlockHeader>
-                  <span className="text-xs font-mono text-muted-foreground">
-                    Usage
-                  </span>
-                  <CodeBlockActions>
-                    <CodeBlockCopyButton />
-                  </CodeBlockActions>
-                </CodeBlockHeader>
-              </CodeBlock>
-            </div>
-          )}
-
-          {/* ── Tabs: Preview / Source / Demo Code ── */}
-          <div>
-            <div className="flex items-center gap-1 border-b mb-0">
-              {(
-                [
-                  ["preview", "Preview"],
-                  ...(spec?.source ? [["source", "Source"]] : []),
-                  ...(demoSource ? [["demo", "Demo"]] : []),
-                ] as [string, string][]
-              ).map(([key, label]) => (
-                <button
-                  key={key}
-                  onClick={() => setActiveTab(key as typeof activeTab)}
-                  className={cn(
-                    "px-3 py-2 text-sm font-medium transition-colors relative cursor-pointer",
-                    activeTab === key
-                      ? "text-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {label}
-                  {activeTab === key && (
-                    <span className="absolute bottom-0 left-0 right-0 h-px bg-foreground" />
-                  )}
-                </button>
-              ))}
-            </div>
-
-            <div className="pt-6">
-              {activeTab === "preview" && (
-                <ComponentErrorBoundary name={component.slug}>
-                  <DemoLoader name={component.slug} />
-                </ComponentErrorBoundary>
-              )}
-
-              {activeTab === "source" && spec?.source && (
-                <div className="rounded-lg border overflow-hidden">
-                  <CodeBlock code={spec.source} language="tsx" showLineNumbers>
-                    <CodeBlockHeader>
-                      <span className="text-xs font-mono text-muted-foreground">
-                        {spec.filePath}
-                      </span>
-                      <CodeBlockActions>
-                        <CodeBlockCopyButton />
-                      </CodeBlockActions>
-                    </CodeBlockHeader>
-                  </CodeBlock>
-                </div>
-              )}
-
-              {activeTab === "demo" && demoSource && (
-                <div className="rounded-lg border overflow-hidden">
-                  <CodeBlock code={demoSource} language="tsx" showLineNumbers>
-                    <CodeBlockHeader>
-                      <span className="text-xs font-mono text-muted-foreground">
-                        {component.slug}-demo.tsx
-                      </span>
-                      <CodeBlockActions>
-                        <CodeBlockCopyButton />
-                      </CodeBlockActions>
-                    </CodeBlockHeader>
-                  </CodeBlock>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* ── Spec Sheet ── */}
-          <div className="border rounded-lg divide-y divide-border/50">
-            <div className="px-4 py-3">
-              <h2
-                className="font-display uppercase text-muted-foreground"
-                style={{
-                  fontSize: "var(--label-font-size)",
-                  letterSpacing: "var(--label-letter-spacing)",
-                  fontWeight: "var(--label-font-weight)",
-                }}
-              >
-                Specification
-              </h2>
-            </div>
-
-            <div className="px-4 py-1">
-              {/* Variants */}
-              {spec && spec.variants.length > 0 && (
-                <SpecRow label="Variants">
-                  <VariantTable variants={spec.variants} />
-                </SpecRow>
-              )}
-
-              {/* Sub-components */}
-              {componentExports.length > 1 && (
-                <SpecRow label="Exports" mono>
-                  <div className="flex flex-wrap gap-1.5">
-                    {componentExports.map((exp) => (
-                      <span
-                        key={exp}
-                        className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs"
-                      >
-                        {exp}
-                      </span>
-                    ))}
-                  </div>
-                </SpecRow>
-              )}
-
-              {/* Data slots */}
-              {spec && spec.dataSlots.length > 0 && (
-                <SpecRow label="Data Slots" mono>
-                  <div className="flex flex-wrap gap-1.5">
-                    {spec.dataSlots.map((slot) => (
-                      <span
-                        key={slot}
-                        className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs"
-                      >
-                        [data-slot=&quot;{slot}&quot;]
-                      </span>
-                    ))}
-                  </div>
-                </SpecRow>
-              )}
-
-              {/* Registry dependencies */}
-              {component.registryDependencies.length > 0 && (
-                <SpecRow label="Built With">
-                  <div className="flex flex-wrap gap-1.5">
-                    {component.registryDependencies.map((dep) => (
-                      <Link
-                        key={dep}
-                        to={`/ui/components/${dep}`}
-                        className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono transition-colors hover:bg-accent hover:text-accent-foreground"
-                      >
-                        {dep}
-                      </Link>
-                    ))}
-                  </div>
-                </SpecRow>
-              )}
-
-              {/* npm Dependencies */}
-              {component.dependencies.length > 0 && (
-                <SpecRow label="Packages" mono>
-                  <div className="flex flex-wrap gap-1.5">
-                    {component.dependencies.map((dep) => (
-                      <span
-                        key={dep}
-                        className="inline-flex items-center rounded-md border bg-muted/30 px-2 py-0.5 text-xs"
-                      >
-                        {dep}
-                      </span>
-                    ))}
-                  </div>
-                </SpecRow>
-              )}
-
-              {/* File path */}
-              {spec?.filePath && (
-                <SpecRow label="File" mono>
-                  <span className="text-muted-foreground">{spec.filePath}</span>
-                </SpecRow>
-              )}
-            </div>
-          </div>
-
-          {docs && docs.props.length > 0 && (
-            <div className="border rounded-lg divide-y divide-border/50">
-              <div className="px-4 py-3">
-                <h2
+                <NavigationBackIcon className="size-4" />
+              </Link>
+              <div className="flex items-center gap-2">
+                <span
                   className="font-display uppercase text-muted-foreground"
                   style={{
                     fontSize: "var(--label-font-size)",
@@ -432,30 +192,143 @@ export function ComponentPageShell({
                     fontWeight: "var(--label-font-weight)",
                   }}
                 >
-                  Props
-                </h2>
+                  {categoryName}
+                </span>
               </div>
-              <div className="px-4 py-1">
-                {docs.props.map((prop) => (
-                  <SpecRow key={prop.name} label={prop.name} mono>
-                    <div className="flex flex-col gap-0.5">
-                      <code className="text-xs text-muted-foreground">
-                        {prop.type}
-                      </code>
-                      {prop.default && (
-                        <span className="text-xs text-muted-foreground">
-                          Default: <code className="font-mono">{prop.default}</code>
-                        </span>
-                      )}
-                      <span className="text-sm">{prop.description}</span>
-                    </div>
-                  </SpecRow>
+            </div>
+
+            <h1
+              className="font-display font-black tracking-[-0.04em] leading-[0.9]"
+              style={{ fontSize: "clamp(2rem, 5vw, 3.5rem)" }}
+            >
+              {component.name}
+            </h1>
+            {docs?.description && (
+              <p
+                className="mt-3 text-muted-foreground leading-relaxed"
+                style={{ fontSize: "clamp(0.875rem, 1.5vw, 1rem)" }}
+              >
+                {docs.description}
+              </p>
+            )}
+          </div>
+
+          <div className="shell-content space-y-6">
+            {/* ── Install ── */}
+            <div className="flex items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2">
+              <DownloadIcon className="size-3.5 shrink-0 text-muted-foreground" />
+              <code className="flex-1 text-[13px] font-mono truncate text-muted-foreground">
+                {installCommand}
+              </code>
+              <Button
+                appearance="icon"
+                variant="ghost"
+                size="icon-xs"
+                className="relative shrink-0 cursor-pointer"
+                onClick={() => copyToClipboard(installCommand)}
+              >
+                <CopyIcon
+                  className={cn(
+                    "absolute size-3.5 transition duration-200",
+                    isCopied ? "scale-0" : "scale-100",
+                  )}
+                />
+                <CheckIcon
+                  className={cn(
+                    "absolute size-3.5 transition duration-200",
+                    !isCopied ? "scale-0" : "scale-100",
+                  )}
+                />
+              </Button>
+            </div>
+
+            {docs?.usage && (
+              <div className="rounded-lg border overflow-hidden">
+                <CodeBlock code={docs.usage} language="tsx">
+                  <CodeBlockHeader>
+                    <span className="text-xs font-mono text-muted-foreground">
+                      Usage
+                    </span>
+                    <CodeBlockActions>
+                      <CodeBlockCopyButton />
+                    </CodeBlockActions>
+                  </CodeBlockHeader>
+                </CodeBlock>
+              </div>
+            )}
+
+            {/* ── Tabs: Preview / Source / Demo Code ── */}
+            <div>
+              <div className="flex items-center gap-1 border-b mb-0">
+                {(
+                  [
+                    ["preview", "Preview"],
+                    ...(spec?.source ? [["source", "Source"]] : []),
+                    ...(demoSource ? [["demo", "Demo"]] : []),
+                  ] as [string, string][]
+                ).map(([key, label]) => (
+                  <button
+                    key={key}
+                    onClick={() => setActiveTab(key as typeof activeTab)}
+                    className={cn(
+                      "px-3 py-2 text-sm font-medium transition-colors relative cursor-pointer",
+                      activeTab === key
+                        ? "text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {label}
+                    {activeTab === key && (
+                      <span className="absolute bottom-0 left-0 right-0 h-px bg-foreground" />
+                    )}
+                  </button>
                 ))}
               </div>
-            </div>
-          )}
 
-          {docs && docs.composedWith.length > 0 && (
+              <div className="pt-6">
+                {activeTab === "preview" && (
+                  <ComponentErrorBoundary name={component.slug}>
+                    <DemoLoader name={component.slug} />
+                  </ComponentErrorBoundary>
+                )}
+
+                {activeTab === "source" && spec?.source && (
+                  <div className="rounded-lg border overflow-hidden">
+                    <CodeBlock
+                      code={spec.source}
+                      language="tsx"
+                      showLineNumbers
+                    >
+                      <CodeBlockHeader>
+                        <span className="text-xs font-mono text-muted-foreground">
+                          {spec.filePath}
+                        </span>
+                        <CodeBlockActions>
+                          <CodeBlockCopyButton />
+                        </CodeBlockActions>
+                      </CodeBlockHeader>
+                    </CodeBlock>
+                  </div>
+                )}
+
+                {activeTab === "demo" && demoSource && (
+                  <div className="rounded-lg border overflow-hidden">
+                    <CodeBlock code={demoSource} language="tsx" showLineNumbers>
+                      <CodeBlockHeader>
+                        <span className="text-xs font-mono text-muted-foreground">
+                          {component.slug}-demo.tsx
+                        </span>
+                        <CodeBlockActions>
+                          <CodeBlockCopyButton />
+                        </CodeBlockActions>
+                      </CodeBlockHeader>
+                    </CodeBlock>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* ── Spec Sheet ── */}
             <div className="border rounded-lg divide-y divide-border/50">
               <div className="px-4 py-3">
                 <h2
@@ -466,105 +339,239 @@ export function ComponentPageShell({
                     fontWeight: "var(--label-font-weight)",
                   }}
                 >
-                  Works With
+                  Specification
                 </h2>
               </div>
-              <div className="px-4 py-3">
-                <div className="flex flex-wrap gap-1.5">
-                  {docs.composedWith.map((slug) => (
-                    <Link
-                      key={slug}
-                      to={`/ui/components/${slug}`}
-                      className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono transition-colors hover:bg-accent hover:text-accent-foreground"
-                    >
-                      {slug}
-                    </Link>
+
+              <div className="px-4 py-1">
+                {/* Variants */}
+                {spec && spec.variants.length > 0 && (
+                  <SpecRow label="Variants">
+                    <VariantTable variants={spec.variants} />
+                  </SpecRow>
+                )}
+
+                {/* Sub-components */}
+                {componentExports.length > 1 && (
+                  <SpecRow label="Exports" mono>
+                    <div className="flex flex-wrap gap-1.5">
+                      {componentExports.map((exp) => (
+                        <span
+                          key={exp}
+                          className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs"
+                        >
+                          {exp}
+                        </span>
+                      ))}
+                    </div>
+                  </SpecRow>
+                )}
+
+                {/* Data slots */}
+                {spec && spec.dataSlots.length > 0 && (
+                  <SpecRow label="Data Slots" mono>
+                    <div className="flex flex-wrap gap-1.5">
+                      {spec.dataSlots.map((slot) => (
+                        <span
+                          key={slot}
+                          className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs"
+                        >
+                          [data-slot=&quot;{slot}&quot;]
+                        </span>
+                      ))}
+                    </div>
+                  </SpecRow>
+                )}
+
+                {/* Registry dependencies */}
+                {component.registryDependencies.length > 0 && (
+                  <SpecRow label="Built With">
+                    <div className="flex flex-wrap gap-1.5">
+                      {component.registryDependencies.map((dep) => (
+                        <Link
+                          key={dep}
+                          to={`/ui/components/${dep}`}
+                          className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono transition-colors hover:bg-accent hover:text-accent-foreground"
+                        >
+                          {dep}
+                        </Link>
+                      ))}
+                    </div>
+                  </SpecRow>
+                )}
+
+                {/* npm Dependencies */}
+                {component.dependencies.length > 0 && (
+                  <SpecRow label="Packages" mono>
+                    <div className="flex flex-wrap gap-1.5">
+                      {component.dependencies.map((dep) => (
+                        <span
+                          key={dep}
+                          className="inline-flex items-center rounded-md border bg-muted/30 px-2 py-0.5 text-xs"
+                        >
+                          {dep}
+                        </span>
+                      ))}
+                    </div>
+                  </SpecRow>
+                )}
+
+                {/* File path */}
+                {spec?.filePath && (
+                  <SpecRow label="File" mono>
+                    <span className="text-muted-foreground">
+                      {spec.filePath}
+                    </span>
+                  </SpecRow>
+                )}
+              </div>
+            </div>
+
+            {docs && docs.props.length > 0 && (
+              <div className="border rounded-lg divide-y divide-border/50">
+                <div className="px-4 py-3">
+                  <h2
+                    className="font-display uppercase text-muted-foreground"
+                    style={{
+                      fontSize: "var(--label-font-size)",
+                      letterSpacing: "var(--label-letter-spacing)",
+                      fontWeight: "var(--label-font-weight)",
+                    }}
+                  >
+                    Props
+                  </h2>
+                </div>
+                <div className="px-4 py-1">
+                  {docs.props.map((prop) => (
+                    <SpecRow key={prop.name} label={prop.name} mono>
+                      <div className="flex flex-col gap-0.5">
+                        <code className="text-xs text-muted-foreground">
+                          {prop.type}
+                        </code>
+                        {prop.default && (
+                          <span className="text-xs text-muted-foreground">
+                            Default:{" "}
+                            <code className="font-mono">{prop.default}</code>
+                          </span>
+                        )}
+                        <span className="text-sm">{prop.description}</span>
+                      </div>
+                    </SpecRow>
                   ))}
                 </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {docs && docs.examples.length > 0 && (
-            <div className="space-y-6">
-              <h2
-                className="font-display uppercase text-muted-foreground"
-                style={{
-                  fontSize: "var(--label-font-size)",
-                  letterSpacing: "var(--label-letter-spacing)",
-                  fontWeight: "var(--label-font-weight)",
-                }}
-              >
-                Examples
-              </h2>
-              {docs.examples.map((example) => (
-                <div key={example.name} className="space-y-3">
-                  <div>
-                    <h3 className="text-sm font-medium">{example.title}</h3>
-                    {example.description && (
-                      <p className="text-xs text-muted-foreground">
-                        {example.description}
-                      </p>
-                    )}
-                  </div>
-                  <div className="rounded-lg border p-6">
-                    <ComponentErrorBoundary
-                      name={`${component.slug}-${example.name}`}
-                    >
-                      <ExampleLoader
-                        componentSlug={component.slug}
-                        exampleName={example.name}
-                      />
-                    </ComponentErrorBoundary>
+            {docs && docs.composedWith.length > 0 && (
+              <div className="border rounded-lg divide-y divide-border/50">
+                <div className="px-4 py-3">
+                  <h2
+                    className="font-display uppercase text-muted-foreground"
+                    style={{
+                      fontSize: "var(--label-font-size)",
+                      letterSpacing: "var(--label-letter-spacing)",
+                      fontWeight: "var(--label-font-weight)",
+                    }}
+                  >
+                    Works With
+                  </h2>
+                </div>
+                <div className="px-4 py-3">
+                  <div className="flex flex-wrap gap-1.5">
+                    {docs.composedWith.map((slug) => (
+                      <Link
+                        key={slug}
+                        to={`/ui/components/${slug}`}
+                        className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono transition-colors hover:bg-accent hover:text-accent-foreground"
+                      >
+                        {slug}
+                      </Link>
+                    ))}
                   </div>
                 </div>
-              ))}
-            </div>
-          )}
+              </div>
+            )}
 
-          {/* ── Prev / Next (bottom, below xl) ── */}
-          <div className="flex items-center justify-between border-t pt-6 pb-16 xl:hidden">
-            {prev ? (
-              <Link
-                to={`/ui/components/${prev.slug}`}
-                className="group inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <NavigationBackIcon className="size-4 transition-transform group-hover:-translate-x-0.5" />
-                <div className="flex flex-col">
-                  <span className="text-xs text-muted-foreground">
-                    Previous
-                  </span>
-                  <span className="font-medium text-foreground">
-                    {prev.name}
-                  </span>
-                </div>
-              </Link>
-            ) : (
-              <div />
+            {docs && docs.examples.length > 0 && (
+              <div className="space-y-6">
+                <h2
+                  className="font-display uppercase text-muted-foreground"
+                  style={{
+                    fontSize: "var(--label-font-size)",
+                    letterSpacing: "var(--label-letter-spacing)",
+                    fontWeight: "var(--label-font-weight)",
+                  }}
+                >
+                  Examples
+                </h2>
+                {docs.examples.map((example) => (
+                  <div key={example.name} className="space-y-3">
+                    <div>
+                      <h3 className="text-sm font-medium">{example.title}</h3>
+                      {example.description && (
+                        <p className="text-xs text-muted-foreground">
+                          {example.description}
+                        </p>
+                      )}
+                    </div>
+                    <div className="rounded-lg border p-6">
+                      <ComponentErrorBoundary
+                        name={`${component.slug}-${example.name}`}
+                      >
+                        <ExampleLoader
+                          componentSlug={component.slug}
+                          exampleName={example.name}
+                        />
+                      </ComponentErrorBoundary>
+                    </div>
+                  </div>
+                ))}
+              </div>
             )}
-            {next ? (
-              <Link
-                to={`/ui/components/${next.slug}`}
-                className="group inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors text-right"
-              >
-                <div className="flex flex-col items-end">
-                  <span className="text-xs text-muted-foreground">Next</span>
-                  <span className="font-medium text-foreground">
-                    {next.name}
-                  </span>
-                </div>
-                <NavigationBackIcon className="size-4 rotate-180 transition-transform group-hover:translate-x-0.5" />
-              </Link>
-            ) : (
-              <div />
-            )}
+
+            {/* ── Prev / Next (bottom, below xl) ── */}
+            <div className="flex items-center justify-between border-t pt-6 pb-16 xl:hidden">
+              {prev ? (
+                <Link
+                  to={`/ui/components/${prev.slug}`}
+                  className="group inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <NavigationBackIcon className="size-4 transition-transform group-hover:-translate-x-0.5" />
+                  <div className="flex flex-col">
+                    <span className="text-xs text-muted-foreground">
+                      Previous
+                    </span>
+                    <span className="font-medium text-foreground">
+                      {prev.name}
+                    </span>
+                  </div>
+                </Link>
+              ) : (
+                <div />
+              )}
+              {next ? (
+                <Link
+                  to={`/ui/components/${next.slug}`}
+                  className="group inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors text-right"
+                >
+                  <div className="flex flex-col items-end">
+                    <span className="text-xs text-muted-foreground">Next</span>
+                    <span className="font-medium text-foreground">
+                      {next.name}
+                    </span>
+                  </div>
+                  <NavigationBackIcon className="size-4 rotate-180 transition-transform group-hover:translate-x-0.5" />
+                </Link>
+              ) : (
+                <div />
+              )}
+            </div>
+
+            {/* spacer for bottom nav hidden on xl */}
+            <div className="hidden xl:block pb-16" />
           </div>
-
-          {/* spacer for bottom nav hidden on xl */}
-          <div className="hidden xl:block pb-16" />
         </div>
-      </div>
-    </SectionWrapper>
+      </SectionWrapper>
     </>
   );
 }

--- a/packages/ghost-ui/src/components/docs/demo-loader.tsx
+++ b/packages/ghost-ui/src/components/docs/demo-loader.tsx
@@ -1,7 +1,42 @@
 "use client";
 
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useMemo } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+
+const exampleModules = import.meta.glob<{ default: React.ComponentType }>(
+  "/src/components/docs/examples/**/*.tsx",
+);
+
+const LoadingSkeleton = () => (
+  <div className="flex w-full flex-col gap-4 py-8">
+    <Skeleton className="h-8 w-48" />
+    <Skeleton className="h-48 w-full" />
+  </div>
+);
+
+export function ExampleLoader({
+  componentSlug,
+  exampleName,
+}: {
+  componentSlug: string;
+  exampleName: string;
+}) {
+  const path = `/src/components/docs/examples/${componentSlug}/${exampleName}.tsx`;
+  const loader = exampleModules[path];
+
+  const LazyComponent = useMemo(() => {
+    if (!loader) return null;
+    return lazy(loader);
+  }, [loader]);
+
+  if (!LazyComponent) return null;
+
+  return (
+    <Suspense fallback={<LoadingSkeleton />}>
+      <LazyComponent />
+    </Suspense>
+  );
+}
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const wrap = (imp: Promise<any>, name: string) =>

--- a/packages/ghost-ui/src/components/docs/examples/code-block/with-diff.tsx
+++ b/packages/ghost-ui/src/components/docs/examples/code-block/with-diff.tsx
@@ -11,7 +11,10 @@ import {
   CodeBlockLanguageSelectorValue,
 } from "@/components/ai-elements/code-block";
 
-const snippets: Record<string, { code: string; language: "typescript" | "python" | "rust" }> = {
+const snippets: Record<
+  string,
+  { code: string; language: "typescript" | "python" | "rust" }
+> = {
   typescript: {
     code: `function fibonacci(n: number): number {
   if (n <= 1) return n;
@@ -51,7 +54,11 @@ export default function CodeBlockWithDiff() {
 
   return (
     <div className="w-full max-w-xl">
-      <CodeBlock code={snippet.code} language={snippet.language} showLineNumbers>
+      <CodeBlock
+        code={snippet.code}
+        language={snippet.language}
+        showLineNumbers
+      >
         <CodeBlockHeader>
           <CodeBlockLanguageSelector value={lang} onValueChange={setLang}>
             <CodeBlockLanguageSelectorTrigger>

--- a/packages/ghost-ui/src/components/docs/examples/code-block/with-diff.tsx
+++ b/packages/ghost-ui/src/components/docs/examples/code-block/with-diff.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import {
+  CodeBlock,
+  CodeBlockActions,
+  CodeBlockCopyButton,
+  CodeBlockHeader,
+  CodeBlockLanguageSelector,
+  CodeBlockLanguageSelectorContent,
+  CodeBlockLanguageSelectorItem,
+  CodeBlockLanguageSelectorTrigger,
+  CodeBlockLanguageSelectorValue,
+} from "@/components/ai-elements/code-block";
+
+const snippets: Record<string, { code: string; language: "typescript" | "python" | "rust" }> = {
+  typescript: {
+    code: `function fibonacci(n: number): number {
+  if (n <= 1) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+console.log(fibonacci(10)); // 55`,
+    language: "typescript",
+  },
+  python: {
+    code: `def fibonacci(n: int) -> int:
+    if n <= 1:
+        return n
+    return fibonacci(n - 1) + fibonacci(n - 2)
+
+print(fibonacci(10))  # 55`,
+    language: "python",
+  },
+  rust: {
+    code: `fn fibonacci(n: u32) -> u32 {
+    if n <= 1 {
+        return n;
+    }
+    fibonacci(n - 1) + fibonacci(n - 2)
+}
+
+fn main() {
+    println!("{}", fibonacci(10)); // 55
+}`,
+    language: "rust",
+  },
+};
+
+export default function CodeBlockWithDiff() {
+  const [lang, setLang] = useState("typescript");
+  const snippet = snippets[lang];
+
+  return (
+    <div className="w-full max-w-xl">
+      <CodeBlock code={snippet.code} language={snippet.language} showLineNumbers>
+        <CodeBlockHeader>
+          <CodeBlockLanguageSelector value={lang} onValueChange={setLang}>
+            <CodeBlockLanguageSelectorTrigger>
+              <CodeBlockLanguageSelectorValue />
+            </CodeBlockLanguageSelectorTrigger>
+            <CodeBlockLanguageSelectorContent>
+              <CodeBlockLanguageSelectorItem value="typescript">
+                TypeScript
+              </CodeBlockLanguageSelectorItem>
+              <CodeBlockLanguageSelectorItem value="python">
+                Python
+              </CodeBlockLanguageSelectorItem>
+              <CodeBlockLanguageSelectorItem value="rust">
+                Rust
+              </CodeBlockLanguageSelectorItem>
+            </CodeBlockLanguageSelectorContent>
+          </CodeBlockLanguageSelector>
+          <CodeBlockActions>
+            <CodeBlockCopyButton />
+          </CodeBlockActions>
+        </CodeBlockHeader>
+      </CodeBlock>
+    </div>
+  );
+}

--- a/packages/ghost-ui/src/components/docs/examples/conversation/with-messages.tsx
+++ b/packages/ghost-ui/src/components/docs/examples/conversation/with-messages.tsx
@@ -1,0 +1,48 @@
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from "@/components/ai-elements/conversation";
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from "@/components/ai-elements/message";
+
+const messages = [
+  { id: "1", role: "user" as const, text: "What is TypeScript?" },
+  {
+    id: "2",
+    role: "assistant" as const,
+    text: "TypeScript is a strongly-typed superset of JavaScript developed by Microsoft. It adds optional static type checking, interfaces, enums, and other features that help catch errors at compile time rather than at runtime.",
+  },
+  { id: "3", role: "user" as const, text: "How does it compare to Flow?" },
+  {
+    id: "4",
+    role: "assistant" as const,
+    text: "Both TypeScript and Flow add static types to JavaScript, but they differ in key ways:\n\n- **Adoption**: TypeScript has much wider community adoption and tooling support.\n- **Type system**: TypeScript uses a structural type system; Flow also uses structural typing but with some nominal typing features.\n- **Tooling**: TypeScript ships its own compiler (`tsc`), while Flow relies on Babel for compilation.\n- **Ecosystem**: TypeScript has DefinitelyTyped with type definitions for thousands of packages.",
+  },
+];
+
+export default function ConversationWithMessages() {
+  return (
+    <div className="h-[400px] rounded-lg border">
+      <Conversation>
+        <ConversationContent>
+          {messages.map((msg) => (
+            <Message key={msg.id} from={msg.role}>
+              <MessageContent>
+                {msg.role === "assistant" ? (
+                  <MessageResponse>{msg.text}</MessageResponse>
+                ) : (
+                  <p>{msg.text}</p>
+                )}
+              </MessageContent>
+            </Message>
+          ))}
+        </ConversationContent>
+        <ConversationScrollButton />
+      </Conversation>
+    </div>
+  );
+}

--- a/packages/ghost-ui/src/components/docs/examples/message/streaming.tsx
+++ b/packages/ghost-ui/src/components/docs/examples/message/streaming.tsx
@@ -1,0 +1,29 @@
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from "@/components/ai-elements/message";
+import { Shimmer } from "@/components/ai-elements/shimmer";
+
+export default function MessageStreaming() {
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <Message from="user">
+        <MessageContent>
+          <p>Explain quantum entanglement in simple terms.</p>
+        </MessageContent>
+      </Message>
+
+      <Message from="assistant">
+        <MessageContent>
+          <MessageResponse isAnimating>
+            {`Quantum entanglement is when two particles become linked so that measuring one instantly affects the other, no matter how far apart they are. Einstein called it "spooky action at a distance."`}
+          </MessageResponse>
+          <Shimmer className="text-sm text-muted-foreground" duration={1.5}>
+            Generating...
+          </Shimmer>
+        </MessageContent>
+      </Message>
+    </div>
+  );
+}

--- a/packages/ghost-ui/src/components/docs/examples/message/with-actions.tsx
+++ b/packages/ghost-ui/src/components/docs/examples/message/with-actions.tsx
@@ -1,0 +1,42 @@
+import { CopyIcon, RefreshCwIcon, ThumbsDownIcon, ThumbsUpIcon } from "lucide-react";
+import {
+  Message,
+  MessageActions,
+  MessageAction,
+  MessageContent,
+  MessageResponse,
+} from "@/components/ai-elements/message";
+
+export default function MessageWithActions() {
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <Message from="user">
+        <MessageContent>
+          <p>How do I center a div?</p>
+        </MessageContent>
+      </Message>
+
+      <Message from="assistant">
+        <MessageContent>
+          <MessageResponse>
+            {`You can center a div using **flexbox**:\n\n\`\`\`css\n.parent {\n  display: flex;\n  align-items: center;\n  justify-content: center;\n}\n\`\`\`\n\nOr use **grid**:\n\n\`\`\`css\n.parent {\n  display: grid;\n  place-items: center;\n}\n\`\`\``}
+          </MessageResponse>
+        </MessageContent>
+        <MessageActions>
+          <MessageAction tooltip="Copy">
+            <CopyIcon className="size-3.5" />
+          </MessageAction>
+          <MessageAction tooltip="Regenerate">
+            <RefreshCwIcon className="size-3.5" />
+          </MessageAction>
+          <MessageAction tooltip="Good response">
+            <ThumbsUpIcon className="size-3.5" />
+          </MessageAction>
+          <MessageAction tooltip="Bad response">
+            <ThumbsDownIcon className="size-3.5" />
+          </MessageAction>
+        </MessageActions>
+      </Message>
+    </div>
+  );
+}

--- a/packages/ghost-ui/src/components/docs/examples/message/with-actions.tsx
+++ b/packages/ghost-ui/src/components/docs/examples/message/with-actions.tsx
@@ -1,8 +1,13 @@
-import { CopyIcon, RefreshCwIcon, ThumbsDownIcon, ThumbsUpIcon } from "lucide-react";
+import {
+  CopyIcon,
+  RefreshCwIcon,
+  ThumbsDownIcon,
+  ThumbsUpIcon,
+} from "lucide-react";
 import {
   Message,
-  MessageActions,
   MessageAction,
+  MessageActions,
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";

--- a/packages/ghost-ui/src/components/docs/examples/prompt-input/with-attachments.tsx
+++ b/packages/ghost-ui/src/components/docs/examples/prompt-input/with-attachments.tsx
@@ -1,9 +1,9 @@
 import {
   PromptInput,
-  PromptInputTextarea,
+  PromptInputActionAddAttachments,
   PromptInputFooter,
   PromptInputSubmit,
-  PromptInputActionAddAttachments,
+  PromptInputTextarea,
   PromptInputTools,
 } from "@/components/ai-elements/prompt-input";
 

--- a/packages/ghost-ui/src/components/docs/examples/prompt-input/with-attachments.tsx
+++ b/packages/ghost-ui/src/components/docs/examples/prompt-input/with-attachments.tsx
@@ -1,0 +1,31 @@
+import {
+  PromptInput,
+  PromptInputTextarea,
+  PromptInputFooter,
+  PromptInputSubmit,
+  PromptInputActionAddAttachments,
+  PromptInputTools,
+} from "@/components/ai-elements/prompt-input";
+
+export default function PromptInputWithAttachments() {
+  return (
+    <div className="w-full max-w-xl mx-auto p-4">
+      <PromptInput
+        accept="image/*,.pdf,.txt"
+        maxFiles={5}
+        maxFileSize={10 * 1024 * 1024}
+        onSubmit={(msg) => {
+          console.log("Submitted:", msg);
+        }}
+      >
+        <PromptInputTextarea placeholder="Describe your task or attach files..." />
+        <PromptInputFooter>
+          <PromptInputTools>
+            <PromptInputActionAddAttachments />
+          </PromptInputTools>
+          <PromptInputSubmit />
+        </PromptInputFooter>
+      </PromptInput>
+    </div>
+  );
+}

--- a/packages/ghost-ui/src/components/docs/primitives/calendar-demo.tsx
+++ b/packages/ghost-ui/src/components/docs/primitives/calendar-demo.tsx
@@ -40,7 +40,7 @@ export function CalendarDemo() {
         selected={range}
         onSelect={setRange}
         numberOfMonths={3}
-        className="hidden rounded-md border @4xl:flex [&>div]:gap-5"
+        className="hidden rounded-md border @2xl:flex [&>div]:gap-5"
       />
     </div>
   );

--- a/packages/ghost-ui/src/components/docs/primitives/carousel-demo.tsx
+++ b/packages/ghost-ui/src/components/docs/primitives/carousel-demo.tsx
@@ -11,7 +11,7 @@ import {
 
 export function CarouselDemo() {
   return (
-    <div className="hidden w-full flex-col items-center gap-4 @4xl:flex">
+    <div className="flex w-full flex-col items-center gap-4">
       <Carousel className="max-w-sm *:data-[slot=carousel-next]:hidden *:data-[slot=carousel-previous]:hidden *:data-[slot=carousel-next]:md:inline-flex *:data-[slot=carousel-previous]:md:inline-flex">
         <CarouselContent>
           {Array.from({ length: 5 }).map((_, index) => (

--- a/packages/ghost-ui/src/lib/component-docs.ts
+++ b/packages/ghost-ui/src/lib/component-docs.ts
@@ -1,0 +1,659 @@
+export type PropDef = {
+  name: string;
+  type: string;
+  default?: string;
+  description: string;
+};
+
+export type ExampleMeta = {
+  name: string;
+  title: string;
+  description?: string;
+};
+
+export type ComponentDoc = {
+  description: string;
+  usage: string;
+  props: PropDef[];
+  composedWith: string[];
+  examples: ExampleMeta[];
+};
+
+const docs: Record<string, ComponentDoc> = {
+  message: {
+    description:
+      "Renders a single chat message with support for markdown streaming, actions, and branching.",
+    usage: `import {
+  Message,
+  MessageContent,
+  MessageResponse,
+  MessageActions,
+  MessageAction,
+} from "@/components/ai-elements/message";
+
+<Message from="assistant">
+  <MessageContent>
+    <MessageResponse>Hello, how can I help?</MessageResponse>
+  </MessageContent>
+  <MessageActions>
+    <MessageAction tooltip="Copy">
+      <CopyIcon className="size-3.5" />
+    </MessageAction>
+  </MessageActions>
+</Message>`,
+    props: [
+      {
+        name: "from",
+        type: '"user" | "assistant" | "system"',
+        description: "The role of the message sender, controls alignment and styling.",
+      },
+      {
+        name: "children",
+        type: "ReactNode",
+        description: "Message sub-components (MessageContent, MessageActions, etc.).",
+      },
+    ],
+    composedWith: [
+      "conversation",
+      "prompt-input",
+      "reasoning",
+      "chain-of-thought",
+      "code-block",
+    ],
+    examples: [
+      {
+        name: "with-actions",
+        title: "With Actions",
+        description: "Message with copy and regenerate action buttons.",
+      },
+      {
+        name: "streaming",
+        title: "Streaming Response",
+        description: "Message with an animated streaming indicator.",
+      },
+    ],
+  },
+  conversation: {
+    description:
+      "A scrollable container that auto-sticks to the bottom as new messages arrive.",
+    usage: `import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from "@/components/ai-elements/conversation";
+
+<Conversation>
+  <ConversationContent>
+    {messages.map((msg) => (
+      <Message key={msg.id} from={msg.role}>...</Message>
+    ))}
+  </ConversationContent>
+  <ConversationScrollButton />
+</Conversation>`,
+    props: [
+      {
+        name: "initial",
+        type: '"smooth" | "instant" | "auto"',
+        default: '"smooth"',
+        description: "Scroll behavior when the component first mounts.",
+      },
+      {
+        name: "resize",
+        type: '"smooth" | "instant" | "auto"',
+        default: '"smooth"',
+        description: "Scroll behavior when content resizes.",
+      },
+    ],
+    composedWith: ["message", "prompt-input", "reasoning"],
+    examples: [
+      {
+        name: "with-messages",
+        title: "With Messages",
+        description: "Conversation with multiple user and assistant messages.",
+      },
+    ],
+  },
+  "prompt-input": {
+    description:
+      "A composable prompt input form with file attachments, commands, screenshots, and submit handling.",
+    usage: `import {
+  PromptInput,
+  PromptInputTextarea,
+  PromptInputActions,
+} from "@/components/ai-elements/prompt-input";
+
+<PromptInput onSubmit={(msg) => console.log(msg)}>
+  <PromptInputTextarea placeholder="Ask anything..." />
+  <PromptInputSubmit />
+</PromptInput>`,
+    props: [
+      {
+        name: "onSubmit",
+        type: "(message: PromptInputMessage, event: FormEvent) => void | Promise<void>",
+        description: "Called when the user submits the prompt.",
+      },
+      {
+        name: "accept",
+        type: "string",
+        description: 'MIME filter for file attachments, e.g. "image/*".',
+      },
+      {
+        name: "maxFiles",
+        type: "number",
+        description: "Maximum number of attachable files.",
+      },
+      {
+        name: "maxFileSize",
+        type: "number",
+        description: "Maximum file size in bytes.",
+      },
+      {
+        name: "globalDrop",
+        type: "boolean",
+        default: "false",
+        description: "Accept file drops anywhere on the document.",
+      },
+    ],
+    composedWith: ["conversation", "message", "attachments"],
+    examples: [
+      {
+        name: "with-attachments",
+        title: "With Attachments",
+        description: "PromptInput showing file attachment controls.",
+      },
+    ],
+  },
+  reasoning: {
+    description:
+      "A collapsible thinking indicator that auto-opens during streaming and auto-closes when done.",
+    usage: `import {
+  Reasoning,
+  ReasoningTrigger,
+  ReasoningContent,
+} from "@/components/ai-elements/reasoning";
+
+<Reasoning isStreaming={false} duration={12}>
+  <ReasoningTrigger />
+  <ReasoningContent>The model's internal reasoning text...</ReasoningContent>
+</Reasoning>`,
+    props: [
+      {
+        name: "isStreaming",
+        type: "boolean",
+        default: "false",
+        description: "Whether the model is currently generating reasoning tokens.",
+      },
+      {
+        name: "duration",
+        type: "number",
+        description: "Elapsed thinking time in seconds, shown in the trigger label.",
+      },
+      {
+        name: "open",
+        type: "boolean",
+        description: "Controlled open state.",
+      },
+      {
+        name: "defaultOpen",
+        type: "boolean",
+        description: "Initial open state when uncontrolled.",
+      },
+    ],
+    composedWith: ["message", "conversation", "chain-of-thought"],
+    examples: [],
+  },
+  "chain-of-thought": {
+    description:
+      "Displays a step-by-step breakdown of an AI model's reasoning process with collapsible detail.",
+    usage: `import {
+  ChainOfThought,
+  ChainOfThoughtHeader,
+  ChainOfThoughtContent,
+  ChainOfThoughtStep,
+} from "@/components/ai-elements/chain-of-thought";
+
+<ChainOfThought>
+  <ChainOfThoughtHeader>Reasoning steps</ChainOfThoughtHeader>
+  <ChainOfThoughtContent>
+    <ChainOfThoughtStep label="Analyzing query" status="complete" />
+    <ChainOfThoughtStep label="Searching docs" status="active" />
+  </ChainOfThoughtContent>
+</ChainOfThought>`,
+    props: [
+      {
+        name: "open",
+        type: "boolean",
+        description: "Controlled open state of the collapsible.",
+      },
+      {
+        name: "defaultOpen",
+        type: "boolean",
+        default: "false",
+        description: "Initial open state when uncontrolled.",
+      },
+      {
+        name: "onOpenChange",
+        type: "(open: boolean) => void",
+        description: "Called when the open state changes.",
+      },
+    ],
+    composedWith: ["message", "reasoning", "conversation"],
+    examples: [],
+  },
+  "code-block": {
+    description:
+      "Syntax-highlighted code viewer powered by Shiki with copy-to-clipboard, line numbers, and language selection.",
+    usage: `import {
+  CodeBlock,
+  CodeBlockHeader,
+  CodeBlockActions,
+  CodeBlockCopyButton,
+} from "@/components/ai-elements/code-block";
+
+<CodeBlock code="console.log('hello')" language="typescript">
+  <CodeBlockHeader>
+    <span className="text-xs font-mono">example.ts</span>
+    <CodeBlockActions>
+      <CodeBlockCopyButton />
+    </CodeBlockActions>
+  </CodeBlockHeader>
+</CodeBlock>`,
+    props: [
+      {
+        name: "code",
+        type: "string",
+        description: "The source code string to highlight and display.",
+      },
+      {
+        name: "language",
+        type: "BundledLanguage",
+        description: 'The programming language for syntax highlighting (e.g. "tsx", "python").',
+      },
+      {
+        name: "showLineNumbers",
+        type: "boolean",
+        default: "false",
+        description: "Whether to display line numbers in the gutter.",
+      },
+    ],
+    composedWith: ["message", "artifact", "terminal"],
+    examples: [
+      {
+        name: "with-diff",
+        title: "Multi-Language",
+        description: "CodeBlock with a language selector for multiple snippets.",
+      },
+    ],
+  },
+  agent: {
+    description:
+      "Displays an AI agent configuration card with name, model, instructions, tools, and output schema.",
+    usage: `import {
+  Agent,
+  AgentHeader,
+  AgentContent,
+  AgentInstructions,
+} from "@/components/ai-elements/agent";
+
+<Agent>
+  <AgentHeader name="Research Agent" model="gpt-4o" />
+  <AgentContent>
+    <AgentInstructions>Find relevant papers on the topic.</AgentInstructions>
+  </AgentContent>
+</Agent>`,
+    props: [
+      {
+        name: "children",
+        type: "ReactNode",
+        description: "Agent sub-components (AgentHeader, AgentContent, AgentTools, etc.).",
+      },
+    ],
+    composedWith: ["code-block", "message"],
+    examples: [],
+  },
+  terminal: {
+    description:
+      "A terminal emulator view with ANSI color support, auto-scroll, copy, and clear actions.",
+    usage: `import {
+  Terminal,
+  TerminalHeader,
+  TerminalTitle,
+  TerminalContent,
+} from "@/components/ai-elements/terminal";
+
+<Terminal output="$ npm install\\n\\nup to date in 0.5s" />`,
+    props: [
+      {
+        name: "output",
+        type: "string",
+        description: "The terminal output string, supports ANSI escape codes.",
+      },
+      {
+        name: "isStreaming",
+        type: "boolean",
+        default: "false",
+        description: "Shows a blinking cursor when true.",
+      },
+      {
+        name: "autoScroll",
+        type: "boolean",
+        default: "true",
+        description: "Automatically scroll to the bottom when output changes.",
+      },
+      {
+        name: "onClear",
+        type: "() => void",
+        description: "Callback to clear the terminal; enables the clear button when provided.",
+      },
+    ],
+    composedWith: ["code-block", "agent", "message"],
+    examples: [],
+  },
+  "file-tree": {
+    description:
+      "An interactive file system tree with expandable folders, file selection, and custom icons.",
+    usage: `import {
+  FileTree,
+  FileTreeFolder,
+  FileTreeFile,
+} from "@/components/ai-elements/file-tree";
+
+<FileTree defaultExpanded={new Set(["src"])}>
+  <FileTreeFolder path="src" name="src">
+    <FileTreeFile path="src/index.ts" name="index.ts" />
+  </FileTreeFolder>
+</FileTree>`,
+    props: [
+      {
+        name: "expanded",
+        type: "Set<string>",
+        description: "Controlled set of expanded folder paths.",
+      },
+      {
+        name: "defaultExpanded",
+        type: "Set<string>",
+        description: "Initial set of expanded folder paths when uncontrolled.",
+      },
+      {
+        name: "selectedPath",
+        type: "string",
+        description: "The currently selected file or folder path.",
+      },
+      {
+        name: "onSelect",
+        type: "(path: string) => void",
+        description: "Called when a file or folder is selected.",
+      },
+    ],
+    composedWith: ["artifact", "code-block"],
+    examples: [],
+  },
+  artifact: {
+    description:
+      "A panel container for generated content with a header, close button, actions, and scrollable body.",
+    usage: `import {
+  Artifact,
+  ArtifactHeader,
+  ArtifactTitle,
+  ArtifactContent,
+  ArtifactClose,
+} from "@/components/ai-elements/artifact";
+
+<Artifact>
+  <ArtifactHeader>
+    <ArtifactTitle>Generated Code</ArtifactTitle>
+    <ArtifactClose onClick={handleClose} />
+  </ArtifactHeader>
+  <ArtifactContent>...</ArtifactContent>
+</Artifact>`,
+    props: [
+      {
+        name: "children",
+        type: "ReactNode",
+        description: "Artifact sub-components (ArtifactHeader, ArtifactContent, etc.).",
+      },
+    ],
+    composedWith: ["code-block", "file-tree", "message"],
+    examples: [],
+  },
+  context: {
+    description:
+      "A hover card displaying model context window usage, token breakdown, and cost estimation.",
+    usage: `import {
+  Context,
+  ContextTrigger,
+  ContextContent,
+  ContextContentHeader,
+} from "@/components/ai-elements/context";
+
+<Context usedTokens={4000} maxTokens={8000}>
+  <ContextTrigger />
+  <ContextContent>
+    <ContextContentHeader />
+  </ContextContent>
+</Context>`,
+    props: [
+      {
+        name: "usedTokens",
+        type: "number",
+        description: "Number of tokens used in the current context window.",
+      },
+      {
+        name: "maxTokens",
+        type: "number",
+        description: "Maximum token capacity of the model.",
+      },
+      {
+        name: "usage",
+        type: "LanguageModelUsage",
+        description: "Detailed token usage breakdown (input, output, reasoning, cache).",
+      },
+      {
+        name: "modelId",
+        type: "string",
+        description: "Model identifier used for cost estimation via tokenlens.",
+      },
+    ],
+    composedWith: ["prompt-input", "conversation"],
+    examples: [],
+  },
+  plan: {
+    description:
+      "A collapsible card showing an AI-generated plan with streaming shimmer support.",
+    usage: `import {
+  Plan,
+  PlanHeader,
+  PlanTitle,
+  PlanDescription,
+  PlanContent,
+} from "@/components/ai-elements/plan";
+
+<Plan defaultOpen>
+  <PlanHeader>
+    <PlanTitle>Implementation Plan</PlanTitle>
+    <PlanDescription>3 steps to complete the task</PlanDescription>
+  </PlanHeader>
+  <PlanContent>...</PlanContent>
+</Plan>`,
+    props: [
+      {
+        name: "isStreaming",
+        type: "boolean",
+        default: "false",
+        description: "Enables shimmer animation on title and description while streaming.",
+      },
+      {
+        name: "open",
+        type: "boolean",
+        description: "Controlled collapsed/expanded state.",
+      },
+      {
+        name: "defaultOpen",
+        type: "boolean",
+        description: "Initial open state when uncontrolled.",
+      },
+    ],
+    composedWith: ["message", "conversation", "chain-of-thought"],
+    examples: [],
+  },
+  button: {
+    description:
+      "A versatile button with multiple visual variants, sizes, and an icon-only appearance mode.",
+    usage: `import { Button } from "@/components/ui/button";
+
+<Button variant="default" size="default">Click me</Button>`,
+    props: [
+      {
+        name: "variant",
+        type: '"default" | "destructive" | "outline" | "secondary" | "ghost" | "link"',
+        default: '"default"',
+        description: "Visual style of the button.",
+      },
+      {
+        name: "size",
+        type: '"default" | "sm" | "lg" | "icon" | "icon-xs" | "icon-sm"',
+        default: '"default"',
+        description: "Size preset controlling height and padding.",
+      },
+      {
+        name: "appearance",
+        type: '"default" | "icon"',
+        default: '"default"',
+        description: 'Set to "icon" for square icon-only buttons that scale with size.',
+      },
+      {
+        name: "asChild",
+        type: "boolean",
+        default: "false",
+        description: "Merge props onto child element instead of rendering a <button>.",
+      },
+    ],
+    composedWith: ["dialog", "card"],
+    examples: [],
+  },
+  card: {
+    description:
+      "A content container with header, title, description, body, action slot, and footer sections.",
+    usage: `import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+
+<Card>
+  <CardHeader>
+    <CardTitle>Card Title</CardTitle>
+    <CardDescription>Card description text.</CardDescription>
+  </CardHeader>
+  <CardContent>Body content here.</CardContent>
+</Card>`,
+    props: [
+      {
+        name: "children",
+        type: "ReactNode",
+        description: "Card sub-components (CardHeader, CardContent, CardFooter, etc.).",
+      },
+    ],
+    composedWith: ["button", "dialog"],
+    examples: [],
+  },
+  dialog: {
+    description:
+      "A modal dialog overlay with title, description, header/footer sections, and close button.",
+    usage: `import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+<Dialog>
+  <DialogTrigger asChild>
+    <Button variant="outline">Open</Button>
+  </DialogTrigger>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>Dialog Title</DialogTitle>
+      <DialogDescription>Description text.</DialogDescription>
+    </DialogHeader>
+  </DialogContent>
+</Dialog>`,
+    props: [
+      {
+        name: "open",
+        type: "boolean",
+        description: "Controlled open state of the dialog.",
+      },
+      {
+        name: "onOpenChange",
+        type: "(open: boolean) => void",
+        description: "Called when the dialog open state changes.",
+      },
+    ],
+    composedWith: ["button", "card"],
+    examples: [],
+  },
+  input: {
+    description:
+      "A styled text input with focus ring, validation states, and file input support.",
+    usage: `import { Input } from "@/components/ui/input";
+
+<Input type="text" placeholder="Enter text..." />`,
+    props: [
+      {
+        name: "type",
+        type: "string",
+        default: '"text"',
+        description: "HTML input type attribute.",
+      },
+      {
+        name: "placeholder",
+        type: "string",
+        description: "Placeholder text shown when empty.",
+      },
+    ],
+    composedWith: ["button", "label"],
+    examples: [],
+  },
+  tabs: {
+    description:
+      "A tabbed interface for switching between panels of related content.",
+    usage: `import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+
+<Tabs defaultValue="tab1">
+  <TabsList>
+    <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+    <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+  </TabsList>
+  <TabsContent value="tab1">Content 1</TabsContent>
+  <TabsContent value="tab2">Content 2</TabsContent>
+</Tabs>`,
+    props: [
+      {
+        name: "defaultValue",
+        type: "string",
+        description: "The value of the tab that should be active by default.",
+      },
+      {
+        name: "value",
+        type: "string",
+        description: "Controlled active tab value.",
+      },
+      {
+        name: "onValueChange",
+        type: "(value: string) => void",
+        description: "Called when the active tab changes.",
+      },
+    ],
+    composedWith: ["card"],
+    examples: [],
+  },
+};
+
+export function getComponentDoc(slug: string): ComponentDoc | undefined {
+  return docs[slug];
+}

--- a/packages/ghost-ui/src/lib/component-docs.ts
+++ b/packages/ghost-ui/src/lib/component-docs.ts
@@ -45,12 +45,14 @@ const docs: Record<string, ComponentDoc> = {
       {
         name: "from",
         type: '"user" | "assistant" | "system"',
-        description: "The role of the message sender, controls alignment and styling.",
+        description:
+          "The role of the message sender, controls alignment and styling.",
       },
       {
         name: "children",
         type: "ReactNode",
-        description: "Message sub-components (MessageContent, MessageActions, etc.).",
+        description:
+          "Message sub-components (MessageContent, MessageActions, etc.).",
       },
     ],
     composedWith: [
@@ -181,12 +183,14 @@ const docs: Record<string, ComponentDoc> = {
         name: "isStreaming",
         type: "boolean",
         default: "false",
-        description: "Whether the model is currently generating reasoning tokens.",
+        description:
+          "Whether the model is currently generating reasoning tokens.",
       },
       {
         name: "duration",
         type: "number",
-        description: "Elapsed thinking time in seconds, shown in the trigger label.",
+        description:
+          "Elapsed thinking time in seconds, shown in the trigger label.",
       },
       {
         name: "open",
@@ -267,7 +271,8 @@ const docs: Record<string, ComponentDoc> = {
       {
         name: "language",
         type: "BundledLanguage",
-        description: 'The programming language for syntax highlighting (e.g. "tsx", "python").',
+        description:
+          'The programming language for syntax highlighting (e.g. "tsx", "python").',
       },
       {
         name: "showLineNumbers",
@@ -281,7 +286,8 @@ const docs: Record<string, ComponentDoc> = {
       {
         name: "with-diff",
         title: "Multi-Language",
-        description: "CodeBlock with a language selector for multiple snippets.",
+        description:
+          "CodeBlock with a language selector for multiple snippets.",
       },
     ],
   },
@@ -305,7 +311,8 @@ const docs: Record<string, ComponentDoc> = {
       {
         name: "children",
         type: "ReactNode",
-        description: "Agent sub-components (AgentHeader, AgentContent, AgentTools, etc.).",
+        description:
+          "Agent sub-components (AgentHeader, AgentContent, AgentTools, etc.).",
       },
     ],
     composedWith: ["code-block", "message"],
@@ -343,7 +350,8 @@ const docs: Record<string, ComponentDoc> = {
       {
         name: "onClear",
         type: "() => void",
-        description: "Callback to clear the terminal; enables the clear button when provided.",
+        description:
+          "Callback to clear the terminal; enables the clear button when provided.",
       },
     ],
     composedWith: ["code-block", "agent", "message"],
@@ -410,7 +418,8 @@ const docs: Record<string, ComponentDoc> = {
       {
         name: "children",
         type: "ReactNode",
-        description: "Artifact sub-components (ArtifactHeader, ArtifactContent, etc.).",
+        description:
+          "Artifact sub-components (ArtifactHeader, ArtifactContent, etc.).",
       },
     ],
     composedWith: ["code-block", "file-tree", "message"],
@@ -446,7 +455,8 @@ const docs: Record<string, ComponentDoc> = {
       {
         name: "usage",
         type: "LanguageModelUsage",
-        description: "Detailed token usage breakdown (input, output, reasoning, cache).",
+        description:
+          "Detailed token usage breakdown (input, output, reasoning, cache).",
       },
       {
         name: "modelId",
@@ -480,7 +490,8 @@ const docs: Record<string, ComponentDoc> = {
         name: "isStreaming",
         type: "boolean",
         default: "false",
-        description: "Enables shimmer animation on title and description while streaming.",
+        description:
+          "Enables shimmer animation on title and description while streaming.",
       },
       {
         name: "open",
@@ -519,13 +530,15 @@ const docs: Record<string, ComponentDoc> = {
         name: "appearance",
         type: '"default" | "icon"',
         default: '"default"',
-        description: 'Set to "icon" for square icon-only buttons that scale with size.',
+        description:
+          'Set to "icon" for square icon-only buttons that scale with size.',
       },
       {
         name: "asChild",
         type: "boolean",
         default: "false",
-        description: "Merge props onto child element instead of rendering a <button>.",
+        description:
+          "Merge props onto child element instead of rendering a <button>.",
       },
     ],
     composedWith: ["dialog", "card"],
@@ -553,7 +566,8 @@ const docs: Record<string, ComponentDoc> = {
       {
         name: "children",
         type: "ReactNode",
-        description: "Card sub-components (CardHeader, CardContent, CardFooter, etc.).",
+        description:
+          "Card sub-components (CardHeader, CardContent, CardFooter, etc.).",
       },
     ],
     composedWith: ["button", "dialog"],


### PR DESCRIPTION
## Summary
- Added description, usage snippet, props table, composition links, and examples sections to component doc pages
- Install command now uses full Ghost registry URL (`--registry https://block.github.io/ghost/r/registry.json`)
- Component page content centered at `max-w-3xl` for better readability
- Prev/next navigation floats on sides at `xl+`, falls back to bottom bar
- Fixed carousel and calendar demos hidden by container query breakpoints
- Removed AI badge from component headers
- Initial docs for 17 priority components (12 AI + 5 primitives)

## Test plan
- [x] `/ui/components/message` — all new sections visible (description, usage, props, works with, examples)
- [x] `/ui/components/separator` — no new sections, no errors
- [x] Install command shows full registry URL
- [x] Floating side nav visible at xl+ viewport
- [x] Bottom nav visible below xl
- [x] Carousel and calendar demos render
- [x] Mobile layout intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)