### PR TITLE
docs(ghost-drift): surface Node 18+ requirement in package README

### DIFF
--- a/.changeset/readme-requirements.md
+++ b/.changeset/readme-requirements.md
@@ -1,0 +1,5 @@
+---
+"ghost-drift": patch
+---
+
+Document the Node.js 18+ requirement in the package README so it's visible on the npm listing page without readers having to open the `engines` field in `package.json`.

--- a/packages/ghost-drift/README.md
+++ b/packages/ghost-drift/README.md
@@ -4,6 +4,10 @@
 
 `ghost-drift` captures a design language as a human-readable `fingerprint.md` (49-dim embedding + three-layer prose body) and gives any agent the primitives to detect drift against it. Judgement lives in whatever agent you already use; arithmetic lives here.
 
+## Requirements
+
+- Node.js **18+**
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a small **Requirements** section to `packages/ghost-drift/README.md` surfacing the Node 18+ minimum (already enforced by `engines.node`, just not previously discoverable on the npm page).
- Ships a `patch` changeset for `ghost-drift` that will bump `0.1.0` → `0.1.1` on the next Version Packages PR.

This PR also functions as a **CI publish smoke test**. Path:

1. Bootstrap `ghost-drift@0.1.0` to npm locally first (one-time, from off-VPN machine: `npm login && pnpm --filter ghost-drift publish --access public --provenance=false`).
2. Merge this PR.
3. Changesets workflow opens a new Version Packages PR bumping to `0.1.1`.
4. Merge that PR.
5. CI publish runs with the now-scopeable `NPM_PUBLISH_TOKEN` — if the token permissions are sorted, `0.1.1` lands on npm cleanly. If not, we see the failure mode with no cost to shipping real features.

## Test plan

- [ ] Local `ghost-drift@0.1.0` bootstrap publish completed off-VPN
- [ ] Merge this PR
- [ ] Merge the resulting Version Packages PR
- [ ] Confirm `npm view ghost-drift version` reports `0.1.1`
- [ ] Confirm a GitHub Release appears for `ghost-drift@0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)