### PR TITLE
feat(ghost-drift): support token references in role palette fields

### DIFF
--- a/.changeset/role-token-references.md
+++ b/.changeset/role-token-references.md
@@ -1,0 +1,5 @@
+---
+"ghost-drift": minor
+---
+
+Role palette fields accept `{palette.dominant.<role>}` and `{palette.semantic.<role>}` references, so renames in the palette cascade into every role that cites them. `ghost-drift lint` flags unresolved references as `broken-role-reference`.

--- a/docs/fingerprint-format.md
+++ b/docs/fingerprint-format.md
@@ -208,6 +208,25 @@ Tokens alone are ingredients: "sizes 14, 16, 20, 32, 64 exist." A role is a reci
 
 **Strictness.** The `tokens` sub-blocks are zod `.strict()` — unknown keys reject, so the schema stays disciplined as it grows. Add a field to the schema before emitting it.
 
+### Token references
+
+Role palette fields (`background`, `foreground`, `border`) may point at a named palette slot instead of inlining a raw hex. The syntax is `{<namespace>.<role>}`:
+
+```yaml
+roles:
+  - name: button
+    tokens:
+      palette:
+        background: '{palette.dominant.accent}'   # resolves to #c96442
+        foreground: '{palette.dominant.surface}'  # resolves to #f5f4ed
+        border:     '#e8e6dc'                     # raw is fine too
+    evidence: ["components/ui/button.tsx:18"]
+```
+
+**Supported namespaces:** `palette.dominant` and `palette.semantic` — the two palette blocks that already carry a `role`. Renames cascade (change the role value in one place, every role that references it updates too), and `ghost-drift lint` reports `broken-role-reference` for references that don't resolve.
+
+**What cannot be referenced.** `palette.neutrals.steps` is positional (no name). Typography, spacing, and surfaces are inventories, not named vocabularies — role tokens for those dimensions inline raw values. If a future profile recipe starts emitting a named layer on these blocks, the reference surface will grow; until then, referencing them is an unsupported-namespace error.
+
 ---
 
 ## Embedding fragment
