### PR TITLE
Add handoffs frontmatter to skill bundle recipes

### DIFF
--- a/packages/ghost-cli/src/skill-bundle/references/compare.md
+++ b/packages/ghost-cli/src/skill-bundle/references/compare.md
@@ -1,3 +1,18 @@
+---
+name: compare
+description: Interpret ghost compare output — pairwise distance or fleet analysis.
+handoffs:
+  - label: Accept the drift as aligned reality
+    command: ghost ack
+    prompt: Accept current drift across the board
+  - label: Adopt the other fingerprint as a new parent baseline
+    command: ghost adopt
+    prompt: Adopt the other fingerprint.md as the new parent baseline
+  - label: Declare a dimension intentionally divergent
+    command: ghost diverge
+    prompt: Record an intentional divergence on a specific dimension
+---
+
 # Recipe: Compare fingerprints
 
 **Goal:** answer "how different are these design systems?" or "how has ours drifted over time?"

--- a/packages/ghost-cli/src/skill-bundle/references/discover.md
+++ b/packages/ghost-cli/src/skill-bundle/references/discover.md
@@ -1,3 +1,15 @@
+---
+name: discover
+description: Find public design systems matching a query — for benchmarking, inspiration, or adoption.
+handoffs:
+  - label: Profile a discovered system into its own fingerprint.md
+    skill: profile
+    prompt: Profile the discovered system into a fingerprint.md under discovered/
+  - label: Compare my fingerprint against a discovered system
+    skill: compare
+    prompt: Compare my fingerprint.md against the discovered system's fingerprint with --semantic
+---
+
 # Recipe: Discover public design systems
 
 **Goal:** find public design systems matching a query — for benchmarking, inspiration, or competitive analysis.

--- a/packages/ghost-cli/src/skill-bundle/references/generate.md
+++ b/packages/ghost-cli/src/skill-bundle/references/generate.md
@@ -1,3 +1,12 @@
+---
+name: generate
+description: Produce UI code that lives within fingerprint.md bounds.
+handoffs:
+  - label: Verify the generated UI matches the fingerprint
+    skill: verify
+    prompt: Verify the UI I just generated against fingerprint.md
+---
+
 # Recipe: Generate UI from a fingerprint.md
 
 **Goal:** produce a UI artifact (component, page, snippet) that lives within the `fingerprint.md` boundaries.

--- a/packages/ghost-cli/src/skill-bundle/references/profile.md
+++ b/packages/ghost-cli/src/skill-bundle/references/profile.md
@@ -1,3 +1,15 @@
+---
+name: profile
+description: Write fingerprint.md from a project's design sources.
+handoffs:
+  - label: Compare against a parent or peer fingerprint
+    skill: compare
+    prompt: Compare the fingerprint.md I just wrote against a parent or peer
+  - label: Emit a project-scoped drift review command
+    command: ghost emit review-command
+    prompt: Emit a per-project review command derived from this fingerprint.md
+---
+
 # Recipe: Profile a project into fingerprint.md
 
 **Goal:** produce a valid `fingerprint.md` that captures the project's visual language. Ghost's CLI does not call an LLM for this — you, the host agent, explore the repo and synthesize the result, then hand it to `ghost lint` for validation.

--- a/packages/ghost-cli/src/skill-bundle/references/review.md
+++ b/packages/ghost-cli/src/skill-bundle/references/review.md
@@ -1,3 +1,21 @@
+---
+name: review
+description: Flag PR or working-tree changes that drift from the local fingerprint.md.
+handoffs:
+  - label: Regenerate drifting components to match the fingerprint
+    skill: verify
+    prompt: Regenerate the drifting code against fingerprint.md and re-review
+  - label: Accept the drift as aligned reality
+    command: ghost ack
+    prompt: Acknowledge that the current fingerprint.md no longer matches and record the drift
+  - label: Declare a dimension intentionally divergent
+    command: ghost diverge
+    prompt: Record an intentional divergence on a specific dimension so it stops flagging
+  - label: Adopt a new parent baseline
+    command: ghost adopt
+    prompt: Adopt the provided fingerprint.md as a new parent baseline
+---
+
 # Recipe: Review code changes for design drift
 
 **Goal:** flag frontend changes that drift from the local `fingerprint.md` and produce a review (chat summary or PR comments).

--- a/packages/ghost-cli/src/skill-bundle/references/verify.md
+++ b/packages/ghost-cli/src/skill-bundle/references/verify.md
@@ -1,3 +1,15 @@
+---
+name: verify
+description: Confirm generated UI stays within fingerprint.md bounds; iterate if not.
+handoffs:
+  - label: Regenerate with feedback from the review
+    skill: generate
+    prompt: Regenerate the UI using the review findings as constraints
+  - label: Update the fingerprint to capture an uncaptured decision
+    skill: profile
+    prompt: Add the missing decision to fingerprint.md and re-lint
+---
+
 # Recipe: Verify generated UI against the fingerprint
 
 **Goal:** confirm that generated UI (a component, a page, a variant) stays within the bounds of the local `fingerprint.md`. This is the "generate → review → iterate" loop.


### PR DESCRIPTION
## Summary

- Each recipe (`profile`, `review`, `verify`, `generate`, `compare`, `discover`) now declares its common next actions as structured frontmatter — either another recipe via `skill:` or a CLI invocation via `command:`.
- Pattern borrowed from [DirectedEdges/specs](https://github.com/DirectedEdges/specs)' agent handoff convention, adapted for Ghost's skill bundle model.
- Purely additive: the bundle loader copies files verbatim, so hosts that ignore unknown frontmatter keys see no change; hosts that read it can surface next-step actions inline.

## Handoff graph

- `profile` → `compare` (benchmark) or `ghost emit review-command` (set up drift detection)
- `review` → `verify` (regenerate to match) or `ghost ack` / `ghost diverge` / `ghost adopt` (record stance)
- `verify` → `generate` (regenerate with feedback) or `profile` (capture a missing decision)
- `generate` → `verify` (confirm the output stays in bounds)
- `compare` → `ghost ack` / `ghost adopt` / `ghost diverge`
- `discover` → `profile` / `compare`

## Notes

- `schema.md` left alone — it's a reference, not a recipe.
- No host harness currently parses the `handoffs:` key; it's documentation the host agent can read and act on. Wiring a parser would be a follow-up.

## Test plan

- [x] `pnpm check` passes (pre-push hook)
- [x] `pnpm build` passes (pre-push hook)
- [x] `pnpm test` passes — 159 tests (pre-push hook)
- [x] Manually verify `ghost emit skill <dir>` copies the updated reference files with frontmatter intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)