### PR TITLE
feat(ci): add tag-triggered tarball release for ghost-drift

### DIFF
--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -35,10 +35,13 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
+      # Intentionally no `cache: pnpm` — GitHub's actions cache is shared
+      # across branches/PRs, so in a publishing workflow a poisoned cache
+      # entry could be baked into the released tarball. Install fresh each
+      # run; zizmor flags this (rule: cache-poisoning).
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
-          cache: pnpm
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -33,20 +33,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Intentionally no caching (no `cache:` on setup-node, no pnpm/action-setup
-      # which maintains its own cache store). GitHub's actions/cache is shared
-      # across branches and PRs, so in a publishing workflow a poisoned cache
-      # entry could be baked into the released tarball. We install cold each
-      # run; zizmor's cache-poisoning rule is satisfied and the extra ~30s is
-      # invisible on a release cadence.
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22
-
-      # Corepack ships with Node and reads `packageManager` from the root
-      # package.json to install the exact pnpm version the repo pins —
-      # no registry action, no implicit cache.
-      - run: corepack enable
+      # No setup-node and no pnpm/action-setup — both would trip zizmor's
+      # cache-poisoning rule because any GitHub-official setup action is
+      # treated as cache-capable regardless of whether caching is enabled.
+      # ubuntu-latest ships Node 20 + corepack, which satisfies our
+      # engines.node (>=18). Corepack reads `packageManager` from root
+      # package.json to install the exact pinned pnpm version with no
+      # cross-branch cache store.
+      - run: node --version && corepack enable
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -33,15 +33,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      # Intentionally no `cache: pnpm` — GitHub's actions cache is shared
-      # across branches/PRs, so in a publishing workflow a poisoned cache
-      # entry could be baked into the released tarball. Install fresh each
-      # run; zizmor flags this (rule: cache-poisoning).
+      # Intentionally no caching (no `cache:` on setup-node, no pnpm/action-setup
+      # which maintains its own cache store). GitHub's actions/cache is shared
+      # across branches and PRs, so in a publishing workflow a poisoned cache
+      # entry could be baked into the released tarball. We install cold each
+      # run; zizmor's cache-poisoning rule is satisfied and the extra ~30s is
+      # invisible on a release cadence.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
+
+      # Corepack ships with Node and reads `packageManager` from the root
+      # package.json to install the exact pnpm version the repo pins —
+      # no registry action, no implicit cache.
+      - run: corepack enable
 
       - run: pnpm install --frozen-lockfile
 
@@ -51,21 +56,29 @@ jobs:
       - name: Pack
         run: pnpm --filter ghost-drift pack
 
+      # Resolve the release tag. Inputs from workflow_dispatch are attacker-
+      # controlled (anyone with Actions write can trigger). Pass them in via
+      # `env:` and reference as shell variables so they can't be interpolated
+      # as shell syntax — that's what the semgrep shell-injection rule wants.
       - name: Resolve tag
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            TAG="${GITHUB_REF_NAME}"
+          if [ "$EVENT_NAME" = "push" ]; then
+            TAG="$GITHUB_REF_NAME"
           else
-            TAG="ghost-drift@${{ inputs.version }}"
+            TAG="ghost-drift@$INPUT_VERSION"
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          gh release create "${{ steps.tag.outputs.tag }}" \
-            --title "${{ steps.tag.outputs.tag }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --generate-notes \
             packages/ghost-drift/ghost-drift-*.tgz

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -1,0 +1,68 @@
+name: Publish tarball to GitHub Release
+
+# Temporary distribution channel while npm publish is blocked. Packs
+# ghost-drift and attaches the .tgz to a GitHub Release, so consumers can:
+#
+#   npm install https://github.com/block/ghost/releases/download/<tag>/<file>.tgz
+#
+# Triggered by pushing a tag of the form `ghost-drift@<version>` or by
+# manual workflow_dispatch.
+
+on:
+  push:
+    tags:
+      - "ghost-drift@*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (must match packages/ghost-drift/package.json)"
+        required: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: tarball-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tarball:
+    name: Pack and release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm --filter ghost-drift build
+
+      - name: Pack
+        run: pnpm --filter ghost-drift pack
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          else
+            TAG="ghost-drift@${{ inputs.version }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            --title "${{ steps.tag.outputs.tag }}" \
+            --generate-notes \
+            packages/ghost-drift/ghost-drift-*.tgz

--- a/packages/ghost-drift/README.md
+++ b/packages/ghost-drift/README.md
@@ -10,11 +10,27 @@
 
 ## Install
 
+> While `ghost-drift` is being registered on the npm public registry, the package is distributed as a tarball attached to each [GitHub Release](https://github.com/block/ghost/releases). Install directly from the release URL:
+
 ```bash
-npm i -g ghost-drift
-# or
-pnpm add -D ghost-drift
+# latest release
+npm install https://github.com/block/ghost/releases/download/ghost-drift%400.1.1/ghost-drift-0.1.1.tgz
+
+# pnpm / yarn work the same
+pnpm add https://github.com/block/ghost/releases/download/ghost-drift%400.1.1/ghost-drift-0.1.1.tgz
 ```
+
+Or pin in `package.json`:
+
+```json
+{
+  "dependencies": {
+    "ghost-drift": "https://github.com/block/ghost/releases/download/ghost-drift%400.1.1/ghost-drift-0.1.1.tgz"
+  }
+}
+```
+
+Once npm publishing is unblocked this will move to the registry — swap the URL for a plain `^0.1.1`.
 
 ## Use
 


### PR DESCRIPTION
## Summary

Distribution channel for \`ghost-drift\` while npm publishing is blocked on the org-side package-name bootstrap. Adds a tag-triggered workflow that packs the package and attaches the \`.tgz\` to a GitHub Release.

## Consumer install

```bash
npm install https://github.com/block/ghost/releases/download/ghost-drift%400.1.1/ghost-drift-0.1.1.tgz
```

Works with npm, pnpm, yarn. \`ghost-drift\` binary installs to \`node_modules/.bin\` exactly as it would from npm. Library imports (\`import { parseFingerprint } from "ghost-drift"\`) work normally.

## How to cut a release

After merge:

```bash
git tag ghost-drift@0.1.1
git push origin ghost-drift@0.1.1
```

That triggers \`.github/workflows/release-tarball.yml\`, which:
1. Builds \`ghost-drift\`
2. Runs \`pnpm --filter ghost-drift pack\`
3. Creates a GitHub Release at \`ghost-drift@0.1.1\` with auto-generated notes
4. Attaches \`ghost-drift-0.1.1.tgz\` to the release

Can also trigger manually via \`workflow_dispatch\` if needed.

## Not changed

- npm publishing workflow (\`.github/workflows/release.yml\`) left in place; once the org unblocks creation of \`ghost-drift\` on npm, it takes over and this tarball channel can be deprecated.
- Changesets flow stays the same — version bumps land in \`packages/ghost-drift/package.json\` via Version Packages PRs.

## Test plan

- [ ] Merge this PR
- [ ] \`git tag ghost-drift@0.1.1 && git push origin ghost-drift@0.1.1\`
- [ ] Confirm workflow runs and creates a release at https://github.com/block/ghost/releases/tag/ghost-drift%400.1.1
- [ ] \`npm install <release-url>\` in a throwaway project, verify \`ghost-drift --help\` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)