@@ -341,6 +360,7 @@ Programmatic API (`ghost-drift`): `loadFingerprint`, `parseFingerprint`, `serial
 - **Implementation-specific tokens.** No framework names, no CSS-in-JS specifics, no component library assumptions. Decisions are abstract ("warm-only neutrals"), not concrete ("`neutral-50` in `tailwind.config.js`").
 - **Confidence theatre.** If the generator isn't sure, omit `confidence` or set `source: unknown`. Fabricated `1.0` is worse than missing.
 - **Schema migration.** Schema 1, 2, and 3 files are rejected outright. Regenerate by running the `profile` recipe in your host agent.
+- **Token references into typography / spacing / surfaces.** Those blocks are positional inventories (`sizeRamp`, `scale`, `borderRadii`) with no named slots to point at. Role tokens for those dimensions inline raw values; referencing them triggers `broken-role-reference`.
 
 ---
 

--- a/packages/ghost-drift/src/core/fingerprint/lint.ts
+++ b/packages/ghost-drift/src/core/fingerprint/lint.ts
@@ -2,6 +2,11 @@ import { parse as parseYaml } from "yaml";
 import type { Fingerprint } from "../types.js";
 import type { BodyData } from "./body.js";
 import { parseFingerprint, splitRaw } from "./parser.js";
+import {
+  formatReferenceError,
+  isTokenReference,
+  resolveTokenReference,
+} from "./references.js";
 import { FrontmatterSchema } from "./schema.js";
 
 export type LintSeverity = "error" | "warning" | "info";
@@ -67,6 +72,7 @@ export function lintFingerprint(
   checkStrayEvidenceInBody(bodyText, rawIssues);
   checkEvidenceHexes(fingerprint, rawIssues);
   checkUnusedPalette(fingerprint, rawIssues);
+  checkRoleReferences(fingerprint, rawIssues);
 
   return finalize(rawIssues, strict, off);
 }
@@ -223,4 +229,32 @@ function collectPaletteHexes(fp: Fingerprint): Set<string> {
   for (const step of fp.palette?.neutrals?.steps ?? [])
     out.add(step.toLowerCase());
   return out;
+}
+
+/**
+ * Role palette fields may reference named palette slots via `{palette.dominant.<role>}`
+ * or `{palette.semantic.<role>}`. Flag references that don't resolve — the linter
+ * catches renames in the palette that left a role pointing at nothing.
+ */
+const ROLE_PALETTE_FIELDS = ["background", "foreground", "border"] as const;
+
+function checkRoleReferences(fp: Fingerprint, issues: LintIssue[]): void {
+  const roles = fp.roles ?? [];
+  roles.forEach((role, ri) => {
+    const palette = role.tokens?.palette;
+    if (!palette) return;
+    for (const field of ROLE_PALETTE_FIELDS) {
+      const value = palette[field];
+      if (!isTokenReference(value)) continue;
+      const result = resolveTokenReference(fp, value);
+      if (result.error) {
+        issues.push({
+          severity: "error",
+          rule: "broken-role-reference",
+          message: formatReferenceError(result.error),
+          path: `roles[${ri}].tokens.palette.${field}`,
+        });
+      }
+    }
+  });
 }

--- a/packages/ghost-drift/src/core/fingerprint/references.ts
+++ b/packages/ghost-drift/src/core/fingerprint/references.ts
@@ -1,0 +1,125 @@
+import type { Fingerprint } from "../types.js";
+
+/**
+ * Role token reference syntax: `{palette.dominant.<role>}` or
+ * `{palette.semantic.<role>}`. Lets a role bind its palette to a named
+ * palette slot instead of a raw hex — renames cascade, and the linter
+ * can flag a role pointing at a palette entry that no longer exists.
+ *
+ * Only the named palette slots are referenceable in v1. Positional
+ * inventories (neutrals.steps, typography.sizeRamp, spacing.scale,
+ * surfaces.borderRadii) have no names to point at, so role tokens for
+ * those dimensions stay raw.
+ */
+
+/** Matches `{namespace.role}` where namespace contains one or more segments. */
+const REFERENCE_RE = /^\{([a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+)\}$/i;
+
+export interface ParsedTokenReference {
+  /** Full reference string, e.g. `palette.dominant.accent`. */
+  path: string;
+  /** Namespace segment, e.g. `palette.dominant`. */
+  namespace: string;
+  /** Terminal segment — the role name to look up. */
+  role: string;
+}
+
+/** True when `value` is wrapped in `{...}` and shaped like a dotted path. */
+export function isTokenReference(value: unknown): value is string {
+  return typeof value === "string" && REFERENCE_RE.test(value);
+}
+
+/** Parse `{palette.dominant.accent}` → structured form, or null if malformed. */
+export function parseTokenReference(
+  value: string,
+): ParsedTokenReference | null {
+  const match = REFERENCE_RE.exec(value);
+  if (!match) return null;
+  const path = match[1];
+  const lastDot = path.lastIndexOf(".");
+  return {
+    path,
+    namespace: path.slice(0, lastDot),
+    role: path.slice(lastDot + 1),
+  };
+}
+
+export type TokenReferenceError =
+  | { kind: "malformed"; value: string }
+  | { kind: "unsupported-namespace"; namespace: string; supported: string[] }
+  | { kind: "unknown-role"; namespace: string; role: string };
+
+export interface ResolveResult {
+  value: string | null;
+  error: TokenReferenceError | null;
+}
+
+const SUPPORTED_NAMESPACES = ["palette.dominant", "palette.semantic"];
+
+/**
+ * Resolve a `{...}` reference against a fingerprint. Returns the primitive
+ * value (hex string) when resolvable, plus a structured error describing why
+ * resolution failed otherwise. Callers that just want the value can ignore
+ * `error`; the linter uses it to report `broken-role-reference` precisely.
+ */
+export function resolveTokenReference(
+  fp: Fingerprint,
+  value: string,
+): ResolveResult {
+  const parsed = parseTokenReference(value);
+  if (!parsed) {
+    return { value: null, error: { kind: "malformed", value } };
+  }
+
+  const list = lookupNamespace(fp, parsed.namespace);
+  if (!list) {
+    return {
+      value: null,
+      error: {
+        kind: "unsupported-namespace",
+        namespace: parsed.namespace,
+        supported: SUPPORTED_NAMESPACES,
+      },
+    };
+  }
+
+  const hit = list.find((c) => c.role === parsed.role);
+  if (!hit) {
+    return {
+      value: null,
+      error: {
+        kind: "unknown-role",
+        namespace: parsed.namespace,
+        role: parsed.role,
+      },
+    };
+  }
+
+  return { value: hit.value, error: null };
+}
+
+function lookupNamespace(
+  fp: Fingerprint,
+  namespace: string,
+): { role: string; value: string }[] | null {
+  switch (namespace) {
+    case "palette.dominant":
+      return fp.palette?.dominant ?? [];
+    case "palette.semantic":
+      return fp.palette?.semantic ?? [];
+    default:
+      return null;
+  }
+}
+
+/** Human-readable message for a resolve error — used by the linter. */
+export function formatReferenceError(error: TokenReferenceError): string {
+  switch (error.kind) {
+    case "malformed":
+      return `\`${error.value}\` is not a valid token reference (expected \`{namespace.role}\`).`;
+    case "unsupported-namespace":
+      return `Reference targets \`${error.namespace}\` which is not a valid reference namespace. Supported: ${error.supported.map((n) => `\`${n}\``).join(", ")}.`;
+    case "unknown-role":
+      return `Reference \`{${error.namespace}.${error.role}}\` does not resolve — no entry with role \`${error.role}\` in \`${error.namespace}\`.`;
+  }
+}

