### PR TITLE
Clarify agent-facing Ghost guidance

### DIFF
--- a/.changeset/clarify-agent-guidance.md
+++ b/.changeset/clarify-agent-guidance.md
@@ -1,0 +1,6 @@
+---
+"ghost-drift": patch
+"ghost-expression": patch
+---
+
+Clarifies agent-facing scan and drift guidance across docs and skill bundles.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Ghost
 
-**Brand fidelity infrastructure for an agent-authored world. Every generation gets an expression the harness can read, enforce, and check.**
+**Ghost helps agents keep generated UI aligned with a project's design language.**
 
-AI is becoming the primary author of shipped code. Humans sit in fewer diffs; the harness (guardrails, reviewers, verifiers) catches drift before it lands. In that world, ensuring every generation reflects a brand's voice is paramount. Fonts and spacing are the easy half. The hard half is character: the posture a product takes, what it refuses to do. That's where generations drift first.
+Agents can ship UI now. The problem is drift: wrong palette, wrong density, wrong hierarchy, wrong feel. Most repos do not have a clear, local answer to “what should this interface look like?”
 
-Ghost closes that loop. It captures a brand as an **expression**: a human-readable `expression.md` encoding character, signature traits, and concrete decisions. It gives any agent what it needs to author against the expression, detect drift the moment it happens, and record the right stance: **acknowledge**, **track**, or **intentionally diverge**. Each repo owns its expression, its trajectory, and its stance. The fleet of expressions drifts in the open. Nothing gets enforced; nothing drifts silently. The agent does the reading, deciding, and writing; Ghost's CLIs are the calculator it reaches for.
+Ghost gives the repo that answer. A scan creates three files: `map.md` says where the design system lives, `survey.json` records the values found in source, and `expression.md` is the compact design-language contract agents read for generation and review. Agents do the judgment work; Ghost's CLIs provide deterministic checks, diffs, and comparisons.
 
 ## BYOA: bring your own agent
 
