### PR TITLE
fix(ci): pin changesets/action to a real SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - run: pnpm --filter ghost-drift build
 
       - name: Create Release PR or publish
-        uses: changesets/action@e0538b8a655baa250543a7f1f2d045e66d4ca530 # v1.5.3
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: pnpm -r publish --access public --no-git-checks
           version: pnpm changeset version


### PR DESCRIPTION
## Summary

The pin for `changesets/action` in `.github/workflows/release.yml` referenced a SHA that doesn't exist on the upstream repo. The Actions runner reported:

> Unable to resolve action `changesets/action@e0538b8a655baa250543a7f1f2d045e66d4ca530`, unable to find version `e0538b8a655baa250543a7f1f2d045e66d4ca530`

That SHA was fabricated when I wrote the workflow. This swaps it for the real SHA of `v1.7.0`, resolved against `changesets/action` on GitHub.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the Release workflow runs on the next push to `main`
- [ ] Verify it opens a "chore: version packages" PR bumping `ghost-drift` from `0.0.0` → `0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)