--- a/packages/ghost-drift/src/skill-bundle/references/schema.md
+++ b/packages/ghost-drift/src/skill-bundle/references/schema.md
@@ -60,6 +60,9 @@ surfaces:
   borderUsage: moderate             # minimal | moderate | heavy
 
 # slot → token bindings (optional but strongly recommended)
+# Role palette fields may use `{palette.dominant.<role>}` or
+# `{palette.semantic.<role>}` references instead of raw hexes.
+# Other dimensions (typography, spacing, surfaces) inline raw values.
 roles:
   - name: h1
     tokens:
@@ -68,7 +71,9 @@ roles:
   - name: button
     tokens:
       surfaces: { borderRadius: 8 }
-      palette: { background: "#0066cc", foreground: "#ffffff" }
+      palette:
+        background: "{palette.dominant.accent}"
+        foreground: "{palette.dominant.surface}"
     evidence: ["src/components/button.tsx:12"]
 
 # extension bag (optional, opaque to comparisons)

--- a/packages/ghost-drift/test/fingerprint/lint.test.ts
+++ b/packages/ghost-drift/test/fingerprint/lint.test.ts
@@ -149,4 +149,73 @@ refers to a ghost color
     expect(unused.length).toBeGreaterThan(0);
     expect(unused.every((i) => i.severity === "error")).toBe(true);
   });
