### PR TITLE
Build @ghost/core before docs in Pages deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,6 +32,9 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
+      - name: Build @ghost/core library
+        run: pnpm --filter @ghost/core build
+
       - name: Build @ghost/ui library
         run: pnpm --filter @ghost/ui build:lib
 


### PR DESCRIPTION
## Summary
- Pages deploy was failing because `apps/docs` imports `@ghost/core/browser` but the workflow only built `@ghost/ui` first. Without `packages/ghost-core/dist/`, tsc couldn't resolve the entry and every call into `parseFingerprint`/`lintFingerprint` collapsed to `any`.
- Adds a `Build @ghost/core library` step before the `@ghost/ui` build in `.github/workflows/deploy-pages.yml`.

## Test plan
- [ ] GitHub Pages deploy workflow succeeds on this branch
- [ ] `apps/docs` builds without TS2307 on `@ghost/core/browser`

🤖 Generated with [Claude Code](https://claude.com/claude-code)