### PR TITLE
fix(ci): drop CLI version from cli-manifest to avoid release drift

### DIFF
--- a/apps/docs/src/generated/cli-manifest.json
+++ b/apps/docs/src/generated/cli-manifest.json
@@ -1,6 +1,5 @@
 {
-  "generatedAt": "2026-04-21T03:12:41.765Z",
-  "version": "0.0.0",
+  "generatedAt": "2026-04-21T12:40:50.343Z",
   "commands": [
     {
       "name": "compare",

--- a/scripts/dump-cli-help.mjs
+++ b/scripts/dump-cli-help.mjs
@@ -43,9 +43,13 @@ const globalOptions = cli.globalCommand.options.map((o) => ({
   default: o.config?.default ?? null,
 }));
 
+// Intentionally omits `version`: the CLI reads its version from
+// package.json at runtime, so baking it in here would make every
+// Changesets-driven version bump drift the committed manifest and
+// fail CI. Command/flag shape is what the docs render — that's the
+// only signal the drift check needs to guard.
 const manifest = {
   generatedAt: new Date().toISOString(),
-  version: cli.globalCommand.versionNumber ?? null,
   commands,
   globalOptions,
 };


### PR DESCRIPTION
## Summary

PR #41 (the Changesets "Version Packages" PR) is failing CI because \`pnpm check:cli-manifest\` reports the committed manifest as stale. Root cause: the manifest bakes in the CLI's \`version\` string, sourced from \`readPackageVersion()\` at runtime. Every version bump (which is what the Version Packages PR *is*) invalidates the manifest.

The docs site's \`<CliHelp>\` component only consumes \`manifest.commands\` — the \`version\` field was never read anywhere. Dropping it from the emitted manifest makes the manifest invariant under version bumps and unblocks the first release.

- \`scripts/dump-cli-help.mjs\` stops emitting \`version\` and adds a comment documenting why.
- \`apps/docs/src/generated/cli-manifest.json\` regenerated without the \`version\` key.

## Test plan

- [ ] Merge this PR
- [ ] Rebase PR #41 against new \`main\` (or let the Changesets workflow rebuild it automatically)
- [ ] Confirm \`pnpm check\` passes on PR #41
- [ ] Merge PR #41 → \`ghost-drift@0.1.0\` publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)