+
+  it("accepts a role palette reference that resolves", () => {
+    const md = build(
+      `
+roles:
+  - name: button
+    tokens:
+      palette: { background: '{palette.dominant.accent}' }
+    evidence: ["src/ui/button.tsx:12"]`,
+      "",
+    );
+    const report = lintFingerprint(md);
+    expect(report.issues.some((i) => i.rule === "broken-role-reference")).toBe(
+      false,
+    );
+  });
+
+  it("flags a role reference that points at a missing palette role", () => {
+    const md = build(
+      `
+roles:
+  - name: button
+    tokens:
+      palette: { background: '{palette.dominant.ghost}' }
+    evidence: ["src/ui/button.tsx:12"]`,
+      "",
+    );
+    const report = lintFingerprint(md);
+    const broken = report.issues.filter(
+      (i) => i.rule === "broken-role-reference",
+    );
+    expect(broken.length).toBe(1);
+    expect(broken[0].severity).toBe("error");
+    expect(broken[0].path).toBe("roles[0].tokens.palette.background");
+  });
+
+  it("flags a role reference into an unsupported namespace", () => {
+    const md = build(
+      `
+roles:
+  - name: button
+    tokens:
+      palette: { foreground: '{typography.families.primary}' }
+    evidence: ["src/ui/button.tsx:12"]`,
+      "",
+    );
+    const report = lintFingerprint(md);
+    const broken = report.issues.find(
+      (i) => i.rule === "broken-role-reference",
+    );
+    expect(broken).toBeDefined();
+    expect(broken?.message).toMatch(/palette\.dominant.*palette\.semantic/);
+  });
+
+  it("leaves raw hex values in role palette alone", () => {
+    const md = build(
+      `
+roles:
+  - name: button
+    tokens:
+      palette: { background: '#c96442' }
+    evidence: ["src/ui/button.tsx:12"]`,
+      "",
+    );
+    const report = lintFingerprint(md);
+    expect(report.issues.some((i) => i.rule === "broken-role-reference")).toBe(
+      false,
+    );
+  });
 });

--- a/packages/ghost-drift/test/fingerprint/references.test.ts
+++ b/packages/ghost-drift/test/fingerprint/references.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatReferenceError,
+  isTokenReference,
+  parseTokenReference,
+  resolveTokenReference,
+} from "../../src/core/fingerprint/references.js";
+import type { Fingerprint } from "../../src/core/types.js";
+
+function buildFingerprint(): Fingerprint {
+  return {
+    id: "x",
+    source: "llm",
+    timestamp: "2026-04-22T00:00:00Z",
+    palette: {
+      dominant: [
+        { role: "accent", value: "#c96442" },
+        { role: "surface", value: "#f5f4ed" },
+      ],
+      neutrals: { steps: ["#141413", "#4d4c48"], count: 2 },
+      semantic: [
+        { role: "error", value: "#b53333" },
+        { role: "focus", value: "#3898ec" },
+      ],
+      saturationProfile: "muted",
+      contrast: "moderate",
+    },
+    spacing: { scale: [4, 8], regularity: 1, baseUnit: 8 },
+    typography: {
+      families: ["Serif"],
+      sizeRamp: [16],
+      weightDistribution: { 400: 1 },
+      lineHeightPattern: "normal",
+    },
+    surfaces: {
+      borderRadii: [8],
+      shadowComplexity: "subtle",
+      borderUsage: "moderate",
+    },
+    embedding: [],
+  };
+}
+
+describe("isTokenReference", () => {
+  it("recognizes well-formed references", () => {
+    expect(isTokenReference("{palette.dominant.accent}")).toBe(true);
+    expect(isTokenReference("{palette.semantic.error}")).toBe(true);
+  });
+
+  it("rejects raw hex values and plain strings", () => {
+    expect(isTokenReference("#c96442")).toBe(false);
+    expect(isTokenReference("Anthropic Serif")).toBe(false);
+    expect(isTokenReference("")).toBe(false);
+  });
+
+  it("rejects single-segment or empty braces", () => {
+    expect(isTokenReference("{accent}")).toBe(false);
+    expect(isTokenReference("{}")).toBe(false);
+    expect(isTokenReference("{palette}")).toBe(false);
+  });
+
+  it("rejects non-string input", () => {
+    expect(isTokenReference(16)).toBe(false);
+    expect(isTokenReference(null)).toBe(false);
+    expect(isTokenReference(undefined)).toBe(false);
+  });
+});
+
+describe("parseTokenReference", () => {
+  it("splits namespace and role", () => {
+    expect(parseTokenReference("{palette.dominant.accent}")).toEqual({
+      path: "palette.dominant.accent",
+      namespace: "palette.dominant",
+      role: "accent",
+    });
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseTokenReference("{palette}")).toBeNull();
+    expect(parseTokenReference("palette.dominant.accent")).toBeNull();
+  });
+});
+
+describe("resolveTokenReference", () => {
+  const fp = buildFingerprint();
+
+  it("resolves a dominant role to its hex", () => {
+    const result = resolveTokenReference(fp, "{palette.dominant.accent}");
+    expect(result.value).toBe("#c96442");
+    expect(result.error).toBeNull();
+  });
+
+  it("resolves a semantic role to its hex", () => {
+    const result = resolveTokenReference(fp, "{palette.semantic.error}");
+    expect(result.value).toBe("#b53333");
+    expect(result.error).toBeNull();
+  });
+
+  it("flags an unknown role in a supported namespace", () => {
+    const result = resolveTokenReference(fp, "{palette.dominant.ghost}");
+    expect(result.value).toBeNull();
+    expect(result.error).toEqual({
+      kind: "unknown-role",
+      namespace: "palette.dominant",
+      role: "ghost",
+    });
+  });
+
+  it("flags an unsupported namespace with the supported list", () => {
+    const result = resolveTokenReference(fp, "{typography.families.primary}");
+    expect(result.value).toBeNull();
+    expect(result.error?.kind).toBe("unsupported-namespace");
+    if (result.error?.kind === "unsupported-namespace") {
+      expect(result.error.supported).toEqual([
+        "palette.dominant",
+        "palette.semantic",
+      ]);
+    }
+  });
+
+  it("flags a malformed reference string", () => {
+    const result = resolveTokenReference(fp, "{bogus}");
+    expect(result.value).toBeNull();
+    expect(result.error?.kind).toBe("malformed");
+  });
+});
+
+describe("formatReferenceError", () => {
+  it("produces a readable message for each kind", () => {
+    expect(
+      formatReferenceError({ kind: "malformed", value: "{bogus}" }),
+    ).toMatch(/not a valid token reference/);
+    expect(
+      formatReferenceError({
+        kind: "unsupported-namespace",
+        namespace: "typography.sizeRamp",
+        supported: ["palette.dominant", "palette.semantic"],
+      }),
+    ).toMatch(/Supported:.*palette\.dominant.*palette\.semantic/);
+    expect(
+      formatReferenceError({
+        kind: "unknown-role",
+        namespace: "palette.dominant",
+        role: "ghost",
+      }),
+    ).toMatch(/does not resolve/);
+  });
+});


