### PR TITLE
docs: reframe thesis checkability around delegation

### DIFF
--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -53,11 +53,11 @@ export default function Home() {
               and it's where generations drift first.
             </p>
             <p className="thesis-item">
-              And it has to be checkable. The question isn't "did the reviewer
-              feel good about it." It's "can the harness flag this PR as
-              off-brand before a human is paged." A voice that can only be
-              evaluated by taste is a voice that can't survive autonomous
-              generation.
+              And it has to be checkable. A voice that can only be evaluated by
+              its original author can't be delegated — not to an agent, not to a
+              new hire, not to a fork. The harness is how a voice becomes
+              transmissible: enough of it captured outside one person that
+              someone who isn't you can apply it faithfully.
             </p>
             <p className="thesis-item">
               The artifact that carries brand has to live where the agent does:


### PR DESCRIPTION
## Summary

Rewrites the "has to be checkable" paragraph on the docs home page so it leans on **transmissibility** instead of contrasting taste with machines.

The prior wording ("A voice that can only be evaluated by taste is a voice that can't survive autonomous generation") read as devaluing taste and hinged the argument on human-vs-machine. The new wording reframes around delegation: a voice only its original author can evaluate can't be handed off — to an agent, a new hire, or a fork. Autonomous generation is then just the most extreme case of "someone who isn't you."

- Preserves the *checkable* → *enforceable by the harness* thread from the earlier paragraph.
- Hands off more cleanly to the next paragraph ("captured outside one person" → "has to live where the agent does: in the repo").
- Matches the surrounding three-sentence rhythm.

## Test plan

- [x] Run the docs site locally (`just dev`) and read the thesis section end-to-end to confirm the paragraph reads naturally in context.
- [x] Visually check the stagger-reveal animation still hits the paragraph correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)