-Every Ghost workflow runs in the host agent you already use — Claude Code, Codex, Cursor, Goose, whatever ships next. Each tool ships an [agentskills.io](https://agentskills.io)-compatible bundle of recipes for the interpretive work (profile, review, verify, remediate, fleet narrative); the agent loads the bundle, reads the artifacts for that workflow, makes the calls, and writes the outputs. Scan workflows use `map.md` and `survey.json`; generation and drift use `expression.md` as the root. When the agent needs a reproducible number — vector distance between two expressions, schema validation, a structural diff — it calls the relevant Ghost CLI verb for the answer.
+Every Ghost workflow runs in the host agent you already use: Claude Code, Codex, Cursor, Goose, or another agent. Each tool ships an [agentskills.io](https://agentskills.io)-compatible recipe bundle for the interpretive work: profile, review, verify, remediate, or summarize a fleet. The agent reads the files, makes the calls, and writes the outputs. When it needs a reproducible answer, such as schema validation or expression distance, it calls a Ghost CLI.
 
 No API key is required to run any CLI verb. Each tool's `emit skill` verb installs its bundle into your agent.
 
@@ -20,22 +20,22 @@ Ghost is split into one responsibility per tool. A scan produces three artifacts
 | --- | --- | --- |
 | **`ghost-expression`** | the three-stage scan pipeline (`map.md`, `survey.json`, `expression.md`) | `inventory`, `lint`, `verify-profile`, `describe`, `diff`, `survey <op>`, `emit` |
 | **`ghost-drift`** | `.ghost/history.jsonl` + `.ghost-sync.json` — drift detection and stance | `compare`, `ack`, `track`, `diverge`, `emit skill` |
-| **`ghost-fleet`** | `fleet.md` — read-only elevation across many `(map.md, expression.md)` members | `members`, `view`, `emit skill` |
+| **`ghost-fleet`** | `fleet.md` — read-only view across many `(map.md, expression.md)` members | `members`, `view`, `emit skill` |
 | **`ghost-ui`** | A reference design system Ghost dogfoods — 97 shadcn components + an MCP server | (no verbs) |
 
-Scans are single-subject but may be multi-source. A `map.md` can declare a source graph where one `primary` source supplies usage and salience while one or more `resolver` sources supply concrete values for imported symbols. This lets an app expression describe the app in use without pretending the upstream design-system inventory is the app's language.
+Scans describe one subject, but they can read more than one source. For example, an app can be the `primary` source while an upstream design-system package acts as a `resolver` for imported tokens. That keeps the expression about the app's actual usage instead of treating the upstream inventory as the app's design language.
 
 `@ghost/core` underneath is a workspace-only library with embedding math, target resolution, skill-bundle loader, and the `ghost.map/v2` + `ghost.survey/v2` schemas the three CLIs share.
 
 ## Why Ghost?
 
-Ghost gives agents four capabilities the design-at-scale problem actually needs:
+Ghost gives agents a few practical abilities:
 
-- **Author against a real quality bar**: `ghost-expression emit context-bundle` and the `generate` recipe turn a design language into grounding an agent can actually follow. The expression is the bar; the agent authors to it.
-- **Self-govern at author time**: the `review` and `verify` recipes (in the `ghost-drift` skill bundle) run an agent's output against the expression *before* a human sees it. Drift gets caught where it's cheap to fix, not after it ships.
-- **Detect drift at the right time**: PR-time (via `review`), generation-time (via `verify`), or org-time (via `ghost-drift compare` on N≥3 expressions, or `ghost-fleet view` for the full elevation). Timing is load-bearing: the same drift surfaced a month later is noise; surfaced inline, it's action.
-- **Remediate with structured intent**: `ack`, `track`, `diverge` are the three moves. Every stance is published with reasoning and full lineage. Drift without intent is noise; drift with intent becomes useful evidence.
-- **Human-readable, diff-friendly**: `expression.md` is Markdown with YAML frontmatter (machine layer) plus a prose body (Character, Signature, Decisions). `map.md` is the same shape for topology. Humans read them, agents consume them, Ghost's CLIs diff them. No DSL to learn.
+- **Generate from a local contract**: `expression.md` tells the agent what the design language is before it writes UI.
+- **Review changes for drift**: the review and verify recipes compare generated or changed UI against the expression.
+- **Compare systems**: `ghost-drift compare` and `ghost-fleet view` show how expressions differ across projects.
+- **Record intent**: `ack`, `track`, and `diverge` record whether drift is accepted, tracked against a new reference, or intentionally different.
+- **Stay readable**: `expression.md` is Markdown with YAML frontmatter. Humans can review it, agents can use it, and the CLIs can validate and diff it.
 
 ## Repo layout
 
@@ -45,8 +45,8 @@ Ghost is a pnpm monorepo. Four tools, one reference design system, one docs site
 | ---- | ---- | --- |
 | [`packages/ghost-core`](./packages/ghost-core) | Workspace-only shared library — embedding math, target resolver, skill loader, `ghost.map/v2` + `ghost.survey/v2` schemas. | ❌ private (`@ghost/core`) |
 | [`packages/ghost-expression`](./packages/ghost-expression) | The three-stage scan pipeline: `map.md` → `survey.json` → `expression.md`. Authoring, lint, profile verification, describe, diff, survey ops, emit. | ✅ intended-public on npm |
-| [`packages/ghost-drift`](./packages/ghost-drift) | Drift detection + governance verbs. | ✅ `ghost-drift` on npm |
-| [`packages/ghost-fleet`](./packages/ghost-fleet) | Fleet elevation across many members. | ❌ private |
+| [`packages/ghost-drift`](./packages/ghost-drift) | Drift detection and stance verbs. | ✅ `ghost-drift` on npm |
+| [`packages/ghost-fleet`](./packages/ghost-fleet) | Fleet view across many members. | ❌ private |
 | [`packages/ghost-ui`](./packages/ghost-ui) | Reference design system: 97 shadcn components + the `ghost-mcp` MCP server. | ❌ private (distributed via shadcn registry, not npm) |
 | [`apps/docs`](./apps/docs) | Deployed docs site (`ghost-docs`). | ❌ private |
 
@@ -70,7 +70,7 @@ After install, in any repo:
 
 The agent walks `map.md` → `survey.json` → `expression.md`, then emits a `/design-review` slash command tuned to your design language. The recipes work without any Ghost CLI on PATH — every CLI-using step has a prose fallback.
 
-If you want the deterministic CLI helpers (faster lint, embedding math, structural diff, fleet view), install from source instead — see *Getting Started* below.
+If you want the CLI helpers for linting, profile verification, diffing, comparing, and fleet views, install from source instead. See *Getting Started* below.
 
 ## Getting Started
 
@@ -181,7 +181,7 @@ Verbs are scoped to the tool that owns the artifact. Pure inputs → pure output
 | `ghost-expression` | `diff` | Structural prose-level diff between two expressions (NOT vector distance — for that, use `ghost-drift compare`). |
 | `ghost-expression` | `survey <op>` | Operate on `ghost.survey/v2` files. Ops: `merge`, `fix-ids`, `summarize`, `catalog`. |
 | `ghost-expression` | `emit` | Derive an artifact from `expression.md`: `review-command`, `context-bundle`, or `skill`. |
-| `ghost-drift` | `compare` | Pairwise (N=2) or composite (N≥3) over expression embeddings. `--semantic` / `--temporal` add qualitative enrichment. |
+| `ghost-drift` | `compare` | Pairwise (N=2) or composite (N≥3) over runtime expression embeddings. `--semantic` / `--temporal` add qualitative enrichment. |
 | `ghost-drift` | `ack` | Record stance toward the tracked expression in `.ghost-sync.json`. |
 | `ghost-drift` | `track` | Shift the tracked expression. |
 | `ghost-drift` | `diverge` | Declare intentional divergence on a dimension. |
@@ -192,16 +192,16 @@ Verbs are scoped to the tool that owns the artifact. Pure inputs → pure output
 
 ### Skill recipes: run by the host agent
 
-The interpretive verbs from the pitch (*author, self-govern, detect, remediate*) are recipes the agent runs. Install the relevant bundle once; ask in plain English. Each tool ships its own.
+The interpretive work is done by recipes the agent runs. Install the relevant bundle once, then ask in plain English. Each tool ships its own recipes.
 
 | Recipe | Bundle | Capability | Triggered by |
 | --- | --- | --- | --- |
 | `map`       | `ghost-expression` | Author the topology card (stage 1) | "map this repo", "write map.md" |
 | `survey`    | `ghost-expression` | Author the survey of values (stage 2) | "survey design values", "extract design tokens" |
 | `profile`   | `ghost-expression` | Author the design language (stage 3) | "profile this design language", "write expression.md" |
-| `review`    | `ghost-drift` | Self-govern at PR time | "review this PR for drift" |
-| `verify`    | `ghost-drift` | Self-govern at generation time | "verify generated UI against the expression" |
-| `compare`   | `ghost-drift` | Detect drift across the org | "why did these two expressions drift?" |
+| `review`    | `ghost-drift` | Review PR changes for drift | "review this PR for drift" |
+| `verify`    | `ghost-drift` | Check generated UI against the expression | "verify generated UI against the expression" |
+| `compare`   | `ghost-drift` | Compare expressions | "why did these two expressions drift?" |
 | `remediate` | `ghost-drift` | Suggest minimal fixes for drift | "fix this drift" |
 | `target`    | `ghost-fleet` | Synthesize fleet narrative | "describe this fleet" |
 
@@ -213,7 +213,7 @@ These are instructions, not code. The agent executes them using its normal tools
 
 ### Environment variables
 
-- `OPENAI_API_KEY` / `VOYAGE_API_KEY`: optional, consumed by `computeSemanticEmbedding` (a `@ghost/core` library function) when a host writes an `expression.md` and wants the enriched 49-dim vector.
+- `OPENAI_API_KEY` / `VOYAGE_API_KEY`: optional, consumed by `computeSemanticEmbedding` (a `@ghost/core` library function) when a host wants enriched runtime embeddings.
 - `GITHUB_TOKEN`: optional, used by `resolveTrackedExpression` when fetching a tracked expression from GitHub (avoids rate limits).
 
 Each CLI auto-loads `.env` and `.env.local` from the working directory.
@@ -222,39 +222,39 @@ Each CLI auto-loads `.env` and `.env.local` from the working directory.
 
 ### The expression
 
-What the agent reads when it authors, reviews, or remediates. The canonical artifact is **`expression.md`** (owned by `ghost-expression`): a Markdown document with YAML frontmatter (machine layer) plus a prose body. Human-readable, LLM-consumable, diff-friendly:
+What the agent reads when it writes or reviews UI. The main file is **`expression.md`** (owned by `ghost-expression`): Markdown with YAML frontmatter plus a prose body.
 
-- **Frontmatter**: direct `references`, palette, spacing, typography, surfaces, provenance, and `checks[]` — human-promoted, grep-friendly review gates with `paths`, `contexts`, `observed_count`, and `presence_floor` for codifying absences. The machine layer.
-- **`# Character`**: the opening atmosphere read, evocative not technical. What an agent quotes to stay on-brand.
-- **`# Signature`**: the final-picture guidance — dominant moves, layout posture, and recognizable output habits.
-- **`# Decisions`**: abstract, implementation-agnostic choices with evidence. Runtime comparison computes embeddings from the authored file so `ghost-drift compare --semantic` can match semantically without an authored embedding fragment.
+- **Frontmatter**: `references`, palette, spacing, typography, surfaces, and promoted `checks[]`.
+- **`# Character`**: what the design language feels like.
+- **`# Signature`**: what output should look like when the language comes together.
+- **`# Decisions`**: the important design choices, with evidence. Runtime comparison computes embeddings from this file; no authored embedding file is needed.
 
 Generate one with the `profile` recipe (in the `ghost-expression` skill bundle). See [`docs/expression-format.md`](./docs/expression-format.md) for the full spec.
 
 ### The map
 
-What Ghost uses during scan and fleet workflows to learn the topology of a repo. The canonical artifact is **`map.md`** (owned by `ghost-expression`, stage 1 of a scan): YAML frontmatter against the `ghost.map/v2` schema (languages, build system, package manifests, registry, design-system paths, observable surface sources, feature areas) plus a short prose body (Identity, Topology, Conventions). Generation and drift context starts from `expression.md`, not `map.md`. The repo's own `map.md` lives at the root.
+What Ghost uses during scan and fleet workflows to understand the repo. **`map.md`** is stage 1 of a scan. It records languages, build system, package manifests, registry files, design-system paths, observable surfaces, and feature areas. Generation and drift review start from `expression.md`, not `map.md`.
 
-Generate one with the `map` recipe (in the `ghost-expression` skill bundle). The agent reads `ghost-expression inventory` (raw repo signals as JSON) and synthesizes the prose layer.
+Generate one with the `map` recipe (in the `ghost-expression` skill bundle). The agent reads `ghost-expression inventory` (raw repo signals as JSON) and writes the short body.
 
-### Author + self-govern loop
+### Author + Review Loop
 
-The literal loop the pitch describes: the agent authors UI, Ghost detects drift against the expression, a human (or the agent itself) picks the remediation. The expression grounds the generator; the `review` recipe surfaces drift in the output so a decision (*acknowledge, track, or diverge*) can be made at the right time. The `verify` recipe drives the loop across a prompt suite and classifies each dimension as _tight_, _leaky_, or _uncaptured_: the mechanism that tells the expression where it needs to say more. See [`docs/generation-loop.md`](./docs/generation-loop.md) for details.
+The loop is simple: the agent writes UI, the review or verify recipe checks it against `expression.md`, and a human or agent decides what to do next. Fix the drift, accept it, track a new expression, or mark one dimension as intentionally different. See [`docs/generation-loop.md`](./docs/generation-loop.md) for details.
 
 ### Remediation
 
-Three responses, each with recorded reasoning and full lineage, so a year from now you know whether a divergence was meant or missed:
+Three files record what happened:
 
-- **`expression.md`**: The canonical expression artifact.
+- **`expression.md`**: The design-language contract.
 - **`.ghost-sync.json`**: Per-dimension stances toward the tracked expression (aligned, accepted, or diverging), each with recorded reasoning. Written by `ghost-drift ack` / `track` / `diverge`.
 - **`.ghost/history.jsonl`**: Append-only expression history for temporal analysis. Read by `ghost-drift compare --temporal`.
 
 ### Org-scale observability
 
-Drift at scale: the fleet view. Two routes, depending on what you have:
+To look across many projects:
 
-- **Many expressions, no map**: run `ghost-drift compare` with three or more `expression.md` files. Returns the **composite expression** — pairwise distances, a centroid, similarity clusters. An expression of expressions.
-- **A registered fleet** (members each with `map.md` + `expression.md`): run `ghost-fleet view`. Adds group-by axes (platform, build system, design-system status) on top of the composite. The map metadata is the orthogonal axis pure expression-comparison can't see.
+- **Many expressions, no map**: run `ghost-drift compare` with three or more `expression.md` files. It returns pairwise distances, a centroid, and similarity clusters.
+- **A registered fleet** (members each with `map.md` + `expression.md`): run `ghost-fleet view`. It adds groupings such as platform, build system, and design-system status.
 
 ## Project Resources
 

--- a/apps/docs/src/app/tools/expression/page.tsx
+++ b/apps/docs/src/app/tools/expression/page.tsx
@@ -31,7 +31,7 @@ const cards: {
     name: "Format spec",
     href: "https://github.com/block/ghost/blob/main/docs/expression-format.md",
     description:
-      "The full expression.md spec — frontmatter schema, three-layer body, 49-dim machine vector.",
+      "The full expression.md spec — authored frontmatter, portable prose, and derived runtime views.",
     icon: <FileText className="size-8" strokeWidth={1.5} />,
   },
 ];
@@ -48,7 +48,7 @@ export default function GhostExpressionLanding() {
       <AnimatedPageHeader
         kicker="ghost-expression"
         title="Authoring"
-        description="The package that owns expression.md — Ghost's canonical design-language artifact. YAML frontmatter for machines, prose body (Character / Decisions) for humans and LLMs. Validated, described, diffed, and emitted into per-project review commands and grounding bundles for any generator."
+        description="The package that owns expression.md — Ghost's authored design-language contract. YAML frontmatter stores compact value digests, while the prose body (Character / Signature / Decisions) explains the design choices for humans and LLMs. Validated, described, diffed, and emitted into per-project review commands and context bundles for any generator."
       />
 
       <div

--- a/apps/docs/src/content/docs/cli-reference.mdx
+++ b/apps/docs/src/content/docs/cli-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Eighteen verbs across three tools. Everything interpretive lives in the skill bundles your host agent runs.
+description: Eighteen verbs across three tools. Judgment work lives in the skill bundles your host agent runs.
 kicker: Docs
 section: guide
 order: 20
@@ -9,17 +9,16 @@ slug: cli
 
 <DocSection title="Overview">
 
-The CLIs are the calculator your host agent reaches for when it needs a
-reproducible answer. A scan produces three artifacts in sequence — **`map.md`**
+The CLIs give your host agent reproducible answers. A scan produces three artifacts in sequence — **`map.md`**
 (map the system) → **`survey.json`** (survey what exists) → **`expression.md`** (express what it means) —
 all owned by `ghost-expression`. Most commands accept a path; they default to
-`./expression.md` for kind-aware verbs.  No API key required.
+`./expression.md` for kind-aware verbs. No API key required.
 
 Verbs are scoped to the tool that owns the artifact:
 
 - **`ghost-expression`** — the scan pipeline: `inventory`, `scan-status`, `lint`, `verify-profile`, `describe`, `diff`, `survey <op>`, `emit`
-- **`ghost-drift`** — drift detection + governance: `compare`, `ack`, `track`, `diverge`, `emit skill`
-- **`ghost-fleet`** — elevation across many members: `members`, `view`, `emit skill`
+- **`ghost-drift`** — drift detection + stance: `compare`, `ack`, `track`, `diverge`, `emit skill`
+- **`ghost-fleet`** — view across many members: `members`, `view`, `emit skill`
 
 Workflows like _scan_, _map_, _survey_, _profile_, _review_, _verify_, and
 _remediate_ are skill recipes your host agent runs — not CLI verbs. Install
@@ -82,18 +81,11 @@ recommended next stage (or "scan complete" when every artifact is present).
 
 Operate on `ghost.survey/v2` files:
 
-- **`merge`** — concat with id-based dedup, deterministic and idempotent.
-  The composition primitive: modular rollups (one repo, N feature modules)
-  and fleet cohort views (N members merged into one cohort survey) both
-  reduce to survey merge.
-- **`fix-ids`** — recompute every row's `id` from its content. The survey
-  recipe instructs the agent to author rows with `"id": ""` and finalize
-  with this verb in one pass — agents don't compute SHA-256 hashes by hand.
-- **`summarize`** — emit a bounded Markdown or JSON digest for broad
-  profiling context.
-- **`catalog`** — emit a deterministic compact value enum/spec view derived
-  from survey rows. Markdown is the default; JSON uses
-  `ghost.survey.catalog/v1`. Use `--kind <kind>` to focus one value family.
+- **`merge`** — combine surveys with id-based dedup.
+- **`fix-ids`** — recompute every row's `id` from its content.
+- **`summarize`** — print a short Markdown or JSON digest for profiling.
+- **`catalog`** — print exact value enums/specs derived from survey rows.
+  Markdown is the default; JSON uses `ghost.survey.catalog/v1`.
 
 <CliHelp tool="ghost-expression" command="survey" hideDescription />
 
@@ -144,13 +136,11 @@ ghost-expression lint path/to/expression.md --format json
 
 ### Profile fidelity — `verify-profile`
 
-Validate that an `expression.md` stayed faithful to the `survey.json` that
-produced it. This is stricter than `lint`: palette, spacing, typography,
-radii, and shadow posture must be backed by survey evidence; high-salience
-new survey values are surfaced as drift warnings; and promoted `checks[]`
-entries must carry calibration metadata. With `--root`, promoted check
-patterns are counted under their `paths` scopes and mismatched
-`observed_count` values fail the gate. `contexts` are guidance only.
+Validate that an `expression.md` matches its `survey.json`. This is stricter
+than `lint`: palette, spacing, typography, radii, and shadow posture must be
+survey-backed. High-salience survey values omitted from the expression become
+warnings. With `--root`, promoted check patterns are counted under their
+`paths` scopes; `contexts` are guidance only.
 
 <CliHelp tool="ghost-expression" command="verify-profile" hideDescription />
 
@@ -239,7 +229,7 @@ ghost-expression emit skill
 # Emit a per-project design-review slash command
 ghost-expression emit review-command
 
-# Emit a grounding bundle any generator can consume
+# Emit a context bundle any generator can consume
 ghost-expression emit context-bundle
 
 # Single prompt.md for plain-text LLM context
@@ -251,7 +241,7 @@ ghost-expression emit context-bundle --out dist/context
 
 </DocSection>
 
-<DocSection title="ghost-drift — drift detection & governance">
+<DocSection title="ghost-drift — drift detection & stance">
 
 ### Comparison — `compare`
 
@@ -333,7 +323,7 @@ ghost-drift emit skill --out ~/.my-agent/skills/ghost-drift
 
 </DocSection>
 
-<DocSection title="ghost-fleet — elevation across members">
+<DocSection title="ghost-fleet — view across members">
 
 A fleet is a directory containing many `(map.md, expression.md)` members.
 `ghost-fleet` reads the fleet, emits per-fleet outputs (`fleet.md` +

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -10,29 +10,28 @@ slug: getting-started
 <DocSection title="The Shape of Ghost">
 
 Ghost is split into **four small tools**, each with one responsibility, plus a
-shared library (`@ghost/core`) underneath. Your host agent (Claude Code, Cursor,
-Goose, Codex, …) does the interpretive work — profile, review, verify, remediate —
-using [agentskills.io](https://agentskills.io)-compatible recipe bundles that
-each tool ships. The CLIs are the calculator the agent reaches for when it
-needs a reproducible answer.
+shared library (`@ghost/core`). Your host agent (Claude Code, Cursor, Goose,
+Codex, …) does the judgment work: profile, review, verify, remediate. The CLIs
+handle deterministic checks such as linting, profile verification, diffs, and
+distance.
 
 A scan runs in three stages, all owned by `ghost-expression`:
 
 ```
 map            →     survey          →     expression
 map.md               survey.json           expression.md
-ghost.map/v2         ghost.survey/v2       (the canonical artifact)
+ghost.map/v2         ghost.survey/v2       design contract
 ```
 
 | Tool | Owns | Verbs |
 | --- | --- | --- |
 | `ghost-expression` | the three-stage scan pipeline | `inventory`, `scan-status`, `lint`, `verify-profile`, `describe`, `diff`, `survey <op>`, `emit` |
-| `ghost-drift` | drift detection + governance | `compare`, `ack`, `track`, `diverge`, `emit skill` |
-| `ghost-fleet` | `fleet.md` (elevation across members) | `members`, `view`, `emit skill` |
+| `ghost-drift` | drift detection + stance | `compare`, `ack`, `track`, `diverge`, `emit skill` |
+| `ghost-fleet` | `fleet.md` (view across members) | `members`, `view`, `emit skill` |
 | `ghost-ui` | reference design system (97 shadcn components) | — |
 
-You install Ghost in two steps: add whichever CLI(s) you need, then emit the
-matching skill bundle into your agent.
+Install the CLI(s) you need, then emit the matching skill bundle into your
+agent.
 
 </DocSection>
 
@@ -64,8 +63,7 @@ embeddings, `GITHUB_TOKEN` for fetching tracked expressions).
 
 <DocSection title="Install the Skill Bundles">
 
-Each tool ships its own bundle. Install whichever capability you want
-your agent to gain:
+Each tool ships its own recipe bundle:
 
 ```bash
 ghost-drift emit skill            # → .claude/skills/ghost-drift
@@ -79,19 +77,16 @@ Each bundle ships its own `SKILL.md` plus recipes under `references/`:
 - **`ghost-drift`** — `compare.md` (interpretation), `review.md` (PR review), `verify.md` (generation→review loop), `remediate.md` (suggest minimal fixes).
 - **`ghost-fleet`** — `target.md` (synthesize fleet narrative from `view` output).
 
-Each recipe declares `handoffs` in its frontmatter so hosts can surface the
-next step inline — e.g. after `profile`, a prompt to `compare` against
-another expression, or to run `ghost-expression emit review-command`. Once
-installed, ask your agent in plain English ("profile this design language",
-"review this PR for drift") and it'll follow the recipe, calling the right
-CLI whenever it needs a reproducible answer.
+Once installed, ask your agent in plain English: "profile this design language"
+or "review this PR for drift". The recipe tells the agent what to read, what to
+write, and which CLI checks to run.
 
 </DocSection>
 
 <DocSection title="Scan Your First System">
 
-Scanning is the host-agent loop, not a single CLI verb. Open your host
-agent in the project you want to profile and ask it something like:
+Scanning is a recipe your agent runs, not one CLI command. Open your agent in
+the project you want to profile and ask:
 
 ```text
 Scan this design language end-to-end
@@ -105,12 +100,11 @@ dispatches into the per-stage recipes:
    describing where the design system lives. Validated by
    `ghost-expression lint map.md`.
 2. **Survey (`survey.json`)** — the `survey` recipe walks the source
-   exhaustively (writing dialect-specific greps; the recipe forbids
-   sampling) and writes a `survey.json` cataloguing every concrete value,
-   token, component, and implemented UI surface. Validated by
+   exhaustively and writes a `survey.json` cataloguing concrete values,
+   tokens, components, and implemented UI surfaces. Validated by
    `ghost-expression lint survey.json`.
 3. **Expression (`expression.md`)** — the `profile` recipe interprets the
-   survey as ground truth: reads `survey summarize` for broad context and
+   survey as evidence: reads `survey summarize` for broad context and
    `survey catalog` for exact value enums/specs, assigns roles to values,
    emits direct references, names design decisions, writes Character and
    Signature, and produces the `expression.md`. Cannot fabricate values not
@@ -122,12 +116,10 @@ If you only want one stage, ask for it directly: "map this repo", "survey
 the design values", "profile this expression from the survey". The recipes
 chain via `handoffs`, so the agent surfaces the next stage when ready.
 
-An **expression** is a two-layer Markdown file: YAML frontmatter is the
-machine layer (palette, spacing, typography, surfaces, direct references,
-checks), and the body is prose organized into Character, Signature, and
-Decisions. Runtime comparison derives embeddings from the authored file;
-there is no sibling embedding artifact to edit. Humans can read it. LLMs can
-consume it. Ghost's CLIs diff it.
+An **expression** is one Markdown file. YAML frontmatter stores compact values
+such as palette, spacing, typography, surfaces, references, and checks. The
+body stores prose: Character, Signature, and Decisions. Runtime comparison
+derives embeddings from the file; there is no sibling embedding file to edit.
 See the expression fixture at
 [`packages/ghost-expression/test/fixtures/ghost-ui-expression/expression.md`](https://github.com/block/ghost/blob/main/packages/ghost-expression/test/fixtures/ghost-ui-expression/expression.md)
 for a full example.
@@ -148,9 +140,8 @@ ghost-expression verify-profile expression.md survey.json --root .
 
 <DocSection title="Compare Two Systems">
 
-Once you have two expressions, `ghost-drift compare` returns a scalar
-distance, per-dimension deltas, and (optionally) qualitative or temporal
-enrichment:
+Once you have two expressions, `ghost-drift compare` returns distance and
+per-dimension deltas:
 
 ```bash
 # Pairwise (N=2) — distance + per-dimension delta
@@ -166,9 +157,8 @@ ghost-drift compare before.expression.md after.expression.md --temporal
 ghost-drift compare *.expression.md
 ```
 
-`compare` weights palette, spacing, typography, surfaces, and runtime
-decision embeddings. Decisions are matched semantically above a
-cosine-similarity threshold so wording doesn't have to line up.
+`compare` uses palette, spacing, typography, surfaces, and runtime decision
+embeddings. Decisions can match semantically even when the wording differs.
 
 For a structural prose-level diff (what decisions and palette roles
 changed, ignoring vector distance), use `ghost-expression diff` instead.
@@ -224,10 +214,10 @@ ghost-drift diverge typography --reason "Editorial product uses a different type
 
 <DocSection title="The Generation Loop">
 
-Ghost doubles as pipeline infrastructure for AI-generated UI. The
-expression grounds the generator; the `review` recipe gates the output.
+Ghost can sit inside an AI-generated UI pipeline. The expression gives the
+generator design-language context; the `review` recipe checks the output.
 
-1. `ghost-expression emit context-bundle` — emit a grounding bundle from an
+1. `ghost-expression emit context-bundle` — emit a context bundle from an
    expression (SKILL.md + expression.md + prompt.md + tokens.css) that any
    generator can consume.
 2. Run any generator — your host agent, Cursor, v0, or an in-house tool —
@@ -237,7 +227,7 @@ expression grounds the generator; the `review` recipe gates the output.
    classifying each dimension as _tight_, _leaky_, or _uncaptured_.
 
 ```bash
-# Emit a grounding bundle — default output: ./ghost-context/
+# Emit a context bundle — default output: ./ghost-context/
 ghost-expression emit context-bundle
 
 # Single prompt.md for plain-text LLM context

--- a/docs/expression-format.md
+++ b/docs/expression-format.md
@@ -1,16 +1,16 @@
 # The `expression.md` Format
 
-A Ghost expression is the authored design-language contract agents read for generation and drift review. It is a Markdown file with YAML frontmatter plus a prose body: compact enough to travel, grounded enough to verify against `survey.json`.
+A Ghost expression is the design-language contract agents read for generation and drift review. It is one Markdown file: YAML frontmatter for compact values, plus prose for the parts that need judgment.
 
-`survey.json` remains the durable evidence ledger. `survey catalog` and runtime embeddings are derived views, not manually edited source of truth.
+`survey.json` stores the scan evidence. `survey catalog` and runtime embeddings are derived from existing files; regenerate them instead of editing them by hand.
 
 ## Shape
 
-Frontmatter is the machine layer: identity, references, personality tags, decision slugs, promoted checks, and compact value digests.
+Frontmatter stores the compact data: identity, references, personality tags, decision slugs, promoted checks, and value digests.
 
-Body is the prose layer: `# Character`, `# Signature`, and `# Decisions` with `### <dimension>` rationale blocks and `**Evidence:**` bullets.
+The body stores the prose: `# Character`, `# Signature`, and `# Decisions` with `### <dimension>` blocks and `**Evidence:**` bullets.
 
-There are no canonical sibling fragments. Readers do not auto-load `embedding.md`, `# Fragments`, or `decisions/*.md`. Embeddings are computed at runtime from the parsed expression structure when comparison needs them.
+Everything authored lives in `expression.md`. Readers do not auto-load `embedding.md`, `# Fragments`, or `decisions/*.md`. Comparisons compute embeddings at runtime from the parsed expression.
 
 ## Frontmatter
 
@@ -68,7 +68,7 @@ Required: `id`, `source`, `timestamp`, `palette`, `spacing`, `typography`, `surf
 
 Forbidden: root `embedding`, `decisions[].embedding`, `observation.summary`, `decisions[].decision`, `decisions[].evidence`, `checks[].enforce_at`, `checks[].rationale`, and unknown root keys such as `schema`.
 
-`checks[].paths` are filesystem scopes for verifier counts. `checks[].contexts` are reviewer/generator hints. Check rationale belongs in the matching Decision body; `summary` is only the short reviewer label.
+`checks[].paths` are filesystem scopes used by `verify-profile` for counts. `checks[].contexts` are hints for reviewers and generators. Put the reason for a check in the matching Decision body; keep `summary` short.
 
 ## Body
 
@@ -92,13 +92,13 @@ Every gray carries a warm undertone; hue appears only when it clarifies state or
 - Survey color evidence: 31 of 33 color observations fall on the documented palette
 ```
 
-The body should travel. Local paths may appear as provenance, but Character, Signature, and Decisions should still make sense to a downstream project that cannot open the original repo.
+Write the body so it still makes sense outside the original repo. Local paths are fine as provenance, but Character, Signature, and Decisions should not depend on opening those files.
 
 ## Derived Views
 
-- `ghost-expression survey summarize survey.json` gives bounded profiling context.
-- `ghost-expression survey catalog survey.json [--kind <kind>]` gives compact value enums/specs for exact frontmatter values.
-- `ghost-drift compare` computes runtime embeddings from `expression.md`; no embedding file is authored.
+- `ghost-expression survey summarize survey.json` gives a short profiling digest.
+- `ghost-expression survey catalog survey.json [--kind <kind>]` lists exact values/specs from the survey.
+- `ghost-drift compare` computes runtime embeddings from `expression.md`; there is no authored embedding file.
 
 ## Validation States
 

--- a/docs/generation-loop.md
+++ b/docs/generation-loop.md
@@ -1,18 +1,17 @@
 # Generation Loop
 
-Ghost sits as pipeline infrastructure for AI-driven UI generation. The
-`expression.md` is the grounding input; the *review* recipe is the
-post-generation gate; the *verify* recipe drives the loop over a prompt
-suite to expose where the expression leaks.
+Ghost gives UI generators a local design-language input and a review loop.
+`expression.md` is the file the generator reads. The *review* recipe checks
+the result for drift. The *verify* recipe repeats that loop across a prompt
+suite to show where the expression needs more detail.
 
-Only the grounding step is a deterministic CLI verb (`ghost-expression
+Only the bundle step is a deterministic CLI verb (`ghost-expression
 emit context-bundle`). *Review*, *verify*, and *remediate* are skill recipes
 the host agent follows — installed with `ghost-drift emit skill`.
 
-(Note: `generate.md` was dropped from scope in the five-tool decomposition.
 Use any generator — the host agent itself, Cursor, v0, or an in-house tool —
-with the emitted context bundle in its prompt; Ghost's job is grounding the
-input and gating the output, not running the generator.)
+with the emitted context bundle in its prompt. Ghost prepares the input and
+checks the output; it does not run the generator.
 
 ## Pipeline shape
 
@@ -34,14 +33,13 @@ expression.md  ──►  [ghost-expression emit context-bundle]  ──►  SKI
 
 ### `ghost-expression emit context-bundle [flags]` — the one CLI verb
 
-Emit a grounding bundle any generator can consume. Default output writes
+Emit a context bundle any generator can consume. Default output writes
 `SKILL.md` + `expression.md` + `prompt.md` + `tokens.css` into
-`./ghost-context/`. The generated `prompt.md` is a generation lens over the
-expression: Character sets feel, Signature carries final-picture posture,
-Local References point to optional source material when accessible, Decisions
-provide style direction, Checks provide curated gates, and Tokens provide the
-portable value digest. It intentionally does not ask the
-generator to explain or cite decisions unless the user asks for explanation.
+`./ghost-context/`. The generated `prompt.md` turns the expression into a
+short generation prompt: Character sets feel, Signature describes the final
+picture, Local References point to optional source material, Decisions give
+style direction, Checks name review gates, and Tokens provide portable values.
+It does not ask the generator to explain or cite decisions unless the user asks.
 
 Flags:
 - `--out <dir>` — output directory (default: `./ghost-context`)
@@ -55,8 +53,8 @@ reads `SKILL.md`.
 
 ### Driving the generator
 
-Driven by the host agent. Loads the expression (the agent typically pulls
-just the sections it needs via `ghost-expression describe`), builds a system
+The host agent drives this step. It loads the expression (often just the
+sections it needs via `ghost-expression describe`), builds a system
 prompt from Character + Signature + Local References when accessible +
 Decisions + Checks + Tokens, asks the underlying model,
 extracts the artifact (HTML/JSX/etc.), and hands it to the `review`
@@ -65,7 +63,7 @@ agent gives up.
 
 This isn't a recipe Ghost ships — `generate.md` was dropped. The agent's
 own driver code (or whatever generator it shells out to) owns this step.
-Ghost's job is the bundle that goes in and the review that gates the output.
+Ghost's job is the bundle that goes in and the review that checks the output.
 
 ### The `review` recipe
 
@@ -86,9 +84,9 @@ drift per dimension and classifies:
 - **leaky** (1–3): generator drifts here often — tighten Decisions
 - **uncaptured** (≥ 3): expression likely under-specifies this dimension
 
-The killer demo: run `verify` on a mature expression, intentionally drop
-a section (e.g. motion), re-run, watch drift rise in dimensions that lost
-grounding.
+A useful test: run `verify` on a mature expression, remove one section
+(for example, motion), then run it again. Drift should rise in the dimension
+that lost guidance.
 
 Source: `packages/ghost-drift/src/skill-bundle/references/verify.md`.
 
@@ -110,25 +108,25 @@ distinguish *targeted* drift (a pricing-page prompt leaking spacing) from
 *incidental* drift (the same prompt leaking color, which it wasn't
 supposed to stress).
 
-## How the expression format earns its keep
+## Why Each Section Exists
 
 Each layer has a concrete job somewhere in the loop:
 
 | Layer | Role in the loop |
 |---|---|
 | **Character** | Prompt context — shapes feel |
-| **Signature** | Final-picture guidance — dominant moves and output posture |
+| **Signature** | Final-picture guidance — dominant moves and output shape |
 | **References** | Local provenance / optional source material; use when accessible |
-| **Checks** | Human-promoted drift gates; presence-floor checks codify load-bearing absences |
-| **Decisions** | Abstract pattern lookup the generator consults for specific choices |
+| **Checks** | Human-promoted drift gates; presence-floor checks codify important absences |
+| **Decisions** | Pattern guidance the generator consults for specific choices |
 
-Terminal-impact rule: a fact belongs in the terminal expression only when it
-can change generated UI or a drift verdict. `survey.json` can stay broad as
-evidence — including implemented `ui_surfaces[]` specimens and their observed
-composition signals — while `expression.md` stays curated.
+Expression filter: include a fact in `expression.md` only when it can change
+generated UI or a drift verdict. `survey.json` can stay broad as evidence —
+including implemented `ui_surfaces[]` specimens and their observed composition
+signals — while `expression.md` stays compact.
 
-If a layer doesn't pull weight somewhere, that's a signal the format is
-over-specified. The `verify` recipe is the schema-discipline mechanism.
+If a section does not affect generation or review, the format is probably too
+large. The `verify` recipe is how you notice that.
 
 ## Integration patterns
 
@@ -138,7 +136,7 @@ required check on PRs that touch UI files.
 
 **In a generation pipeline**: `ghost-expression emit context-bundle` writes
 the skill bundle into the generator's context; the generator produces; the
-`review` recipe gates the output. Drift disposition belongs to the pipeline
+`review` recipe checks the output. Drift disposition belongs to the pipeline
 owner (block, annotate, require `ghost-drift ack`).
 
 **Expression maintenance**: run `verify` periodically. When a dimension

--- a/packages/ghost-drift/src/skill-bundle/SKILL.md
+++ b/packages/ghost-drift/src/skill-bundle/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: ghost-drift
-description: Detect and govern visual-language drift in design systems. Use when the user wants to compare two expressions, review frontend code changes for drift against an expression.md, verify generated UI against an expression, suggest minimal fixes that close a drift gap, or record stance toward a tracked expression (acknowledge, track, diverge). Triggers on phrases like "check for drift", "compare these expressions", "review this PR for design issues", "verify this generated UI", or "we accept this divergence".
+description: Compare expressions and review UI drift. Use when the user wants to compare two expressions, review frontend code changes against an expression.md, verify generated UI, suggest fixes, or record stance toward a tracked expression (acknowledge, track, diverge). Triggers on phrases like "check for drift", "compare these expressions", "review this PR for design issues", "verify this generated UI", or "we accept this divergence".
 license: Apache-2.0
 metadata:
   homepage: https://github.com/block/ghost
   cli: ghost-drift
 ---
 
-# Ghost Drift — Design Drift Detection
+# Ghost Drift — Drift Review
 
-When you generate UI in this project, it drifts. Palette goes off, spacing creeps, hierarchy slips. This skill helps you catch and resolve that drift against the project's `expression.md` — the canonical answer to "what does the design language look like here."
+This skill compares UI changes against the project's `expression.md`. It helps catch palette, spacing, type, surface, and decision drift.
 
-You do the reading, deciding, and writing. The `ghost-drift` CLI is the calculator you reach for when you need a reproducible answer: vector distance between expressions, temporal aggregates, governance manifest writes. Call it freely; the output is ground truth.
+You do the reading and judgment. The `ghost-drift` CLI gives deterministic results: expression distance, temporal aggregates, and stance-file writes.
 
 Authoring an `expression.md` lives in the sibling `ghost-expression` skill. Drift compares them under change.
 
@@ -40,21 +40,21 @@ For authoring or describing an expression itself (write expression.md, lint, des
 
 An `expression.md` has:
 
-- **YAML frontmatter (machine layer):** `id`, `source`, `timestamp`, `references`, `observation.personality`, `observation.resembles`, `decisions[].dimension`, `checks[]`, `palette`, `spacing`, `typography`, `surfaces`.
-- **Markdown body (prose layer):** `# Character`, `# Signature`, `# Decisions` with `### <dimension>` rationale blocks ending in `**Evidence:**` bullets.
+- **YAML frontmatter:** `id`, `source`, `timestamp`, `references`, `observation.personality`, `observation.resembles`, `decisions[].dimension`, `checks[]`, `palette`, `spacing`, `typography`, `surfaces`.
+- **Markdown body:** `# Character`, `# Signature`, `# Decisions` with `### <dimension>` rationale blocks ending in `**Evidence:**` bullets.
 
-No sibling fragments are canonical. Do not look for `embedding.md`, `# Fragments`, or implicit `decisions/*.md`; comparison computes embeddings from `expression.md` at runtime.
+There are no sibling fragments. Do not look for `embedding.md`, `# Fragments`, or implicit `decisions/*.md`; comparison computes embeddings from `expression.md` at runtime.
 
 Validate via `ghost-expression lint` before drawing conclusions from a drift comparison.
 
 ## Always
 
-- Reads of `expression.md` are read-only — drift never rewrites the canonical artifact. To update an expression, run the profile recipe (in `ghost-expression`).
-- A non-zero distance is information, not a verdict. The threshold belongs to the consumer (CI gate, PR review, human judgement).
-- When the user accepts a drift, record it: `ghost-drift ack` / `track` / `diverge`. An undeclared drift is governance noise.
+- Reads of `expression.md` are read-only. Drift never rewrites it. To update an expression, run the profile recipe in `ghost-expression`.
+- A non-zero distance is information, not a verdict. The threshold belongs to the consumer (CI gate, PR review, human judgment).
+- When the user accepts a drift, record it: `ghost-drift ack` / `track` / `diverge`.
 
 ## Never
 
 - Don't go looking for CLI verbs for `review`, `verify`, or `remediate`. Those are recipes you execute, not commands to invoke.
-- Never auto-update an expression because drift exists. Expressions evolve by deliberate act — your role is to surface the drift and wait for instruction.
-- Don't expect the CLI to make the judgement call. Vector distance is math; whether the drift is intentional, acceptable, or a regression is for you to decide via the relevant recipe.
+- Never auto-update an expression because drift exists. Surface the drift and wait for instruction.
+- Don't expect the CLI to make the judgment call. Vector distance is math; whether the drift is intentional, acceptable, or a regression is for you to decide via the relevant recipe.

--- a/packages/ghost-drift/src/skill-bundle/references/remediate.md
+++ b/packages/ghost-drift/src/skill-bundle/references/remediate.md
@@ -85,4 +85,4 @@ After the user applies (or rejects) the patches:
 
 ## Why this is a recipe, not a verb
 
-Remediation requires judgement: which token is "closest", what counts as load-bearing, when to escalate vs auto-patch. None of that is deterministic, so it lives here in your court — the CLI gives you the math (`compare`), the recipe gives you the procedure, you write the patch.
+Remediation requires judgment: which token is "closest", what matters enough to fix, when to escalate vs auto-patch. None of that is deterministic, so it stays in the recipe — the CLI gives you the math (`compare`), the recipe gives you the procedure, and you write the patch.

--- a/packages/ghost-drift/src/skill-bundle/references/review.md
+++ b/packages/ghost-drift/src/skill-bundle/references/review.md
@@ -52,7 +52,7 @@ For each changed file, read the diff and look for values that don't belong to th
 - **Palette drift:** hex codes (`#ff6600`), `rgb(...)`, `oklch(...)`, Tailwind color classes (`bg-slate-500`) that aren't in `palette.dominant`/`.neutrals`/`.semantic`.
 - **Spacing drift:** `px`, `rem`, `em` values not in `spacing.scale` (converted: 1rem = 16px). Tailwind spacing classes (`p-3`, `mt-7`) that land off-grid.
 - **Typography drift:** font-family declarations not in `typography.families`, font-size values not in `sizeRamp`, font-weight values far from the `weightDistribution`.
-- **Surface drift:** `border-radius` not in `surfaces.borderRadii`, `box-shadow` present when `surfaces.shadowComplexity: deliberate-none`, or absent when the expression says shadows are load-bearing.
+- **Surface drift:** `border-radius` not in `surfaces.borderRadii`, `box-shadow` present when `surfaces.shadowComplexity: deliberate-none`, or absent when the expression expects shadows.
 - **Decision drift:** behavior that contradicts a decision (e.g. decision says "no animation" and the change adds a `transition`; decision says "component-height tokens, not padding arithmetic" and the change uses `padding-y: 14px`).
 
 ### 4. Filter noise
@@ -67,7 +67,7 @@ Drop matches that are clearly not real drift:
 
 ### 5. Produce the review
 
-Group findings by dimension. Lead with the most load-bearing drift. For each finding:
+Group findings by dimension. Lead with the most important drift. For each finding:
 
 - `file:line` — where
 - What was found (`#ff6600`)

--- a/packages/ghost-drift/src/skill-bundle/references/verify.md
+++ b/packages/ghost-drift/src/skill-bundle/references/verify.md
@@ -20,7 +20,7 @@ Ghost has no `ghost verify` CLI command. You drive the loop; the expression is t
 
 ### 1. Generate
 
-Produce the UI code. Use whatever generator/recipe your harness provides; respect `palette`, `spacing.scale`, `typography`, `surfaces`, `decisions` from the expression. The expression is the constraint set — feed it into the generator's system prompt, or load `tokens.css` (via `ghost-expression emit context-bundle`) as grounding.
+Produce the UI code. Use whatever generator or recipe this workflow provides; respect `palette`, `spacing.scale`, `typography`, `surfaces`, and `decisions` from the expression. Feed the expression into the generator's system prompt, or load `tokens.css` via `ghost-expression emit context-bundle`.
 
 ### 2. Self-review
 

--- a/packages/ghost-expression/README.md
+++ b/packages/ghost-expression/README.md
@@ -2,19 +2,19 @@
 
 **Author the three-stage scan of a project's design language: `map.md` → `survey.json` → `expression.md`. No LLM calls in any verb.**
 
-`ghost-expression` owns the on-disk artifacts every other Ghost tool reads. A scan runs in three stages, each a separate skill recipe with a deterministic CLI verb as its success gate:
+`ghost-expression` owns the scan files every other Ghost tool reads. A scan has three stages:
 
 | Stage | Artifact | Schema | Authored via | Validated by |
 |---|---|---|---|---|
 | **Map** | `map.md` | `ghost.map/v2` | `map.md` skill recipe + `ghost-expression inventory` | `ghost-expression lint map.md` |
 | **Survey** | `survey.json` | `ghost.survey/v2` | `survey.md` skill recipe + `ghost-expression survey fix-ids` | `ghost-expression lint survey.json` |
-| **Express** | `expression.md` | (unversioned) | `profile.md` skill recipe (reads survey as ground truth) | `ghost-expression lint expression.md` + `ghost-expression verify-profile expression.md survey.json --root .` |
+| **Express** | `expression.md` | (unversioned) | `profile.md` skill recipe (reads survey evidence) | `ghost-expression lint expression.md` + `ghost-expression verify-profile expression.md survey.json --root .` |
 
 This is a breaking v0 scan migration: `ghost.map/v1` and `ghost.survey/v1` are no longer accepted. Regenerate old scan artifacts through map → survey so `surface_sources` and `ui_surfaces[]` capture implemented UI evidence.
 
-The CLI parses, lints (auto-detects file kind), verifies profile-to-survey fidelity, inventories raw repo signals, runs deterministic data ops on surveys (`merge`, `fix-ids`, `summarize`, `catalog`), structurally diffs expressions, reports per-stage scan progress, and emits derived artifacts (per-project review slash commands, generation context bundles, agentskills.io skill bundles).
+The CLI validates files, verifies that an expression matches its survey, inventories repo signals, runs survey ops (`merge`, `fix-ids`, `summarize`, `catalog`), diffs expressions, reports scan progress, and emits derived artifacts.
 
-The actual *writing* of each artifact is a host-agent recipe — the four ship in this package's skill bundle and walk an agent through map / survey / expression / end-to-end orchestration. The CLI here is the success gate.
+The actual writing is done by your host agent using the recipes in this package. The CLI is the checker.
 
 For drift detection, comparison, and stance recording (`compare`, `ack`, `track`, `diverge`), see **[`ghost-drift`](../ghost-drift)**.
 
@@ -114,16 +114,16 @@ The bundle ships four recipes:
 
 - **`scan.md`** — meta-recipe orchestrating map → survey → profile end-to-end via `scan-status` checkpoints. Use when the user wants a full scan rather than a specific stage.
 - **`map.md`** — write `map.md` from a target's `inventory` output. Stage 1.
-- **`survey.md`** — write `survey.json` from a target's source code. Stage 2. The load-bearing exhaustiveness rule lives here: enumerate the canonical signal in *this* repo (registry, manifest, named declarations), record implemented UI surfaces in `ui_surfaces[]`, and cross-check counts; sampling is forbidden.
+- **`survey.md`** — write `survey.json` from a target's source code. Stage 2. Enumerate concrete values, tokens, components, and implemented UI surfaces; do not sample.
 - **`profile.md`** — interpret a `survey.json` into `expression.md`. Stage 3. Cannot fabricate values not in the survey; cites survey rows as evidence; validates fidelity with `verify-profile`.
 
-Plus a condensed schema reference (`schema.md`) for the `expression.md` frontmatter / body partition.
+Plus a condensed schema reference (`schema.md`) for the `expression.md` frontmatter and body.
 
-Once installed, ask your agent to "scan this design language end-to-end" (or just "profile this design language") and it'll follow the recipes, ending each map/survey stage at `lint` and ending the expression stage at `lint` + `verify-profile`.
+Once installed, ask your agent to "scan this design language end-to-end" or "profile this design language". It will follow the recipes, lint map and survey outputs, then run `lint` and `verify-profile` for the expression.
 
-## Canonical artifacts
+## Format Docs
 
-See [`docs/expression-format.md`](https://github.com/block/ghost/blob/main/docs/expression-format.md) for the full `expression.md` spec. Runtime comparison derives embeddings from the authored file; no sibling embedding artifact is canonical.
+See [`docs/expression-format.md`](https://github.com/block/ghost/blob/main/docs/expression-format.md) for the full `expression.md` spec. Runtime comparison derives embeddings from the authored file; there is no sibling embedding file.
 
 The `ghost.survey/v2` schema and `ghost.map/v2` schema both live in `@ghost/core`; the condensed authoring references ship in this package's skill bundle.
 

--- a/packages/ghost-expression/src/skill-bundle/SKILL.md
+++ b/packages/ghost-expression/src/skill-bundle/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: ghost-expression
-description: Author and validate expression.md — Ghost's canonical design-language artifact. Use when the user wants to write or update an expression.md, validate one, describe its structure, diff two of them, or emit derived artifacts (review-command, context-bundle, agent skill). Triggers on phrases like "profile this design language", "write expression.md", "lint my expression", "what does this expression say", or whenever an `expression.md` file is being authored.
+description: Author and validate expression.md. Use when the user wants to write or update an expression.md, validate one, describe its structure, diff two of them, or emit derived artifacts (review-command, context-bundle, agent skill). Triggers on phrases like "profile this design language", "write expression.md", "lint my expression", "what does this expression say", or whenever an `expression.md` file is being authored.
 license: Apache-2.0
 metadata:
   homepage: https://github.com/block/ghost
   cli: ghost-expression
 ---
 
-# Ghost Expression — Authoring the Canonical Artifact
+# Ghost Expression — Authoring expression.md
 
-This skill helps you author a project's design language — its `expression.md` (YAML frontmatter + Markdown body: Character → Signature → Decisions). You profile a project to write one, then validate, describe, diff, and emit derived artifacts. The **change** half (compare two expressions for drift, acknowledge it, track another expression as your reference) lives in the sibling `ghost-drift` skill.
+This skill helps you write a project's `expression.md`: YAML frontmatter plus a Markdown body with Character, Signature, and Decisions. Use it to profile a project, validate the result, inspect its structure, diff two expressions, or emit derived artifacts. Drift comparison and stance recording live in the sibling `ghost-drift` skill.
 
-You do the synthesis (the profile recipe). The `ghost-expression` CLI is the calculator you reach for when you need a reproducible answer: parsing, schema validation, layout, structural diff. Call it freely; the output is ground truth.
+You do the synthesis. The `ghost-expression` CLI gives deterministic answers for parsing, schema validation, layout, profile verification, and structural diff.
 
 **Two install paths, same recipes.** When the user installed via `curl … | sh` (the no-CLI v0 path) the `ghost-expression` binary is *not* on PATH. The recipes degrade gracefully: every CLI-using step has a prose fallback you can execute via `Read` / `Glob` / `Bash` / `Grep`. Detect availability once, at the start of a workflow:
 
@@ -19,7 +19,7 @@ You do the synthesis (the profile recipe). The `ghost-expression` CLI is the cal
 command -v ghost-expression >/dev/null && echo "cli" || echo "prose"
 ```
 
-When the CLI is present, prefer it — the output is deterministic and idempotent. When it isn't, follow the fallback recipes. Don't ask the user to install the CLI mid-workflow; the prose path is real, not a degraded mode.
+When the CLI is present, prefer it. When it is not, follow the fallback steps in the recipes instead of stopping to ask the user to install anything.
 
 ## CLI verbs
 
@@ -58,12 +58,12 @@ For drift detection (compare under change, ack/track/diverge, review PR diffs ag
 
 An `expression.md` has:
 
-- **YAML frontmatter (machine layer):** `id`, `source`, `timestamp`, `references`, `observation.personality`, `observation.resembles`, `decisions[].dimension`, `checks[]`, `palette`, `spacing`, `typography`, `surfaces`.
-- **Markdown body (prose layer):** `# Character`, `# Signature`, `# Decisions` with `### <dimension>` rationale blocks ending in `**Evidence:**` bullets.
+- **YAML frontmatter:** `id`, `source`, `timestamp`, `references`, `observation.personality`, `observation.resembles`, `decisions[].dimension`, `checks[]`, `palette`, `spacing`, `typography`, `surfaces`.
+- **Markdown body:** `# Character`, `# Signature`, `# Decisions` with `### <dimension>` rationale blocks ending in `**Evidence:**` bullets.
 
-`decisions[].dimension` is an index, not an empty decision object: the body carries the actual rationale and evidence. `references` are local provenance / optional source material; the expression body should remain portable enough to drift against or generate from in another project.
+`decisions[].dimension` is an index. The body carries the actual rationale and evidence. `references` are local provenance and optional source material; the body should still make sense if another project cannot open those paths.
 
-No sibling fragments are canonical. Do not author or load `embedding.md`, `# Fragments`, or implicit `decisions/*.md`; runtime comparison computes embeddings from the parsed expression structure.
+Everything authored lives in `expression.md`. Do not author or load `embedding.md`, `# Fragments`, or implicit `decisions/*.md`; runtime comparison computes embeddings from the parsed expression.
 
 When profiling for generation, capture positive range as well as constraints. A restrained system should still say how it creates variety: editorial scale, shaped composition, semantic/data color, role-based elevation, functional motion, local font sourcing, a deliberate type ramp, or themeable tokens. Use `composition-patterns` when examples show article, tracker, comparison, card, or control-surface shapes.
 
@@ -83,4 +83,4 @@ Each field lives in exactly one layer — no duplication. Putting prose in front
 - Never invent tokens. If you did not observe a value in the source, omit the field. A missing field is better than a fabricated one.
 - Never use the W3C Design Tokens or Style Dictionary format. Ghost's `expression.md` is the artifact.
 - Never stop at the first variable indirection. Follow the chain.
-- Never write prose into frontmatter or structural data into the body — the partition is load-bearing.
+- Never write prose into frontmatter or structural data into the body.

--- a/packages/ghost-expression/src/skill-bundle/references/map.md
+++ b/packages/ghost-expression/src/skill-bundle/references/map.md
@@ -109,7 +109,7 @@ Use `design_system.upstream` as the compatibility breadcrumb, but `sources[]` is
 
 ### 4. Body sections
 
-`map.md` requires a short prose body with three sections — keep them tight, two-to-four sentences each. The body is interpretation; the frontmatter is ground truth. Sections must appear in this order:
+`map.md` requires a short prose body with three sections — keep them tight, two-to-four sentences each. The body explains the map; the frontmatter stores the structured data. Sections must appear in this order:
 
 - `## Identity` — what is this repo, what does it produce, who consumes it?
 - `## Topology` — how is the codebase organized? Where does the design system live relative to product code?
@@ -151,6 +151,6 @@ Common errors regardless of path:
 
 ## Never
 
-- Never put prose into frontmatter or structural data into the body — the partition is load-bearing.
+- Never put prose into frontmatter or structural data into the body.
 - Never duplicate the inventory's content in the body. The body is interpretation, not data.
 - Never declare done before `ghost-expression lint map.md` exits 0.

--- a/packages/ghost-expression/src/skill-bundle/references/profile.md
+++ b/packages/ghost-expression/src/skill-bundle/references/profile.md
@@ -12,17 +12,17 @@ handoffs:
 
 # Recipe: Profile a project into expression.md
 
-**Goal:** produce a valid `expression.md` that captures the target's design language as an interpretation. **You are the interpreter, not the surveyor.** Treat `survey.json` as ground truth for what values the target actually ships, but read it through a bounded survey summary first; write decisions, form the prose body, and fill the structured token blocks. Do not re-extract values from source — that's the surveyor's job and you'd be doing it twice.
+**Goal:** write a valid `expression.md` from an existing `map.md` and `survey.json`. **Do not re-scan source here.** Use the survey as evidence, write the prose decisions, and fill the structured value blocks.
 
-`expression.md` is the terminal artifact in a three-stage scan: map (`map.md`) → survey (`survey.json`) → express (`expression.md`). Yours is the third stage.
+`expression.md` is stage 3 of a scan: map (`map.md`) → survey (`survey.json`) → express (`expression.md`).
 
-Terminal-impact filter:
+Keep it selective:
 
-> A fact belongs in `expression.md` only if it can change a drift verdict or change generated UI.
+> Put a fact in `expression.md` only if it can change generated UI or a drift review.
 
-`survey.json` is evidence. `expression.md` is curated truth. Do not summarize every survey row, every component, or every upstream token. Promote the few repeated constraints, defaults, absences, references, signatures, and token choices that downstream review or generation will actually use.
+`survey.json` is evidence. `expression.md` is the compact contract. Do not summarize every row or component. Keep only the repeated constraints, defaults, absences, references, signatures, and values that generation or review will use.
 
-`survey.json` is not generation prompt context. It is exhaustive evidence storage. Use `ghost-expression survey summarize survey.json` as the working context for profiling, then look up raw rows only when you need exact provenance. Write a compact expression that carries only the digest needed for generation and drift. Assume `expression.md` may be used as a reference by another project that does not have the original files. Local paths belong in `references:` and evidence provenance; the prose body must stand on its own.
+Do not use raw `survey.json` as prompt context except for targeted lookup. Start with `ghost-expression survey summarize survey.json`; use `ghost-expression survey catalog survey.json` for exact values. Local paths belong in `references:` and evidence bullets, but the prose body should stand on its own.
 
 ## Pre-requisites
 
@@ -33,31 +33,31 @@ Two artifacts must exist before you start, and two bounded working views should 
 - Survey summary — run `ghost-expression survey summarize survey.json` and read the Markdown digest as your primary survey context. Use `--budget compact` for a tight first pass, `--budget standard` by default, or `--format json` when another tool needs structured data.
 - Survey catalog — run `ghost-expression survey catalog survey.json` when you need exact compact value enums/specs for frontmatter. Use `--kind color`, `--kind spacing`, `--kind typography`, `--kind radius`, or `--kind shadow` to focus a dimension.
 
-If either is missing, **stop**. Run the map and survey stages first. Inventing an expression from incomplete inputs poisons every downstream comparison.
+If either is missing, **stop**. Run the map and survey stages first.
 
 ## How to read the survey
 
 A `survey.json` has four sections:
 
-- **`values[]`** — concrete literals shipped in source. Group by `kind`: `color` rows feed `palette`; `spacing` rows feed `spacing.scale` / `spacing.baseUnit`; `typography` rows feed `typography.*`; `radius` rows feed `surfaces.borderRadii`; `shadow` rows feed `surfaces.shadowComplexity` (count + complexity, not literal shadows); `breakpoint` / `motion` / `layout-primitive` rows feed Decisions where they're load-bearing. Each row has `occurrences` (total count) and `files_count` (spread). Higher numbers = stronger signal.
+- **`values[]`** — concrete literals shipped in source. Group by `kind`: `color` rows feed `palette`; `spacing` rows feed `spacing.scale` / `spacing.baseUnit`; `typography` rows feed `typography.*`; `radius` rows feed `surfaces.borderRadii`; `shadow` rows feed `surfaces.shadowComplexity` (count + complexity, not literal shadows); `breakpoint` / `motion` / `layout-primitive` rows feed Decisions when they matter. Each row has `occurrences` (total count) and `files_count` (spread). Higher numbers = stronger signal.
 - **`tokens[]`** — named declarations with `alias_chain` (path through indirection) and `resolved_value`. Long chains and semantic naming (`--color-brand-primary` → `--color-orange-500`) are evidence of a deliberate token layer. Empty chains everywhere = inline literals = no token discipline.
 - **`components[]`** — known components (registry entries or heuristically discovered). Contributes count signal to surface-vocabulary decisions and grounds prose about what the system ships.
 - **`ui_surfaces[]`** — implemented UI specimens. Cluster by `classification.layout_shape`, `classification.density`, `classification.intent`, `classification.surface_type`, and repeated `signals.layout_patterns`; treat tags as soft and `signals` as the factual layer.
 
 Rows may carry `source.role` and `resolution` provenance. Interpret these as a source graph: `primary` sources supply usage/salience, while `resolver` sources supply concrete values for symbols the primary actually uses. A resolver-defined value that has no primary usage is not salient for this expression.
 
-External libraries (icon sets, primitive collections, motion libs) deliberately don't have a survey section — whether a system uses Radix or hand-rolls primitives doesn't change what its design language *is*. When a library is load-bearing for the design language (icon family choice, font sourcing), cite it as prose evidence under the relevant decision dimension; don't expect it as structured data.
+External libraries (icon sets, primitive collections, motion libs) deliberately don't have a survey section — whether a system uses Radix or hand-rolls primitives doesn't change what its design language *is*. When a library matters to the design language (icon family choice, font sourcing), cite it as prose evidence under the relevant decision dimension; don't expect it as structured data.
 
 Do not paste or load a large `survey.json` wholesale into your working context. Start with:
 
     ghost-expression survey summarize survey.json
     ghost-expression survey catalog survey.json
 
-For large scans, these are the only survey-derived views you should read end-to-end: `summarize` for broad profiling context, `catalog` for exact value enums/specs. Keep the raw `survey.json` available for targeted lookup by row ID when a palette entry, token, check, or evidence bullet needs exact provenance:
+For large scans, read only these derived views end-to-end: `summarize` for broad context and `catalog` for exact values/specs. Use raw `survey.json` only for targeted row lookup:
 
     jq '.values[] | select(.id=="<row-id>")' survey.json
 
-If the survey is tiny, directly reading it is acceptable, but the summary-first path is the default because it keeps interpretation bounded and repeatable.
+If the survey is tiny, direct reading is fine. Default to summary first.
 
 ## Steps
 
@@ -94,7 +94,7 @@ Before writing prose, cluster `ui_surfaces[]` into the repeated composition fami
 - Repeated `layout_shape` values (`control-surface`, `article`, `tracker`, `comparison`, `card`, `flow`, `navigation`) with confidence ≥ 0.7.
 - Repeated `signals.layout_patterns` such as `sectioned-form`, `left-nav`, `persistent-actions`, `data-table`, `media-grid`, `empty-state`, or `wizard-flow`.
 - Density splits: compact controls inside spacious pages, compressed operational screens, breathing editorial pages.
-- Which components dominate each family, and which value rows (`value_refs`) are visibly load-bearing.
+- Which components dominate each family, and which value rows (`value_refs`) visibly matter.
 - Coverage gaps from `surface_sources.coverage_gaps` or empty/weak `ui_surfaces[]`; do not overstate composition if surface evidence is sparse.
 
 Keep this clustering in your scratchpad. Promote only repeated, generation-impacting facts into the expression:
@@ -137,7 +137,7 @@ Promote these levers into `# Character`, `# Signature`, relevant decisions, or c
 
 ### 5. Layer 2 — Checks (curated, grep-friendly, perceptual-prior-aware)
 
-This is the load-bearing step. **Your job is to propose 5–15 candidate checks, score each by survey-derived support, and present the ranked list to the human curator.** The curator promotes the sharpest 5–10 to `checks[]`. Promoted checks are the primary drift contract: they need `support >= 0.85`, `observed_count` when calibrated from survey evidence, and `paths` scopes when the verifier should count filesystem matches. `contexts` are guidance for reviewers/generators, not verifier scopes. You do not author final checks unilaterally — design taste is human-curated, agent-proposed.
+This is the main step for review readiness. **Your job is to propose 5–15 candidate checks, score each by survey-derived support, and present the ranked list to the human curator.** The curator promotes the sharpest 5–10 to `checks[]`. Promoted checks are the primary drift contract: they need `support >= 0.85`, `observed_count` when calibrated from survey evidence, and `paths` scopes when the verifier should count filesystem matches. `contexts` are guidance for reviewers/generators, not verifier scopes. You do not author final checks unilaterally — design taste is human-curated, agent-proposed.
 
 Promotion boundary: `checks[]` is the promoted layer, not the scratchpad. If no curator has selected checks in this turn, leave `checks[]` empty and put the ranked candidate list in your final response or scan notes. The expression is still valid without checks; an unpromoted check is more dangerous than a missing check because it turns an agent guess into enforcement.
 
@@ -325,7 +325,7 @@ Self-distance must be 0. Anything else means the file isn't deterministically lo
 
 **Prose fallback (no CLI / no ghost-drift):**
 
-Re-load the file mentally: parse the frontmatter, normalize whitespace in the body, then verify the file would round-trip through a YAML parser without info loss. If you can't be sure, run the CLI (it's the calculator that exists for exactly this question). The self-distance check is genuinely a "machine math" answer — prose verification is best-effort, not authoritative.
+Re-load the file mentally: parse the frontmatter, normalize whitespace in the body, then verify the file would round-trip through a YAML parser without info loss. If you can't be sure, run the CLI. The self-distance check is a machine answer; prose verification is best-effort.
 
 ## When the survey is incomplete
 
@@ -333,4 +333,4 @@ If the surveyor's `survey.json` has known gaps (a `# Coverage` note in the surve
 
 ## When you cannot profile
 
-If `survey.json` is empty (a backend-only repo, no UI) and `map.md` confirms no design system, say so in `# Character` and emit a minimal expression with empty palette/spacing/typography/surfaces. Do not fabricate. A placeholder expression poisons every downstream comparison.
+If `survey.json` is empty (a backend-only repo, no UI) and `map.md` confirms no design system, say so in `# Character` and emit a minimal expression with empty palette/spacing/typography/surfaces. Do not fabricate.

--- a/packages/ghost-expression/src/skill-bundle/references/scan.md
+++ b/packages/ghost-expression/src/skill-bundle/references/scan.md
@@ -76,7 +76,7 @@ Run when `scan-status` reports `map: present` and `survey: missing`.
 
 Recipe: [survey.md](survey.md). The agent reads `map.md` to recognize the dialect and source graph, runs LLM-driven extraction (its own greps/regexes), records rows with empty `id` fields, finalizes IDs with `ghost-expression survey fix-ids survey.json -o survey.json`, then validates with `ghost-expression lint survey.json`.
 
-The survey is the longest stage and the one with the most discipline (exhaustiveness, saturation, cross-checking counts). Don't shortcut it — the interpreter downstream cannot fabricate values that aren't in the survey, so missed values become missed expression fields permanently. Broad survey evidence is okay; over-broad terminal expression is not.
+The survey is the longest stage and the one with the most discipline (exhaustiveness, saturation, cross-checking counts). Don't shortcut it — the interpreter downstream cannot fabricate values that aren't in the survey, so missed values become missed expression fields permanently. Broad survey evidence is okay; an overstuffed `expression.md` is not.
 
 After validation, re-run `scan-status` and proceed.
 
@@ -84,7 +84,7 @@ After validation, re-run `scan-status` and proceed.
 
 Run when `scan-status` reports both prior stages `present` and `expression: missing`.
 
-Recipe: [profile.md](profile.md). The agent reads `map.md` (for repo-kind signals), runs `ghost-expression survey summarize survey.json` for bounded survey context, uses `ghost-expression survey catalog survey.json` for exact value enums/specs, and keeps raw `survey.json` available only for targeted row lookup. It writes `expression.md` purely as interpretation: emits local references, names decisions, writes portable Character and Signature prose, fills frontmatter from survey rows, and promotes only human-curated checks. Cannot invent values not in the survey. Cannot dump every survey fact into the terminal artifact. First scans leave `checks[]` empty unless the user explicitly selects checks to promote; candidate checks belong in the agent response or scan notes. Validates with `ghost-expression lint expression.md`, `ghost-expression verify-profile expression.md survey.json --root <target>`, and a self-distance sanity check (`ghost-drift compare expression.md expression.md` returns 0).
+Recipe: [profile.md](profile.md). The agent reads `map.md` (for repo-kind signals), runs `ghost-expression survey summarize survey.json` for bounded survey context, uses `ghost-expression survey catalog survey.json` for exact value enums/specs, and keeps raw `survey.json` available only for targeted row lookup. It writes `expression.md` as a compact contract: local references, named decisions, portable Character and Signature prose, survey-backed frontmatter values, and only human-curated checks. It cannot invent values not in the survey. First scans leave `checks[]` empty unless the user explicitly selects checks to promote; candidate checks belong in the agent response or scan notes. Validates with `ghost-expression lint expression.md`, `ghost-expression verify-profile expression.md survey.json --root <target>`, and a self-distance sanity check (`ghost-drift compare expression.md expression.md` returns 0).
 
 Stage 3 has a different audience from stages 1 and 2. `map.md` and `survey.json` are allowed to be repo-specific because they are scan artifacts. `expression.md` is the drift/generation root and may be used by another project that cannot resolve the original paths, so its body must describe portable design-language patterns. Local paths belong in `references:` or as optional evidence provenance, not as the main content of Character, Signature, or Decisions.
 
@@ -98,7 +98,7 @@ Each stage is resumable independently because `scan-status` checks artifact pres
 
 ## When a stage fails
 
-If a stage's lint fails, fix the issue in the recipe pass and re-validate. **Do not move to the next stage on a failed lint** — the next stage's recipe assumes a valid input. A malformed `map.md` poisons the survey; a malformed `survey.json` poisons the interpretation.
+If a stage's lint fails, fix the issue in the recipe pass and re-validate. **Do not move to the next stage on a failed lint** — the next stage's recipe assumes a valid input.
 
 If you cannot make a stage pass (e.g. the target genuinely has no design system), the recipe for that stage tells you what to do — usually: write a minimal valid artifact that surfaces the gap (e.g. `expression.md` with empty palette and a `# Character` note explaining the absence), so downstream tools see honest "no signal" rather than a hallucinated one.
 

--- a/packages/ghost-expression/src/skill-bundle/references/schema.md
+++ b/packages/ghost-expression/src/skill-bundle/references/schema.md
@@ -1,10 +1,10 @@
 # expression.md schema reference
 
-Canonical filename: `expression.md`.
+Expected filename: `expression.md`.
 
 `expression.md` is the authored design-language contract. It may point at local `references`, but sibling files are not auto-loaded as authored truth: no `embedding.md`, no `# Fragments`, and no implicit `decisions/` directory.
 
-## Frontmatter (machine layer)
+## Frontmatter
 
 ```yaml
 ---
@@ -75,7 +75,7 @@ Optional: `sources`, `references`, `observation.personality`, `observation.resem
 
 Forbidden in frontmatter: root `embedding`, `decisions[].embedding`, `observation.summary`, `decisions[].decision`, `decisions[].evidence`, `checks[].enforce_at`, `checks[].rationale`, and unknown root keys such as `schema`.
 
-## Body (prose layer)
+## Body
 
 ```markdown
 # Character

--- a/packages/ghost-expression/src/skill-bundle/references/survey.md
+++ b/packages/ghost-expression/src/skill-bundle/references/survey.md
@@ -14,7 +14,7 @@ handoffs:
 
 **Goal:** produce a valid `survey.json` (`ghost.survey/v2`) that catalogues every concrete design value and implemented UI surface the target ships, with structured specs, occurrence counts, and surface evidence. **You are the surveyor, not the interpreter.** Record what is there. Do not assign meaning. Do not write prose. Do not invent.
 
-`survey.json` is the middle artifact in a three-stage scan: map (`map.md`) → survey (`survey.json`) → express (`expression.md`). The interpreter (next stage) reads your survey as ground truth and writes the compact expression. If you skip values or fabricate them here, the expression downstream is wrong.
+`survey.json` is the middle artifact in a three-stage scan: map (`map.md`) → survey (`survey.json`) → express (`expression.md`). The interpreter reads your survey as evidence and writes the compact expression. If you skip values or fabricate them here, the expression downstream is wrong.
 
 The survey is exhaustive evidence, not prompt context. It should be large enough to support interpretation; the profile stage decides what becomes generation-facing expression.
 
@@ -44,7 +44,7 @@ Each row carries an `id` (deterministic SHA-256 prefix you do **not** compute by
 - **`components[]`** — every named component you can confidently identify (registry entries, exported PascalCase components with variants/sizes). Loose schema: `name`, `discovered_via` (`registry.json` / `heuristic` / etc.), optional `variants[]` and `sizes[]`.
 - **`ui_surfaces[]`** — implemented UI specimens the design language can be inferred from. Each row has `name`, `kind` (`route`, `story`, `screen`, `fixture`, `doc-example`, `screenshot`, `source`), `locator`, `renderability` (`rendered`, `screenshot`, `source-only`, `unknown`), `files[]`, optional soft `classification`, and factual `signals`.
 
-External libraries (icon sets, primitive collections, motion libs, charting, etc.) are intentionally *not* a survey section. Whether a system uses Radix or hand-rolls primitives doesn't change what its design language *is*. When a library is load-bearing (icon family, font sourcing), surface it in the interpreter stage as prose evidence under the relevant decision dimension instead.
+External libraries (icon sets, primitive collections, motion libs, charting, etc.) are intentionally *not* a survey section. Whether a system uses Radix or hand-rolls primitives doesn't change what its design language *is*. When a library matters to the design language (icon family, font sourcing), surface it in the interpreter stage as prose evidence under the relevant decision dimension instead.
 
 Every row needs `occurrences` (total count across the scan) and (for values) `files_count` (distinct files that contain the value). Optional `usage` breaks down by context: `{className: 30, css_var: 17}`. Optional `role_hypothesis` is a single tentative role tag (`brand-primary`, `surface-elevated`); **leave it empty if you are not sure** — the interpreter does role assignment, not you.
 
@@ -92,7 +92,7 @@ Recall is the failure mode and the only one. A survey missing 90% of a section's
 
 For every section (`values[]`, `tokens[]`, `components[]`, `ui_surfaces[]`):
 
-1. **Identify the canonical signal in this repo.** Where does the source of truth for this kind of thing actually live? It will be different in every repo — a manifest, a registry, a barrel export, a CSS declaration block, a naming convention. Use the strongest signal the repo offers.
+1. **Identify the strongest signal in this repo.** Where is this kind of value most reliably declared or used? It will be different in every repo — a manifest, a registry, a barrel export, a CSS declaration block, a naming convention. Use the strongest signal the repo offers.
 2. **Enumerate, don't sample.** If you can count entries from the canonical signal independently, your row count must match. 6 components when the canonical signal lists 100 is a lie.
 3. **Cross-check by a second method when one exists** (e.g., file count by glob vs. enumerated entries vs. import graph). If the two counts disagree by more than ~10%, you're missing entries — investigate before recording.
 4. **Honest absence beats partial truth.** If the section has no canonical signal in this repo, leave the array empty rather than recording a sample. Empty is honest; sampled is misleading.
@@ -103,7 +103,7 @@ This applies regardless of dialect. The recipe doesn't tell you what the canonic
 
 **You write your own greps and regexes. There is no pre-built parser.** Adapt to what's actually in the repo:
 
-- **Tailwind (Tailwind v3 / v4 with `@theme`)** — class atoms are load-bearing for the survey. The declared `--spacing-*` / `--text-*` / `--color-*` tokens in `@theme` are only half the picture; the other half is which atoms components actually use, because Tailwind synthesizes most of the rendered scale from the `--spacing` modular base (`p-2` → `padding: calc(var(--spacing) * 2)` → 8px when `--spacing: 0.25rem`). A survey built from declarations alone undercounts spacing/typography/color systematically — see the `## Tailwind class-atom pass` section below.
+- **Tailwind (Tailwind v3 / v4 with `@theme`)** — class atoms are important survey evidence. The declared `--spacing-*` / `--text-*` / `--color-*` tokens in `@theme` are only half the picture; the other half is which atoms components actually use, because Tailwind synthesizes most of the rendered scale from the `--spacing` modular base (`p-2` → `padding: calc(var(--spacing) * 2)` → 8px when `--spacing: 0.25rem`). A survey built from declarations alone undercounts spacing/typography/color systematically — see the `## Tailwind class-atom pass` section below.
 - **CSS / SCSS / CSS modules** — `rg -oN '#[0-9a-fA-F]{3,8}\b' -g '*.{css,scss,sass}'` for hex; `rg -oN '\b(rgba?|hsla?|oklch|color)\([^)]+\)' -g '*.{css,scss}'` for color functions; `rg -oN '\b[0-9]+(\.[0-9]+)?(px|rem|em|%|vh|vw|fr|ch|svh|dvh)\b' -g '*.{css,scss}'` for scalars; `rg -oN -- '--[a-z0-9-]+\s*:' -g '*.{css,scss}'` for custom properties.
 - **CSS-in-JS (styled-components, emotion, vanilla-extract)** — same regex set but expand `-g '*.{ts,tsx,js,jsx}'`. Watch for template literals split across lines.
 - **iOS / Swift** — `rg -oN 'Color\([^)]+\)|UIColor\([^)]+\)|\.(red|blue|green|orange|brand[A-Za-z]*)\b' -g '*.swift'` for color sites; `rg -oN '\b[0-9]+(\.[0-9]+)?\b' -g '*.swift' | sort | uniq -c | sort -rn | head -50` for likely scalars (lots of noise; keep top-N by frequency).
@@ -281,4 +281,4 @@ If you hit a hard stop with exhaustiveness *not* met, write a `# Coverage` note 
 - **Never undercount silently.** If your coverage is weak (mobile dialects, custom DSLs, no canonical signal in this repo), surface it in a `# Coverage` scratchpad note and tell the interpreter.
 - **Never compute IDs by hand.** Use `survey fix-ids`.
 - **Never use placeholder/glob names.** A component row with `name: "*Button"` or `name: "<various>"` is sampling-disguised-as-a-row. Enumerate concretely.
-- **Never edit a survey after the interpreter has used it.** If you find a missed value later, re-run survey end-to-end. The survey is the frozen ground truth between scan and interpretation.
+- **Never edit a survey after the interpreter has used it.** If you find a missed value later, re-run survey end-to-end. Treat the survey used for a profile as frozen evidence.


### PR DESCRIPTION
🤖 Created by my AI agent.

## Summary

- Simplifies and clarifies Ghost docs around agent-led scan, generation, and drift workflows.
- Tightens ghost-expression and ghost-drift skill bundle guidance to describe deterministic CLI checks and authored `expression.md` responsibilities more plainly.
- Adds a changeset for `ghost-drift` and `ghost-expression` patch releases.

## Test plan

- `pnpm check` via pre-commit hook
- `pnpm build` via pre-push hook
- `pnpm check` via pre-push hook
- `pnpm test` via pre-push hook: 34 files / 407 tests passed