### PR DESCRIPTION
## Summary

- `roles[].tokens.palette.{background,foreground,border}` now accept `{palette.dominant.<role>}` and `{palette.semantic.<role>}` references, so renames in the palette cascade into every role that cites them.
- `ghost-drift lint` flags unresolved references as `broken-role-reference` (error). Three failure kinds surface as distinct messages: unknown role, unsupported namespace (with the supported list), malformed syntax.
- Positional inventories (`palette.neutrals`, `typography`, `spacing`, `surfaces`) stay raw — they have no named slots to point at. Called out explicitly under "What's deliberately excluded" in the format docs, so the narrow surface is on the record.

Frame for reviewers: this is the first of two potential moves inspired by Google Labs' design.md. It adds the reference surface where naming already exists; the harder question — whether typography/spacing should grow a named layer — is deferred until a profile recipe has a real reason to emit one.

No schema version bump, no new required fields, no breaking change. Raw hexes continue to work untouched.

## Test plan

- [x] `pnpm test` — 175/175 green (12 new resolver tests + 4 new lint tests)
- [x] `pnpm check` — biome + typecheck + file-size + docs-frontmatter + cli-manifest all pass
- [x] `schemas/fingerprint.schema.json` stays byte-identical after `pnpm --filter ghost-drift build && node scripts/emit-fingerprint-schema.mjs && pnpm fmt`
- [x] Eyeball the new "Token references" subsection in `docs/fingerprint-format.md` once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)