### PR TITLE
[codex] Add drift repair hints and inline comments

### DIFF
--- a/.changeset/ghost-drift-github-comments.md
+++ b/.changeset/ghost-drift-github-comments.md
@@ -1,0 +1,6 @@
+---
+"@ghost/core": minor
+"ghost-drift": minor
+---
+
+Add check-authored repair hints and a GitHub PR comment command for grouped inline drift comments.

--- a/.changeset/ghost-drift-repair-hints.md
+++ b/.changeset/ghost-drift-repair-hints.md
@@ -1,0 +1,5 @@
+---
+"ghost-drift": minor
+---
+
+Add deterministic, source-backed repair hints for supported Tailwind arbitrary color drift findings.

--- a/.changeset/ghost-fingerprint-check-proposals.md
+++ b/.changeset/ghost-fingerprint-check-proposals.md
@@ -1,0 +1,6 @@
+---
+"@ghost/core": patch
+"ghost-fingerprint": patch
+---
+
+Add fingerprint-generated proposed check output for reviewable Ghost check authoring.

--- a/apps/docs/src/generated/cli-manifest.json
+++ b/apps/docs/src/generated/cli-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T00:33:39.453Z",
+  "generatedAt": "2026-05-07T18:11:43.622Z",
   "tools": [
     {
       "tool": "ghost-drift",
@@ -184,6 +184,62 @@
               "description": "Output format: markdown or json",
               "default": "markdown",
               "takesValue": true,
+              "negated": false
+            }
+          ]
+        },
+        {
+          "tool": "ghost-drift",
+          "name": "github-comment",
+          "rawName": "github-comment",
+          "description": "Run ghost-drift check and create/update GitHub PR inline comments plus one summary comment.",
+          "options": [
+            {
+              "rawName": "--repo <repo>",
+              "name": "repo",
+              "description": "GitHub repository in owner/name form",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--pr <number>",
+              "name": "pr",
+              "description": "Pull request number",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--base <ref>",
+              "name": "base",
+              "description": "Git ref to diff against (default: HEAD)",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--diff <patch>",
+              "name": "diff",
+              "description": "Unified diff file to check instead of running git diff. Use '-' for stdin.",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--package <dir>",
+              "name": "package",
+              "description": "Fingerprint package directory (default: .ghost/fingerprint)",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--dry-run",
+              "name": "dryRun",
+              "description": "Print comments without calling GitHub",
+              "default": null,
+              "takesValue": false,
               "negated": false
             }
           ]

--- a/apps/docs/src/generated/cli-manifest.json
+++ b/apps/docs/src/generated/cli-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T18:11:43.622Z",
+  "generatedAt": "2026-05-08T02:45:30.096Z",
   "tools": [
     {
       "tool": "ghost-drift",
@@ -473,6 +473,22 @@
               "name": "budget",
               "description": "survey summarize budget: compact, standard, full",
               "default": "standard",
+              "takesValue": true,
+              "negated": false
+            }
+          ]
+        },
+        {
+          "tool": "ghost-fingerprint",
+          "name": "checks",
+          "rawName": "checks <op> [package]",
+          "description": "Operate on ghost.checks/v1 documents. Ops: propose.",
+          "options": [
+            {
+              "rawName": "--format <fmt>",
+              "name": "format",
+              "description": "Output format: yaml or json",
+              "default": "yaml",
               "takesValue": true,
               "negated": false
             }

--- a/packages/ghost-core/src/checks/index.ts
+++ b/packages/ghost-core/src/checks/index.ts
@@ -15,6 +15,7 @@ export type {
   GhostCheckDetector,
   GhostCheckDetectorType,
   GhostCheckEvidence,
+  GhostCheckRepairHint,
   GhostCheckSeverity,
   GhostCheckStatus,
   GhostChecksDocument,

--- a/packages/ghost-core/src/checks/schema.ts
+++ b/packages/ghost-core/src/checks/schema.ts
@@ -32,6 +32,7 @@ const GhostCheckEvidenceExampleSchema = z.union([
   z
     .object({
       path: z.string().min(1),
+      line: z.number().int().positive().optional(),
       note: z.string().min(1).optional(),
     })
     .strict(),
@@ -42,6 +43,7 @@ const GhostCheckEvidenceSchema = z
     support: z.number().min(0).max(1).optional(),
     observed_count: z.number().int().nonnegative().optional(),
     examples: z.array(GhostCheckEvidenceExampleSchema).optional(),
+    notes: z.array(z.string().min(1)).optional(),
   })
   .strict();
 

--- a/packages/ghost-core/src/checks/schema.ts
+++ b/packages/ghost-core/src/checks/schema.ts
@@ -45,6 +45,32 @@ const GhostCheckEvidenceSchema = z
   })
   .strict();
 
+const GhostCheckRepairHintSourceSchema = z
+  .object({
+    path: z.string().min(1),
+    line: z.number().int().positive().optional(),
+  })
+  .strict();
+
+const GhostCheckRepairHintSchema = z
+  .object({
+    kind: z.enum([
+      "tailwind-class-replacement",
+      "component-pattern-replacement",
+    ]),
+    replacement: z.string().min(1),
+    reason: z.string().min(1),
+    inferred_from: z.enum([
+      "same-file-class-pattern",
+      "sibling-file-pattern",
+      "checks-yml",
+    ]),
+    source: GhostCheckRepairHintSourceSchema,
+    sources: z.array(GhostCheckRepairHintSourceSchema).optional(),
+    confidence: z.enum(["high", "medium"]),
+  })
+  .strict();
+
 export const GhostCheckSchema = z
   .object({
     id: z
@@ -61,6 +87,7 @@ export const GhostCheckSchema = z
     detector: GhostCheckDetectorSchema,
     evidence: GhostCheckEvidenceSchema.optional(),
     repair: z.string().min(1).optional(),
+    repair_hints: z.array(GhostCheckRepairHintSchema).optional(),
   })
   .strict();
 

--- a/packages/ghost-core/src/checks/types.ts
+++ b/packages/ghost-core/src/checks/types.ts
@@ -32,6 +32,25 @@ export interface GhostCheckEvidence {
   examples?: Array<string | { path: string; note?: string }>;
 }
 
+export interface GhostCheckRepairHint {
+  kind: "tailwind-class-replacement" | "component-pattern-replacement";
+  replacement: string;
+  reason: string;
+  inferred_from:
+    | "same-file-class-pattern"
+    | "sibling-file-pattern"
+    | "checks-yml";
+  source: {
+    path: string;
+    line?: number;
+  };
+  sources?: Array<{
+    path: string;
+    line?: number;
+  }>;
+  confidence: "high" | "medium";
+}
+
 export interface GhostCheck {
   id: string;
   title: string;
@@ -41,6 +60,7 @@ export interface GhostCheck {
   detector: GhostCheckDetector;
   evidence?: GhostCheckEvidence;
   repair?: string;
+  repair_hints?: GhostCheckRepairHint[];
 }
 
 export interface GhostChecksDocument {

--- a/packages/ghost-core/src/checks/types.ts
+++ b/packages/ghost-core/src/checks/types.ts
@@ -26,10 +26,17 @@ export interface GhostCheckDetector {
   contexts?: string[];
 }
 
+export interface GhostCheckEvidenceExample {
+  path: string;
+  line?: number;
+  note?: string;
+}
+
 export interface GhostCheckEvidence {
   support?: number;
   observed_count?: number;
-  examples?: Array<string | { path: string; note?: string }>;
+  examples?: Array<string | GhostCheckEvidenceExample>;
+  notes?: string[];
 }
 
 export interface GhostCheckRepairHint {

--- a/packages/ghost-core/src/index.ts
+++ b/packages/ghost-core/src/index.ts
@@ -6,6 +6,7 @@ export type {
   GhostCheckDetector,
   GhostCheckDetectorType,
   GhostCheckEvidence,
+  GhostCheckRepairHint,
   GhostCheckSeverity,
   GhostCheckStatus,
   GhostChecksDocument,

--- a/packages/ghost-core/test/checks.test.ts
+++ b/packages/ghost-core/test/checks.test.ts
@@ -64,6 +64,33 @@ describe("ghost.checks/v1", () => {
     expect(report.errors).toBe(0);
   });
 
+  it("validates source-backed repair hints", () => {
+    const report = lintGhostChecks(
+      checks({
+        repair_hints: [
+          {
+            kind: "component-pattern-replacement",
+            replacement: "Use SharedCard.",
+            reason: "Found a sibling file pattern.",
+            inferred_from: "sibling-file-pattern",
+            source: {
+              path: "Code/Features/Lending/SharedCard.swift",
+              line: 12,
+            },
+            sources: [
+              { path: "Code/Features/Lending/SharedCard.swift", line: 12 },
+              { path: "Code/Features/Lending/OtherCard.swift", line: 30 },
+            ],
+            confidence: "high",
+          },
+        ],
+      }),
+      { map: MAP },
+    );
+
+    expect(report.errors).toBe(0);
+  });
+
   it("fails invalid detector regex", () => {
     const report = lintGhostChecks(
       checks({ detector: { type: "forbidden-regex", pattern: "[" } }),

--- a/packages/ghost-core/test/checks.test.ts
+++ b/packages/ghost-core/test/checks.test.ts
@@ -48,7 +48,14 @@ function checks(
         evidence: {
           support: 0.94,
           observed_count: 47,
-          examples: ["Code/Features/Lending/LendingUI"],
+          examples: [
+            {
+              path: "Code/Features/Lending/LendingUI",
+              line: 12,
+              note: "Source-backed example.",
+            },
+          ],
+          notes: ["False-positive risk: low."],
         },
         repair: "Replace literals with Arcade/Cash semantic tokens.",
         ...overrides,
@@ -121,6 +128,16 @@ describe("ghost.checks/v1", () => {
     expect(routed).toHaveLength(1);
     expect(routed[0].check.id).toBe("no-hardcoded-ui-color");
     expect(routed[0].matched_scopes[0].id).toBe("lending");
+  });
+
+  it("does not route proposed checks as active gates", () => {
+    const routed = routeGhostChecksForPath(
+      checks({ status: "proposed" }).checks,
+      MAP,
+      "Code/Features/Lending/Sources/View.swift",
+    );
+
+    expect(routed).toHaveLength(0);
   });
 
   it("does not route checks outside their declared scope", () => {

--- a/packages/ghost-drift/src/cli.ts
+++ b/packages/ghost-drift/src/cli.ts
@@ -18,11 +18,13 @@ import {
   formatCompositeComparison,
   formatCompositeComparisonJSON,
   formatGhostDriftCheckMarkdown,
+  formatGitHubCommentDryRun,
   formatTemporalComparison,
   formatTemporalComparisonJSON,
   readHistory,
   readSyncManifest,
   runGhostDriftCheck,
+  runGhostDriftGitHubComment,
 } from "./core/index.js";
 import {
   registerAckCommand,
@@ -174,6 +176,72 @@ export function buildCli(): ReturnType<typeof cac> {
           process.stdout.write(formatGhostDriftCheckMarkdown(report));
         }
         process.exit(report.result === "fail" ? 1 : 0);
+      } catch (err) {
+        console.error(
+          `Error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(2);
+      }
+    });
+
+  // --- github-comment ---
+  cli
+    .command(
+      "github-comment",
+      "Run ghost-drift check and create/update GitHub PR inline comments plus one summary comment.",
+    )
+    .option("--repo <repo>", "GitHub repository in owner/name form")
+    .option("--pr <number>", "Pull request number")
+    .option("--base <ref>", "Git ref to diff against (default: HEAD)")
+    .option(
+      "--diff <patch>",
+      "Unified diff file to check instead of running git diff. Use '-' for stdin.",
+    )
+    .option(
+      "--package <dir>",
+      "Fingerprint package directory (default: .ghost/fingerprint)",
+    )
+    .option("--dry-run", "Print comments without calling GitHub")
+    .action(async (opts) => {
+      try {
+        if (typeof opts.repo !== "string" || opts.repo.trim() === "") {
+          console.error("Error: --repo is required");
+          process.exit(2);
+          return;
+        }
+        const pr = Number(opts.pr);
+        if (!Number.isInteger(pr) || pr < 1) {
+          console.error("Error: --pr must be a positive integer");
+          process.exit(2);
+          return;
+        }
+        const diffText =
+          typeof opts.diff === "string"
+            ? await readDiffInput(opts.diff)
+            : undefined;
+        const result = await runGhostDriftGitHubComment({
+          repo: opts.repo,
+          pr,
+          cwd: process.cwd(),
+          packageDir:
+            typeof opts.package === "string" ? opts.package : undefined,
+          base: typeof opts.base === "string" ? opts.base : undefined,
+          diffText,
+          dryRun: Boolean(opts.dryRun),
+        });
+
+        if (opts.dryRun) {
+          process.stdout.write(formatGitHubCommentDryRun(result));
+        } else {
+          const urls = [
+            ...result.inline_comments.map((comment) => comment.html_url),
+            result.summary_comment_url,
+          ].filter(Boolean);
+          process.stdout.write(
+            `${urls.join("\n") || `Updated PR #${pr} Ghost drift comments.`}\n`,
+          );
+        }
+        process.exit(result.report.result === "fail" ? 1 : 0);
       } catch (err) {
         console.error(
           `Error: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/ghost-drift/src/core/check.ts
+++ b/packages/ghost-drift/src/core/check.ts
@@ -13,6 +13,12 @@ import {
 } from "@ghost/core";
 import { resolveFingerprintPackage } from "ghost-fingerprint";
 import { parse as parseYaml } from "yaml";
+import {
+  type GhostDriftRepairHint,
+  type GhostDriftSourceSnapshot,
+  inferRepairHints,
+  readSourceSnapshot,
+} from "./repair-hints.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -49,6 +55,7 @@ export interface GhostDriftCheckFinding {
   detector: GhostCheck["detector"]["type"];
   message: string;
   repair?: string;
+  repair_hints?: GhostDriftRepairHint[];
   match?: string;
 }
 
@@ -68,6 +75,10 @@ interface LoadedCheckPackage {
   checks: GhostChecksDocument;
 }
 
+interface EvaluateCheckOptions {
+  source?: GhostDriftSourceSnapshot;
+}
+
 export async function runGhostDriftCheck(
   options: GhostDriftCheckOptions = {},
 ): Promise<GhostDriftCheckReport> {
@@ -81,6 +92,7 @@ export async function runGhostDriftCheck(
   const findings: GhostDriftCheckFinding[] = [];
 
   for (const file of changedFiles) {
+    const source = await readSourceSnapshot(cwd, file.path);
     const routed = routeGhostChecksForPath(
       pkg.checks.checks,
       pkg.map,
@@ -94,7 +106,7 @@ export async function runGhostDriftCheck(
 
     for (const entry of routed) {
       if (!detectorAppliesToPath(entry.check, file.path)) continue;
-      findings.push(...evaluateCheck(entry.check, file));
+      findings.push(...evaluateCheck(entry.check, file, { source }));
     }
   }
 
@@ -188,6 +200,15 @@ export function formatGhostDriftCheckMarkdown(
       `   ${finding.path}:${finding.line} — ${finding.message}`,
     );
     if (finding.match) lines.push(`   Match: \`${finding.match}\``);
+    for (const hint of finding.repair_hints ?? []) {
+      lines.push(
+        `   Use instead: \`${hint.replacement}\``,
+        `   Why: ${hint.reason}`,
+        `   Source: ${hint.source.path}${
+          hint.source.line ? `:${hint.source.line}` : ""
+        }`,
+      );
+    }
     if (finding.repair) lines.push(`   Repair: ${finding.repair}`);
   });
   return `${lines.join("\n")}\n`;
@@ -254,6 +275,7 @@ async function readGitDiff(
 function evaluateCheck(
   check: GhostCheck,
   file: GhostDriftChangedFile,
+  options: EvaluateCheckOptions = {},
 ): GhostDriftCheckFinding[] {
   const regex = detectorRegex(check);
   if (!regex) return [];
@@ -294,6 +316,9 @@ function evaluateCheck(
         detector: check.detector.type,
         message: forbiddenMessage(check),
         match: match[0],
+        ...repairHintsProperty(
+          inferRepairHints(check, file, line, match[0], options.source),
+        ),
         ...(check.repair ? { repair: check.repair } : {}),
       });
       if (match[0] === "") regex.lastIndex += 1;
@@ -301,6 +326,12 @@ function evaluateCheck(
     }
   }
   return findings;
+}
+
+function repairHintsProperty(
+  hints: GhostDriftRepairHint[],
+): { repair_hints: GhostDriftRepairHint[] } | Record<string, never> {
+  return hints.length > 0 ? { repair_hints: hints } : {};
 }
 
 function detectorRegex(check: GhostCheck): RegExp | null {

--- a/packages/ghost-drift/src/core/check.ts
+++ b/packages/ghost-drift/src/core/check.ts
@@ -201,12 +201,15 @@ export function formatGhostDriftCheckMarkdown(
     );
     if (finding.match) lines.push(`   Match: \`${finding.match}\``);
     for (const hint of finding.repair_hints ?? []) {
+      const sources = hint.sources?.length ? hint.sources : [hint.source];
       lines.push(
         `   Use instead: \`${hint.replacement}\``,
         `   Why: ${hint.reason}`,
-        `   Source: ${hint.source.path}${
-          hint.source.line ? `:${hint.source.line}` : ""
-        }`,
+        `   ${sources.length > 1 ? "Sources" : "Source"}: ${sources
+          .map(
+            (source) => `${source.path}${source.line ? `:${source.line}` : ""}`,
+          )
+          .join(", ")}`,
       );
     }
     if (finding.repair) lines.push(`   Repair: ${finding.repair}`);
@@ -297,6 +300,7 @@ function evaluateCheck(
         line: firstLine.line,
         detector: check.detector.type,
         message: requiredMessage(check),
+        ...repairHintsProperty(check.repair_hints ?? []),
         ...(check.repair ? { repair: check.repair } : {}),
       },
     ];
@@ -316,9 +320,10 @@ function evaluateCheck(
         detector: check.detector.type,
         message: forbiddenMessage(check),
         match: match[0],
-        ...repairHintsProperty(
-          inferRepairHints(check, file, line, match[0], options.source),
-        ),
+        ...repairHintsProperty([
+          ...inferRepairHints(check, file, line, match[0], options.source),
+          ...(check.repair_hints ?? []),
+        ]),
         ...(check.repair ? { repair: check.repair } : {}),
       });
       if (match[0] === "") regex.lastIndex += 1;

--- a/packages/ghost-drift/src/core/github-comment.ts
+++ b/packages/ghost-drift/src/core/github-comment.ts
@@ -1,0 +1,355 @@
+import { execFileSync } from "node:child_process";
+import type { GhostDriftCheckFinding, GhostDriftCheckReport } from "./check.js";
+import { runGhostDriftCheck } from "./check.js";
+import type { GhostDriftRepairHint } from "./repair-hints.js";
+
+const SUMMARY_MARKER = "<!-- Ghost Drift Summary -->";
+const INLINE_MARKER = "<!-- Ghost Drift Inline -->";
+
+interface GitHubIssueComment {
+  id: number;
+  body?: string;
+  html_url?: string;
+}
+
+interface GitHubPullRequest {
+  head: {
+    sha: string;
+  };
+}
+
+interface GitHubReviewComment {
+  id: number;
+  body?: string;
+  html_url?: string;
+}
+
+export interface GhostDriftGitHubCommentOptions {
+  repo: string;
+  pr: number;
+  cwd?: string;
+  packageDir?: string;
+  base?: string;
+  diffText?: string;
+  dryRun?: boolean;
+}
+
+export interface GhostDriftGroupedFinding {
+  key: string;
+  check_id: string;
+  title: string;
+  severity: GhostDriftCheckFinding["severity"];
+  path: string;
+  line: number;
+  matches: string[];
+  repair?: string;
+  repair_hints: GhostDriftRepairHint[];
+}
+
+export interface GhostDriftGitHubCommentResult {
+  report: GhostDriftCheckReport;
+  grouped_findings: GhostDriftGroupedFinding[];
+  summary_body: string;
+  inline_comments: Array<{
+    path: string;
+    line: number;
+    body: string;
+    html_url?: string;
+  }>;
+  summary_comment_url?: string;
+}
+
+export async function runGhostDriftGitHubComment(
+  options: GhostDriftGitHubCommentOptions,
+): Promise<GhostDriftGitHubCommentResult> {
+  const report = await runGhostDriftCheck({
+    cwd: options.cwd,
+    packageDir: options.packageDir,
+    base: options.base,
+    diffText: options.diffText,
+  });
+  const groupedFindings = groupGhostDriftFindings(report.findings);
+  const summaryBody = buildGitHubSummaryComment(report, groupedFindings);
+  const inlineComments = groupedFindings.map((group) => ({
+    path: group.path,
+    line: group.line,
+    body: buildGitHubInlineComment(group),
+  }));
+
+  if (options.dryRun) {
+    return {
+      report,
+      grouped_findings: groupedFindings,
+      summary_body: summaryBody,
+      inline_comments: inlineComments,
+    };
+  }
+
+  const postedInlineComments = postInlineComments(
+    options.repo,
+    options.pr,
+    groupedFindings,
+  );
+  const summaryComment = createOrUpdateSummaryComment(
+    options.repo,
+    options.pr,
+    summaryBody,
+  );
+
+  return {
+    report,
+    grouped_findings: groupedFindings,
+    summary_body: summaryBody,
+    inline_comments: postedInlineComments,
+    summary_comment_url: summaryComment.html_url,
+  };
+}
+
+export function groupGhostDriftFindings(
+  findings: GhostDriftCheckFinding[],
+): GhostDriftGroupedFinding[] {
+  const groups = new Map<string, GhostDriftGroupedFinding>();
+
+  for (const finding of findings) {
+    const repairHints = finding.repair_hints ?? [];
+    const key = Buffer.from(
+      [
+        finding.path,
+        finding.line,
+        finding.check_id,
+        JSON.stringify(repairHints),
+        finding.repair ?? "",
+      ].join("\0"),
+    ).toString("base64url");
+    const group =
+      groups.get(key) ??
+      ({
+        key,
+        check_id: finding.check_id,
+        title: finding.title,
+        severity: finding.severity,
+        path: finding.path,
+        line: finding.line,
+        matches: [],
+        repair: finding.repair,
+        repair_hints: repairHints,
+      } satisfies GhostDriftGroupedFinding);
+
+    if (finding.match && !group.matches.includes(finding.match)) {
+      group.matches.push(finding.match);
+    }
+
+    groups.set(key, group);
+  }
+
+  return [...groups.values()];
+}
+
+export function buildGitHubSummaryComment(
+  report: GhostDriftCheckReport,
+  groupedFindings = groupGhostDriftFindings(report.findings),
+): string {
+  const heading = [SUMMARY_MARKER, "🤖 **Ghost drift check**"];
+  const base = report.base ?? "working tree";
+
+  if (report.findings.length === 0) {
+    return [
+      ...heading,
+      "",
+      `No deterministic design drift found against \`${base}\`.`,
+      "",
+      `<sub>Ran \`ghost-drift check --base ${base} --format json\`.</sub>`,
+    ].join("\n");
+  }
+
+  const targets = groupedFindings.map((group) => {
+    const matches =
+      group.matches.length > 0 ? ` — ${formatMatches(group.matches)}` : "";
+    return `- \`${lineRef(group)}\`${matches}`;
+  });
+
+  return [
+    ...heading,
+    "",
+    `Found ${report.findings.length} deterministic drift match(es) across ${groupedFindings.length} changed line(s) against \`${base}\`.`,
+    "",
+    "Inline review target(s):",
+    ...targets,
+    "",
+    `<sub>Ran \`ghost-drift check --base ${base} --format json\`.</sub>`,
+  ].join("\n");
+}
+
+export function buildGitHubInlineComment(
+  group: GhostDriftGroupedFinding,
+): string {
+  const hiddenKey = `<!-- Ghost Drift Key: ${group.key} -->`;
+  const lines = [
+    INLINE_MARKER,
+    hiddenKey,
+    "🤖 **Ghost drift check**",
+    "",
+    `**${group.title}**`,
+  ];
+
+  if (group.matches.length > 0) {
+    lines.push("", `Matched: ${formatMatches(group.matches)}.`);
+  }
+
+  for (const hint of group.repair_hints) {
+    lines.push(
+      "",
+      `Use instead: \`${hint.replacement}\``,
+      `Why: ${hint.reason}`,
+      formatSources(hint),
+    );
+  }
+
+  if (group.repair_hints.length === 0 && group.repair) {
+    lines.push("", `Repair: ${group.repair}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function formatGitHubCommentDryRun(
+  result: GhostDriftGitHubCommentResult,
+): string {
+  const lines = [result.summary_body];
+  for (const inline of result.inline_comments) {
+    lines.push(
+      "",
+      `--- Inline comment: ${inline.path}:${inline.line} ---`,
+      "",
+      inline.body,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function postInlineComments(
+  repo: string,
+  pr: number,
+  groups: GhostDriftGroupedFinding[],
+): GhostDriftGitHubCommentResult["inline_comments"] {
+  if (groups.length === 0) return [];
+
+  const pullRequest = ghApi<GitHubPullRequest>(repo, [
+    `repos/${repo}/pulls/${pr}`,
+  ]);
+  const existingComments = ghApi<GitHubReviewComment[]>(repo, [
+    `repos/${repo}/pulls/${pr}/comments?per_page=100`,
+  ]);
+
+  return groups.map((group) => {
+    const body = buildGitHubInlineComment(group);
+    const existing = findExistingInlineComment(existingComments, group);
+    const comment = existing
+      ? ghApi<GitHubReviewComment>(repo, [
+          "-X",
+          "PATCH",
+          `repos/${repo}/pulls/comments/${existing.id}`,
+          "--field",
+          `body=${body}`,
+        ])
+      : ghApi<GitHubReviewComment>(repo, [
+          "-X",
+          "POST",
+          `repos/${repo}/pulls/${pr}/comments`,
+          "--field",
+          `body=${body}`,
+          "--field",
+          `commit_id=${pullRequest.head.sha}`,
+          "--field",
+          `path=${group.path}`,
+          "--field",
+          "side=RIGHT",
+          "--field",
+          `line=${group.line}`,
+        ]);
+
+    return {
+      path: group.path,
+      line: group.line,
+      body,
+      html_url: comment.html_url,
+    };
+  });
+}
+
+function createOrUpdateSummaryComment(
+  repo: string,
+  pr: number,
+  body: string,
+): GitHubIssueComment {
+  const existing = ghApi<GitHubIssueComment[]>(repo, [
+    `repos/${repo}/issues/${pr}/comments?per_page=100`,
+  ]).find((comment) => comment.body?.includes(SUMMARY_MARKER));
+
+  if (existing) {
+    return ghApi<GitHubIssueComment>(repo, [
+      "-X",
+      "PATCH",
+      `repos/${repo}/issues/comments/${existing.id}`,
+      "--field",
+      `body=${body}`,
+    ]);
+  }
+
+  return ghApi<GitHubIssueComment>(repo, [
+    "-X",
+    "POST",
+    `repos/${repo}/issues/${pr}/comments`,
+    "--field",
+    `body=${body}`,
+  ]);
+}
+
+function findExistingInlineComment(
+  comments: GitHubReviewComment[],
+  group: GhostDriftGroupedFinding,
+): GitHubReviewComment | undefined {
+  const hiddenKey = `<!-- Ghost Drift Key: ${group.key} -->`;
+
+  return comments.find(
+    (comment) =>
+      comment.body?.includes(INLINE_MARKER) && comment.body.includes(hiddenKey),
+  );
+}
+
+function ghApi<T>(repo: string, args: string[]): T {
+  try {
+    const stdout = execFileSync("gh", ["api", ...args], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 20,
+    });
+    return JSON.parse(stdout) as T;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `GitHub API request failed for ${repo}. Run \`gh auth login -h github.com\`, then retry. ${message}`,
+    );
+  }
+}
+
+function lineRef(group: GhostDriftGroupedFinding): string {
+  return `${group.path}:${group.line}`;
+}
+
+function formatMatches(matches: string[]): string {
+  return matches.map((match) => `\`${truncate(match)}\``).join(", ");
+}
+
+function formatSources(hint: GhostDriftRepairHint): string {
+  const sources = hint.sources?.length ? hint.sources : [hint.source];
+  const label = sources.length > 1 ? "Sources" : "Source";
+  return `${label}: ${sources
+    .map(
+      (source) => `\`${source.path}${source.line ? `:${source.line}` : ""}\``,
+    )
+    .join(", ")}`;
+}
+
+function truncate(value: string): string {
+  return value.length > 120 ? `${value.slice(0, 117)}...` : value;
+}

--- a/packages/ghost-drift/src/core/index.ts
+++ b/packages/ghost-drift/src/core/index.ts
@@ -94,6 +94,7 @@ export {
   resolveTrackedFingerprint,
   writeSyncManifest,
 } from "./evolution/index.js";
+export type { GhostDriftRepairHint } from "./repair-hints.js";
 export {
   formatCompositeComparison,
   formatCompositeComparisonJSON,

--- a/packages/ghost-drift/src/core/index.ts
+++ b/packages/ghost-drift/src/core/index.ts
@@ -94,6 +94,18 @@ export {
   resolveTrackedFingerprint,
   writeSyncManifest,
 } from "./evolution/index.js";
+export type {
+  GhostDriftGitHubCommentOptions,
+  GhostDriftGitHubCommentResult,
+  GhostDriftGroupedFinding,
+} from "./github-comment.js";
+export {
+  buildGitHubInlineComment,
+  buildGitHubSummaryComment,
+  formatGitHubCommentDryRun,
+  groupGhostDriftFindings,
+  runGhostDriftGitHubComment,
+} from "./github-comment.js";
 export type { GhostDriftRepairHint } from "./repair-hints.js";
 export {
   formatCompositeComparison,

--- a/packages/ghost-drift/src/core/repair-hints.ts
+++ b/packages/ghost-drift/src/core/repair-hints.ts
@@ -1,19 +1,9 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { GhostCheck } from "@ghost/core";
+import type { GhostCheck, GhostCheckRepairHint } from "@ghost/core";
 import type { GhostDriftChangedFile, GhostDriftChangedLine } from "./check.js";
 
-export interface GhostDriftRepairHint {
-  kind: "tailwind-class-replacement";
-  replacement: string;
-  reason: string;
-  inferred_from: "same-file-class-pattern";
-  source: {
-    path: string;
-    line?: number;
-  };
-  confidence: "high" | "medium";
-}
+export type GhostDriftRepairHint = GhostCheckRepairHint;
 
 export interface GhostDriftSourceSnapshot {
   path: string;

--- a/packages/ghost-drift/src/core/repair-hints.ts
+++ b/packages/ghost-drift/src/core/repair-hints.ts
@@ -1,0 +1,295 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { GhostCheck } from "@ghost/core";
+import type { GhostDriftChangedFile, GhostDriftChangedLine } from "./check.js";
+
+export interface GhostDriftRepairHint {
+  kind: "tailwind-class-replacement";
+  replacement: string;
+  reason: string;
+  inferred_from: "same-file-class-pattern";
+  source: {
+    path: string;
+    line?: number;
+  };
+  confidence: "high" | "medium";
+}
+
+export interface GhostDriftSourceSnapshot {
+  path: string;
+  text: string;
+}
+
+interface ClassStringCandidate {
+  line: number;
+  tokens: string[];
+}
+
+export async function readSourceSnapshot(
+  cwd: string,
+  path: string,
+): Promise<GhostDriftSourceSnapshot | undefined> {
+  try {
+    return {
+      path,
+      text: await readFile(join(cwd, path), "utf-8"),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function inferRepairHints(
+  check: GhostCheck,
+  file: GhostDriftChangedFile,
+  line: GhostDriftChangedLine,
+  match: string,
+  source: GhostDriftSourceSnapshot | undefined,
+): GhostDriftRepairHint[] {
+  if (check.detector.type !== "forbidden-regex") return [];
+  if (!source || !isReactPath(file.path)) return [];
+
+  const lineTokens = extractClassTokens(line.text);
+  const hasArbitraryColorMatch = lineTokens.some(
+    (token) => token.includes(match) && isArbitraryColorClass(token),
+  );
+  if (!hasArbitraryColorMatch) return [];
+
+  const desiredCategories = unique(
+    lineTokens
+      .map((token) => tailwindColorCategory(token))
+      .filter((category): category is string => category !== undefined),
+  );
+  if (desiredCategories.length === 0) return [];
+
+  const best = findBestClassReplacement(
+    extractClassStringCandidates(source.text),
+    desiredCategories,
+    line.line,
+  );
+  if (!best) return [];
+
+  return [
+    {
+      kind: "tailwind-class-replacement",
+      replacement: best.replacement,
+      reason: repairHintReason(file.path),
+      inferred_from: "same-file-class-pattern",
+      source: {
+        path: source.path,
+        line: best.line,
+      },
+      confidence: best.confidence,
+    },
+  ];
+}
+
+function findBestClassReplacement(
+  candidates: ClassStringCandidate[],
+  desiredCategories: string[],
+  findingLine: number,
+):
+  | { replacement: string; line: number; confidence: "high" | "medium" }
+  | undefined {
+  const desired = new Set(desiredCategories);
+  let best:
+    | {
+        replacement: string;
+        line: number;
+        score: number;
+        confidence: "high" | "medium";
+      }
+    | undefined;
+
+  for (const candidate of candidates) {
+    if (candidate.tokens.some(hasRawOrArbitraryValue)) continue;
+
+    const replacementTokens = candidate.tokens.filter((token) => {
+      const category = tailwindColorCategory(token);
+      return category !== undefined && desired.has(category);
+    });
+    const replacement = unique(replacementTokens).join(" ");
+    if (!replacement) continue;
+    if (!hasSemanticColorToken(replacementTokens)) continue;
+
+    const covered = new Set(
+      replacementTokens
+        .map((token) => tailwindColorCategory(token))
+        .filter((category): category is string => category !== undefined),
+    );
+    const coversAll = desiredCategories.every((category) =>
+      covered.has(category),
+    );
+    if (!coversAll) continue;
+
+    const distance = Math.abs(candidate.line - findingLine);
+    const score =
+      desiredCategories.length * 20 +
+      semanticScore(replacementTokens) -
+      Math.min(distance, 20);
+    const confidence = desiredCategories.length >= 2 ? "high" : "medium";
+
+    if (!best || score > best.score) {
+      best = {
+        replacement,
+        line: candidate.line,
+        score,
+        confidence,
+      };
+    }
+  }
+
+  return best
+    ? {
+        replacement: best.replacement,
+        line: best.line,
+        confidence: best.confidence,
+      }
+    : undefined;
+}
+
+function extractClassStringCandidates(source: string): ClassStringCandidate[] {
+  const candidates: ClassStringCandidate[] = [];
+  const quotedString = /(['"`])((?:\\[\s\S]|(?!\1)[\s\S])*?)\1/g;
+  let match = quotedString.exec(source);
+
+  while (match !== null) {
+    const tokens = extractClassTokens(match[2]);
+    if (tokens.length > 0 && tokens.some(tailwindColorCategory)) {
+      candidates.push({
+        line: lineNumberAt(source, match.index),
+        tokens,
+      });
+    }
+    match = quotedString.exec(source);
+  }
+
+  return candidates;
+}
+
+function extractClassTokens(input: string): string[] {
+  return input.match(/!?[A-Za-z0-9_:[\]#./-]+/g) ?? [];
+}
+
+function tailwindColorCategory(token: string): string | undefined {
+  const normalized = token.replace(/^!/, "");
+  const parts = normalized.split(":");
+  const base = parts.at(-1);
+  if (!base) return undefined;
+
+  const utility = colorUtility(base);
+  if (!utility) return undefined;
+
+  const variants = parts.slice(0, -1).join(":");
+  return variants ? `${variants}:${utility}` : utility;
+}
+
+function colorUtility(base: string): string | undefined {
+  const match = /^(bg|text|border|ring|outline|fill|stroke)-(.+)$/.exec(base);
+  if (!match) return undefined;
+
+  const [, utility, value] = match;
+  if (!isColorValue(utility, value)) return undefined;
+  return utility;
+}
+
+function isColorValue(utility: string, value: string): boolean {
+  if (value.startsWith("[#")) return true;
+  if (utility === "text" && NON_COLOR_TEXT_VALUES.has(value)) return false;
+  if (value.includes("foreground")) return true;
+  if (SEMANTIC_COLOR_PARTS.some((part) => value.includes(part))) return true;
+  return COLOR_VALUE_PATTERN.test(value);
+}
+
+function isArbitraryColorClass(token: string): boolean {
+  return (
+    tailwindColorCategory(token) !== undefined &&
+    /\[#(?:[0-9a-fA-F]{3,8})\]/.test(token)
+  );
+}
+
+function hasRawOrArbitraryValue(token: string): boolean {
+  return /#[0-9a-fA-F]{3,8}|\[[^\]]+\]/.test(token);
+}
+
+function hasSemanticColorToken(tokens: string[]): boolean {
+  return tokens.some((token) =>
+    SEMANTIC_COLOR_PARTS.some((part) => token.includes(part)),
+  );
+}
+
+function semanticScore(tokens: string[]): number {
+  return tokens.reduce((score, token) => {
+    if (token.includes("primary")) return score + 4;
+    if (token.includes("foreground")) return score + 3;
+    if (SEMANTIC_COLOR_PARTS.some((part) => token.includes(part))) {
+      return score + 2;
+    }
+    return score;
+  }, 0);
+}
+
+function repairHintReason(path: string): string {
+  return /button/i.test(path)
+    ? "Found an existing same-file semantic Button action pattern."
+    : "Found an existing same-file semantic Tailwind class pattern.";
+}
+
+function lineNumberAt(input: string, index: number): number {
+  return input.slice(0, index).split(/\r?\n/).length;
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+function isReactPath(path: string): boolean {
+  const lower = path.toLowerCase();
+  return lower.endsWith(".tsx") || lower.endsWith(".jsx");
+}
+
+const NON_COLOR_TEXT_VALUES = new Set([
+  "xs",
+  "sm",
+  "base",
+  "lg",
+  "xl",
+  "2xl",
+  "3xl",
+  "4xl",
+  "5xl",
+  "6xl",
+  "7xl",
+  "8xl",
+  "9xl",
+  "left",
+  "center",
+  "right",
+  "justify",
+  "start",
+  "end",
+  "ellipsis",
+  "clip",
+  "wrap",
+  "nowrap",
+  "balance",
+  "pretty",
+]);
+
+const SEMANTIC_COLOR_PARTS = [
+  "accent",
+  "background",
+  "card",
+  "destructive",
+  "foreground",
+  "input",
+  "muted",
+  "popover",
+  "primary",
+  "secondary",
+  "success",
+  "warning",
+];
+
+const COLOR_VALUE_PATTERN =
+  /^(?:white|black|transparent|current|inherit|neutral-\d{2,3}|slate-\d{2,3}|gray-\d{2,3}|zinc-\d{2,3}|stone-\d{2,3}|red-\d{2,3}|orange-\d{2,3}|amber-\d{2,3}|yellow-\d{2,3}|lime-\d{2,3}|green-\d{2,3}|emerald-\d{2,3}|teal-\d{2,3}|cyan-\d{2,3}|sky-\d{2,3}|blue-\d{2,3}|indigo-\d{2,3}|violet-\d{2,3}|purple-\d{2,3}|fuchsia-\d{2,3}|pink-\d{2,3}|rose-\d{2,3})(?:\/\d{1,3})?$/;

--- a/packages/ghost-drift/test/cli.test.ts
+++ b/packages/ghost-drift/test/cli.test.ts
@@ -189,6 +189,139 @@ describe("ghost-drift CLI", () => {
     });
   });
 
+  it("check infers a source-backed repair hint for Tailwind arbitrary colors", async () => {
+    await writeTailwindCheckPackage(dir);
+    await writeButtonSource(dir, [
+      "const buttonVariants = {",
+      "  default: 'bg-primary text-primary-foreground hover:bg-primary/80 active:opacity-50',",
+      "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      "};",
+    ]);
+    await writeFile(
+      join(dir, "change.patch"),
+      buttonPatch(
+        "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      ),
+    );
+
+    const result = await runCli(
+      ["check", "--diff", "change.patch", "--format", "json"],
+      dir,
+    );
+
+    expect(result.code).toBe(1);
+    const report = JSON.parse(result.stdout);
+    expect(report.findings[0].repair_hints).toEqual([
+      {
+        kind: "tailwind-class-replacement",
+        replacement: "bg-primary text-primary-foreground hover:bg-primary/80",
+        reason: "Found an existing same-file semantic Button action pattern.",
+        inferred_from: "same-file-class-pattern",
+        source: {
+          path: "src/components/button.tsx",
+          line: 2,
+        },
+        confidence: "high",
+      },
+    ]);
+  });
+
+  it("does not infer a Tailwind repair hint without a semantic candidate", async () => {
+    await writeTailwindCheckPackage(dir);
+    await writeButtonSource(dir, [
+      "const buttonVariants = {",
+      "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      "};",
+    ]);
+    await writeFile(
+      join(dir, "change.patch"),
+      buttonPatch(
+        "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      ),
+    );
+
+    const result = await runCli(
+      ["check", "--diff", "change.patch", "--format", "json"],
+      dir,
+    );
+
+    expect(result.code).toBe(1);
+    const report = JSON.parse(result.stdout);
+    expect(report.findings[0]).not.toHaveProperty("repair_hints");
+  });
+
+  it("does not infer a Tailwind repair hint from arbitrary-value candidates", async () => {
+    await writeTailwindCheckPackage(dir);
+    await writeButtonSource(dir, [
+      "const buttonVariants = {",
+      "  default: 'bg-[#112233] text-white hover:bg-[#223344] active:opacity-50',",
+      "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      "};",
+    ]);
+    await writeFile(
+      join(dir, "change.patch"),
+      buttonPatch(
+        "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      ),
+    );
+
+    const result = await runCli(
+      ["check", "--diff", "change.patch", "--format", "json"],
+      dir,
+    );
+
+    expect(result.code).toBe(1);
+    const report = JSON.parse(result.stdout);
+    expect(report.findings[0]).not.toHaveProperty("repair_hints");
+  });
+
+  it("keeps generic repair behavior for unsupported findings", async () => {
+    await writeCheckPackage(dir);
+    await writeFile(
+      join(dir, "change.patch"),
+      lendingPatch("UIColor(#ffffff)"),
+    );
+
+    const result = await runCli(
+      ["check", "--diff", "change.patch", "--format", "json"],
+      dir,
+    );
+
+    expect(result.code).toBe(1);
+    const report = JSON.parse(result.stdout);
+    expect(report.findings[0]).toMatchObject({
+      repair: "Replace literals with Arcade/Cash semantic tokens.",
+    });
+    expect(report.findings[0]).not.toHaveProperty("repair_hints");
+  });
+
+  it("prints Tailwind repair hints in markdown output", async () => {
+    await writeTailwindCheckPackage(dir);
+    await writeButtonSource(dir, [
+      "const buttonVariants = {",
+      "  default: 'bg-primary text-primary-foreground hover:bg-primary/80 active:opacity-50',",
+      "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      "};",
+    ]);
+    await writeFile(
+      join(dir, "change.patch"),
+      buttonPatch(
+        "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      ),
+    );
+
+    const result = await runCli(["check", "--diff", "change.patch"], dir);
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain(
+      "Use instead: `bg-primary text-primary-foreground hover:bg-primary/80`",
+    );
+    expect(result.stdout).toContain(
+      "Why: Found an existing same-file semantic Button action pattern.",
+    );
+    expect(result.stdout).toContain("Source: src/components/button.tsx:2");
+  });
+
   it("check passes when active scoped checks do not match", async () => {
     await writeCheckPackage(dir);
     await writeFile(
@@ -263,6 +396,54 @@ checks:
   );
 }
 
+async function writeTailwindCheckPackage(dir: string): Promise<void> {
+  const pkg = join(dir, ".ghost", "fingerprint");
+  await mkdir(pkg, { recursive: true });
+  await writeFile(join(pkg, "map.md"), webMapWithScopes());
+  await writeFile(join(pkg, "profile.md"), profile());
+  await writeFile(
+    join(pkg, "survey.json"),
+    JSON.stringify({
+      schema: "ghost.survey/v2",
+      sources: [{ target: ".", scanned_at: "2026-05-06T00:00:00.000Z" }],
+      values: [],
+      tokens: [],
+      components: [],
+      ui_surfaces: [],
+    }),
+  );
+  await writeFile(
+    join(pkg, "checks.yml"),
+    `schema: ghost.checks/v1
+id: managerbot-ui
+checks:
+  - id: no-hardcoded-managerbot-ui-hex
+    title: Use Managerbot semantic color tokens
+    status: active
+    severity: serious
+    applies_to:
+      scopes: [managerbot-ui-primitives]
+      paths: [src/components]
+    detector:
+      type: forbidden-regex
+      pattern: '#[0-9a-fA-F]{3,8}'
+      contexts: [react]
+    evidence:
+      support: 0.9
+      observed_count: 1
+      examples:
+        - src/components/button.tsx
+    repair: Replace raw color values with Managerbot semantic color tokens.
+`,
+  );
+}
+
+async function writeButtonSource(dir: string, lines: string[]): Promise<void> {
+  const componentDir = join(dir, "src", "components");
+  await mkdir(componentDir, { recursive: true });
+  await writeFile(join(componentDir, "button.tsx"), `${lines.join("\n")}\n`);
+}
+
 function profile(): string {
   return `---
 id: cash-ios
@@ -303,6 +484,15 @@ function lendingPatch(line: string): string {
 --- a/Code/Features/Lending/View.swift
 +++ b/Code/Features/Lending/View.swift
 @@ -0,0 +1,1 @@
++${line}
+`;
+}
+
+function buttonPatch(line: string): string {
+  return `diff --git a/src/components/button.tsx b/src/components/button.tsx
+--- a/src/components/button.tsx
++++ b/src/components/button.tsx
+@@ -2,0 +3,1 @@
 +${line}
 `;
 }
@@ -360,5 +550,61 @@ Native Swift app.
 ## Conventions
 
 Use feature scopes.
+`;
+}
+
+function webMapWithScopes(): string {
+  return `---
+schema: ghost.map/v2
+id: managerbot-ui
+repo: squareup/square-web
+mapped_at: 2026-05-06T00:00:00.000Z
+platform: web
+languages:
+  - { name: typescript, files: 5, share: 1.0 }
+build_system: pnpm
+package_manifests:
+  - package.json
+composition:
+  frameworks:
+    - { name: react }
+  rendering: react
+  styling:
+    - tailwindcss
+design_system:
+  paths:
+    - src/components
+  status: active
+surface_sources:
+  render_strategy: static-source
+  include:
+    - src/components/**
+  exclude:
+    - "**/node_modules/**"
+feature_areas:
+  - name: managerbot-ui-primitives
+    paths:
+      - src/components
+scopes:
+  - id: managerbot-ui-primitives
+    name: Managerbot UI primitives
+    kind: design-system
+    paths:
+      - src/components
+orientation_files:
+  - README.md
+---
+
+## Identity
+
+Managerbot UI fixture.
+
+## Topology
+
+Components live under src/components.
+
+## Conventions
+
+Use semantic Tailwind tokens.
 `;
 }

--- a/packages/ghost-drift/test/cli.test.ts
+++ b/packages/ghost-drift/test/cli.test.ts
@@ -322,6 +322,111 @@ describe("ghost-drift CLI", () => {
     expect(result.stdout).toContain("Source: src/components/button.tsx:2");
   });
 
+  it("check carries check-authored repair hints with multiple sources", async () => {
+    await writeComponentPatternCheckPackage(dir);
+    await writeFile(
+      join(dir, "change.patch"),
+      componentPatternPatch('<div className="flex justify-end gap-2">'),
+    );
+
+    const result = await runCli(
+      ["check", "--diff", "change.patch", "--format", "json"],
+      dir,
+    );
+
+    expect(result.code).toBe(1);
+    const report = JSON.parse(result.stdout);
+    expect(report.findings[0]).toMatchObject({
+      check_id: "use-managerbot-tool-footer-actions",
+      repair_hints: [
+        {
+          kind: "component-pattern-replacement",
+          replacement:
+            "ToolCardFooter + ToolFooterActions + ToolCancelButton + ToolSubmitButton",
+          reason:
+            "Found the same approval-card footer pattern in sibling tools.",
+          inferred_from: "sibling-file-pattern",
+          source: {
+            path: "src/components/tools/square-update-preview/square-update-preview-ui.tsx",
+            line: 425,
+          },
+          sources: [
+            {
+              path: "src/components/tools/square-update-preview/square-update-preview-ui.tsx",
+              line: 425,
+            },
+            {
+              path: "src/components/tools/square-remove-preview/square-remove-preview-ui.tsx",
+              line: 298,
+            },
+          ],
+          confidence: "high",
+        },
+      ],
+    });
+  });
+
+  it("prints check-authored repair hint sources in markdown output", async () => {
+    await writeComponentPatternCheckPackage(dir);
+    await writeFile(
+      join(dir, "change.patch"),
+      componentPatternPatch('<div className="flex justify-end gap-2">'),
+    );
+
+    const result = await runCli(["check", "--diff", "change.patch"], dir);
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain(
+      "Use instead: `ToolCardFooter + ToolFooterActions + ToolCancelButton + ToolSubmitButton`",
+    );
+    expect(result.stdout).toContain(
+      "Sources: src/components/tools/square-update-preview/square-update-preview-ui.tsx:425, src/components/tools/square-remove-preview/square-remove-preview-ui.tsx:298",
+    );
+  });
+
+  it("github-comment dry-run groups inline comments by changed line", async () => {
+    await writeTailwindCheckPackage(dir);
+    await writeButtonSource(dir, [
+      "const buttonVariants = {",
+      "  default: 'bg-primary text-primary-foreground hover:bg-primary/80 active:opacity-50',",
+      "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      "};",
+    ]);
+    await writeFile(
+      join(dir, "change.patch"),
+      buttonPatch(
+        "  demo: 'bg-[#ff00ff] text-white hover:bg-[#cc00cc] active:opacity-50',",
+      ),
+    );
+
+    const result = await runCli(
+      [
+        "github-comment",
+        "--repo",
+        "squareup/square-web",
+        "--pr",
+        "123",
+        "--diff",
+        "change.patch",
+        "--dry-run",
+      ],
+      dir,
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain("🤖 **Ghost drift check**");
+    expect(result.stdout).toContain(
+      "Found 2 deterministic drift match(es) across 1 changed line(s)",
+    );
+    expect(result.stdout).toContain(
+      "--- Inline comment: src/components/button.tsx:3 ---",
+    );
+    expect(result.stdout).toContain("Matched: `#ff00ff`, `#cc00cc`.");
+    expect(result.stdout).toContain(
+      "Use instead: `bg-primary text-primary-foreground hover:bg-primary/80`",
+    );
+  });
+
   it("check passes when active scoped checks do not match", async () => {
     await writeCheckPackage(dir);
     await writeFile(
@@ -438,6 +543,62 @@ checks:
   );
 }
 
+async function writeComponentPatternCheckPackage(dir: string): Promise<void> {
+  const pkg = join(dir, ".ghost", "fingerprint");
+  await mkdir(pkg, { recursive: true });
+  await writeFile(join(pkg, "map.md"), webMapWithScopes());
+  await writeFile(join(pkg, "profile.md"), profile());
+  await writeFile(
+    join(pkg, "survey.json"),
+    JSON.stringify({
+      schema: "ghost.survey/v2",
+      sources: [{ target: ".", scanned_at: "2026-05-06T00:00:00.000Z" }],
+      values: [],
+      tokens: [],
+      components: [],
+      ui_surfaces: [],
+    }),
+  );
+  await writeFile(
+    join(pkg, "checks.yml"),
+    `schema: ghost.checks/v1
+id: managerbot-ui
+checks:
+  - id: use-managerbot-tool-footer-actions
+    title: Use Managerbot tool footer action primitives
+    status: active
+    severity: serious
+    applies_to:
+      scopes: [managerbot-ui-primitives]
+      paths: [src/components/tools]
+    detector:
+      type: forbidden-regex
+      pattern: 'className="flex justify-end gap-2"'
+      contexts: [react]
+    evidence:
+      support: 0.9
+      observed_count: 2
+      examples:
+        - src/components/tools/square-update-preview/square-update-preview-ui.tsx
+    repair: Replace hand-rolled approval footer layout with shared tool footer primitives.
+    repair_hints:
+      - kind: component-pattern-replacement
+        replacement: ToolCardFooter + ToolFooterActions + ToolCancelButton + ToolSubmitButton
+        reason: Found the same approval-card footer pattern in sibling tools.
+        inferred_from: sibling-file-pattern
+        source:
+          path: src/components/tools/square-update-preview/square-update-preview-ui.tsx
+          line: 425
+        sources:
+          - path: src/components/tools/square-update-preview/square-update-preview-ui.tsx
+            line: 425
+          - path: src/components/tools/square-remove-preview/square-remove-preview-ui.tsx
+            line: 298
+        confidence: high
+`,
+  );
+}
+
 async function writeButtonSource(dir: string, lines: string[]): Promise<void> {
   const componentDir = join(dir, "src", "components");
   await mkdir(componentDir, { recursive: true });
@@ -493,6 +654,15 @@ function buttonPatch(line: string): string {
 --- a/src/components/button.tsx
 +++ b/src/components/button.tsx
 @@ -2,0 +3,1 @@
++${line}
+`;
+}
+
+function componentPatternPatch(line: string): string {
+  return `diff --git a/src/components/tools/demo-tool.tsx b/src/components/tools/demo-tool.tsx
+--- a/src/components/tools/demo-tool.tsx
++++ b/src/components/tools/demo-tool.tsx
+@@ -1,0 +2,1 @@
 +${line}
 `;
 }

--- a/packages/ghost-fingerprint/src/cli.ts
+++ b/packages/ghost-fingerprint/src/cli.ts
@@ -17,7 +17,7 @@ import {
   summarizeSurvey,
 } from "@ghost/core";
 import { cac } from "cac";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import {
   diffFingerprints,
   formatLayout,
@@ -30,6 +30,7 @@ import {
   lintFingerprintPackage,
   lintMap,
   loadFingerprint,
+  proposeGhostChecks,
   resolveFingerprintPackage,
   scanStatus,
   verifyProfile,
@@ -517,6 +518,48 @@ export function buildCli(): ReturnType<typeof cac> {
           process.stdout.write(out);
         }
 
+        process.exit(0);
+      } catch (err) {
+        console.error(
+          `Error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(2);
+      }
+    });
+
+  // --- checks <op> ---
+  cli
+    .command(
+      "checks <op> [package]",
+      "Operate on ghost.checks/v1 documents. Ops: propose.",
+    )
+    .option("--format <fmt>", "Output format: yaml or json", {
+      default: "yaml",
+    })
+    .action(async (op: string, packageDir: string | undefined, opts) => {
+      try {
+        if (op !== "propose") {
+          console.error(`Error: unknown checks op '${op}'. Supported: propose`);
+          process.exit(2);
+          return;
+        }
+        if (opts.format !== "yaml" && opts.format !== "json") {
+          console.error(
+            "Error: checks propose --format must be 'yaml' or 'json'",
+          );
+          process.exit(2);
+          return;
+        }
+
+        const report = await proposeGhostChecks({
+          packageDir,
+          cwd: process.cwd(),
+        });
+        const out =
+          opts.format === "json"
+            ? `${JSON.stringify(report, null, 2)}\n`
+            : stringifyYaml(report.checks);
+        process.stdout.write(out.endsWith("\n") ? out : `${out}\n`);
         process.exit(0);
       } catch (err) {
         console.error(

--- a/packages/ghost-fingerprint/src/core/check-proposals.ts
+++ b/packages/ghost-fingerprint/src/core/check-proposals.ts
@@ -260,6 +260,8 @@ function pulseMetricProposal(
   group: PatternGroup,
 ): GhostCheck {
   const sources = sourceRefs(inputs.cwd, group, [
+    "ChartCard",
+    "Trend",
     "MetricDataCard",
     "ComparisonBadge",
   ]);

--- a/packages/ghost-fingerprint/src/core/check-proposals.ts
+++ b/packages/ghost-fingerprint/src/core/check-proposals.ts
@@ -1,0 +1,493 @@
+import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+import {
+  type GhostCheck,
+  type GhostChecksDocument,
+  GhostChecksSchema,
+  type MapFrontmatter,
+  MapFrontmatterSchema,
+  routeGhostPathToScopes,
+  type Survey,
+  SurveySchema,
+  type UiSurfaceRow,
+} from "@ghost/core";
+import { parse as parseYaml } from "yaml";
+import { resolveFingerprintPackage } from "./fingerprint-package.js";
+
+export interface CheckProposalOptions {
+  cwd?: string;
+  packageDir?: string;
+}
+
+export interface CheckProposalAdvisoryPacket {
+  instructions: string[];
+  profile: string;
+  survey_surface_count: number;
+  proposal_count: number;
+}
+
+export interface CheckProposalReport {
+  schema: "ghost.check-proposals/v1";
+  package_dir: string;
+  checks: GhostChecksDocument;
+  advisory_packet: CheckProposalAdvisoryPacket;
+}
+
+interface ProposalInputs {
+  cwd: string;
+  packageDir: string;
+  map: MapFrontmatter;
+  survey: Survey;
+  profile: string;
+  existingIds: Set<string>;
+}
+
+interface PatternGroup {
+  key: string;
+  label: string;
+  surfaces: UiSurfaceRow[];
+  components: string[];
+  layoutPattern?: string;
+}
+
+interface SourceRef {
+  path: string;
+  line?: number;
+}
+
+const SUPPORT_FLOOR = 2;
+
+export async function proposeGhostChecks(
+  options: CheckProposalOptions = {},
+): Promise<CheckProposalReport> {
+  const inputs = await loadProposalInputs(options);
+  const checks = buildProposedChecks(inputs);
+  const document: GhostChecksDocument = {
+    schema: "ghost.checks/v1",
+    id: inputs.map.id,
+    checks,
+  };
+
+  return {
+    schema: "ghost.check-proposals/v1",
+    package_dir: inputs.packageDir,
+    checks: document,
+    advisory_packet: {
+      instructions: [
+        "Review these generated checks before copying them into checks.yml.",
+        "Keep status: proposed while evaluating noise; change to status: active only after human promotion.",
+        "Generated checks are useful drafts, not declarations of policy.",
+      ],
+      profile: inputs.profile,
+      survey_surface_count: inputs.survey.ui_surfaces.length,
+      proposal_count: checks.length,
+    },
+  };
+}
+
+async function loadProposalInputs(
+  options: CheckProposalOptions,
+): Promise<ProposalInputs> {
+  const cwd = options.cwd ?? process.cwd();
+  const paths = resolveFingerprintPackage(options.packageDir, cwd);
+  const [mapRaw, surveyRaw, profile, checksRaw] = await Promise.all([
+    readFile(paths.map, "utf-8"),
+    readFile(paths.survey, "utf-8"),
+    readFile(paths.profile, "utf-8"),
+    readFile(paths.checks, "utf-8"),
+  ]);
+
+  const map = parseMap(mapRaw);
+  const surveyInput = JSON.parse(surveyRaw) as unknown;
+  const surveyResult = SurveySchema.safeParse(surveyInput);
+  if (!surveyResult.success) {
+    throw new Error(
+      `survey.json failed schema validation: ${surveyResult.error.issues
+        .map((issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
+        .join("; ")}`,
+    );
+  }
+
+  const checksInput = parseYaml(checksRaw);
+  const existingIds = new Set<string>();
+  const checksResult = GhostChecksSchema.safeParse(checksInput);
+  if (checksResult.success) {
+    for (const check of checksResult.data.checks) existingIds.add(check.id);
+  }
+
+  return {
+    cwd,
+    packageDir: paths.dir,
+    map,
+    survey: surveyResult.data,
+    profile,
+    existingIds,
+  };
+}
+
+function parseMap(raw: string): MapFrontmatter {
+  const block = raw.match(/^---\n([\s\S]*?)\n---/)?.[1];
+  if (!block) throw new Error("map.md is missing YAML frontmatter");
+  const result = MapFrontmatterSchema.safeParse(parseYaml(block));
+  if (!result.success) {
+    throw new Error(
+      `map.md failed validation: ${result.error.issues
+        .map((issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
+        .join("; ")}`,
+    );
+  }
+  return result.data;
+}
+
+function buildProposedChecks(inputs: ProposalInputs): GhostCheck[] {
+  const proposals = new Map<string, GhostCheck>();
+  const groups = patternGroups(inputs.survey.ui_surfaces);
+
+  for (const group of groups) {
+    if (group.surfaces.length < SUPPORT_FLOOR) continue;
+    const specific = specificProposal(inputs, group);
+    if (specific && !inputs.existingIds.has(specific.id)) {
+      proposals.set(specific.id, specific);
+      continue;
+    }
+
+    const generic = genericProposal(inputs, group);
+    if (generic && !inputs.existingIds.has(generic.id)) {
+      proposals.set(generic.id, generic);
+    }
+  }
+
+  return [...proposals.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function patternGroups(surfaces: UiSurfaceRow[]): PatternGroup[] {
+  const groups = new Map<string, PatternGroup>();
+
+  for (const surface of surfaces) {
+    for (const pattern of surface.signals.layout_patterns ?? []) {
+      const key = `layout:${slug(pattern)}`;
+      addToGroup(groups, key, pattern, surface, pattern);
+    }
+
+    const components = meaningfulComponents(
+      surface.signals.dominant_components ?? [],
+    );
+    if (components.length >= 2) {
+      const key = `components:${components.join("+")}`;
+      addToGroup(groups, key, components.join(" + "), surface);
+    }
+  }
+
+  return [...groups.values()];
+}
+
+function addToGroup(
+  groups: Map<string, PatternGroup>,
+  key: string,
+  label: string,
+  surface: UiSurfaceRow,
+  layoutPattern?: string,
+): void {
+  const existing = groups.get(key) ?? {
+    key,
+    label,
+    surfaces: [],
+    components: [],
+    layoutPattern,
+  };
+  existing.surfaces.push(surface);
+  existing.components = meaningfulComponents([
+    ...existing.components,
+    ...(surface.signals.dominant_components ?? []),
+  ]);
+  existing.layoutPattern = existing.layoutPattern ?? layoutPattern;
+  groups.set(key, existing);
+}
+
+function specificProposal(
+  inputs: ProposalInputs,
+  group: PatternGroup,
+): GhostCheck | undefined {
+  if (isToolFooterGroup(group)) return toolFooterProposal(inputs, group);
+  if (isPulseMetricGroup(group)) return pulseMetricProposal(inputs, group);
+  return undefined;
+}
+
+function toolFooterProposal(
+  inputs: ProposalInputs,
+  group: PatternGroup,
+): GhostCheck {
+  const sources = sourceRefs(inputs.cwd, group, [
+    "ToolCardFooter",
+    "ToolFooterActions",
+  ]);
+  const replacement =
+    "ToolCardFooter + ToolFooterActions + ToolCancelButton + ToolSubmitButton";
+  return {
+    id: `use-${subjectPrefix(inputs.map.id)}-tool-footer-actions`,
+    title: "Use Managerbot tool footer action primitives",
+    status: "proposed",
+    severity: "serious",
+    applies_to: appliesTo(inputs.map, group),
+    detector: {
+      type: "forbidden-regex",
+      pattern: 'className="flex justify-end gap-2"',
+      contexts: ["react"],
+    },
+    evidence: evidence(group, sources, [
+      "False-positive risk: medium; flex end-aligned action rows can be legitimate outside approval-card footers.",
+    ]),
+    repair:
+      "Replace hand-rolled approval footer layout with shared Managerbot tool footer primitives.",
+    repair_hints: [
+      {
+        kind: "component-pattern-replacement",
+        replacement,
+        reason:
+          "Found the same approval-card footer pattern in sibling tool surfaces.",
+        inferred_from: "sibling-file-pattern",
+        source: sources[0],
+        sources,
+        confidence: "high",
+      },
+    ],
+  };
+}
+
+function pulseMetricProposal(
+  inputs: ProposalInputs,
+  group: PatternGroup,
+): GhostCheck {
+  const sources = sourceRefs(inputs.cwd, group, [
+    "MetricDataCard",
+    "ComparisonBadge",
+  ]);
+  return {
+    id: "use-pulse-metric-components",
+    title: "Use shared Pulse metric components",
+    status: "proposed",
+    severity: "serious",
+    applies_to: appliesTo(inputs.map, group),
+    detector: {
+      type: "forbidden-regex",
+      pattern: "rounded-2xl border p-6 shadow-sm|text-green-600",
+      contexts: ["react"],
+    },
+    evidence: evidence(group, sources, [
+      "False-positive risk: medium; raw card chrome and green trend text can be legitimate outside Pulse metric tiles.",
+    ]),
+    repair:
+      "Replace hand-rolled Pulse metric card and trend styling with shared Pulse metric components.",
+    repair_hints: [
+      {
+        kind: "component-pattern-replacement",
+        replacement: "MetricDataCard forceCardChrome + ComparisonBadge",
+        reason:
+          "Found repeated Pulse metric card and trend semantics in shared components.",
+        inferred_from: "sibling-file-pattern",
+        source: sources[0],
+        sources,
+        confidence: "high",
+      },
+    ],
+  };
+}
+
+function genericProposal(
+  inputs: ProposalInputs,
+  group: PatternGroup,
+): GhostCheck | undefined {
+  const components = group.components.slice(0, 4);
+  if (components.length < 2) return undefined;
+  const sources = sourceRefs(inputs.cwd, group, components);
+  const replacement = components.join(" + ");
+  return {
+    id: `use-${slug(group.layoutPattern ?? replacement)}-pattern`,
+    title: `Use shared ${humanize(group.layoutPattern ?? replacement)} pattern`,
+    status: "proposed",
+    severity: "serious",
+    applies_to: appliesTo(inputs.map, group),
+    detector: {
+      type: "required-regex",
+      pattern: components.map(escapeRegExp).join("|"),
+      contexts: ["react"],
+    },
+    evidence: evidence(group, sources, [
+      "False-positive risk: high; this generic proposal requires human review because it only knows the repeated component sequence.",
+    ]),
+    repair: `Use the shared ${replacement} pattern instead of hand-rolled local structure.`,
+    repair_hints: [
+      {
+        kind: "component-pattern-replacement",
+        replacement,
+        reason: "Found the same component sequence across sibling surfaces.",
+        inferred_from: "sibling-file-pattern",
+        source: sources[0],
+        sources,
+        confidence: "medium",
+      },
+    ],
+  };
+}
+
+function evidence(
+  group: PatternGroup,
+  sources: SourceRef[],
+  notes: string[],
+): NonNullable<GhostCheck["evidence"]> {
+  return {
+    support: support(group.surfaces.length),
+    observed_count: group.surfaces.length,
+    examples: sources.map((source) => ({
+      ...source,
+      note: `Observed in ${group.label}.`,
+    })),
+    notes,
+  };
+}
+
+function appliesTo(
+  map: MapFrontmatter,
+  group: PatternGroup,
+): NonNullable<GhostCheck["applies_to"]> {
+  const files = group.surfaces.flatMap((surface) => surface.files);
+  const scopes = commonScopes(map, files);
+  return {
+    ...(scopes.length > 0 ? { scopes } : {}),
+    paths: [commonDirectory(files)],
+  };
+}
+
+function commonScopes(map: MapFrontmatter, files: string[]): string[] {
+  const counts = new Map<string, number>();
+  for (const file of files) {
+    const scopes = routeGhostPathToScopes(map, file);
+    for (const scope of scopes) {
+      counts.set(scope.id, (counts.get(scope.id) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .filter(([, count]) => count === files.length)
+    .map(([scope]) => scope)
+    .sort();
+}
+
+function commonDirectory(files: string[]): string {
+  if (files.length === 0) return ".";
+  const parts = files.map((file) => dirname(file).split("/"));
+  const common: string[] = [];
+  for (let index = 0; index < parts[0].length; index++) {
+    const part = parts[0][index];
+    if (parts.every((candidate) => candidate[index] === part)) {
+      common.push(part);
+    } else {
+      break;
+    }
+  }
+  return common.length > 0 ? common.join("/") : dirname(files[0]);
+}
+
+function sourceRefs(
+  cwd: string,
+  group: PatternGroup,
+  needles: string[],
+): SourceRef[] {
+  const refs: SourceRef[] = [];
+  const seen = new Set<string>();
+  for (const surface of group.surfaces) {
+    for (const file of surface.files) {
+      if (seen.has(file)) continue;
+      seen.add(file);
+      refs.push({
+        path: file,
+        line: findLine(cwd, file, needles),
+      });
+      if (refs.length >= 5) return refs;
+    }
+  }
+  return refs.length > 0 ? refs : [{ path: group.surfaces[0]?.locator ?? "." }];
+}
+
+function findLine(
+  cwd: string,
+  file: string,
+  needles: string[],
+): number | undefined {
+  try {
+    const absolute = resolve(cwd, file);
+    const safeRelative = relative(cwd, absolute);
+    if (safeRelative.startsWith("..")) return undefined;
+    const content = readFileSyncCompat(absolute);
+    const lines = content.split(/\r?\n/);
+    const index = lines.findIndex((line) =>
+      needles.some((needle) => line.includes(needle)),
+    );
+    return index >= 0 ? index + 1 : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readFileSyncCompat(path: string): string {
+  return readFileSync(path, "utf-8");
+}
+
+function isToolFooterGroup(group: PatternGroup): boolean {
+  const label = group.label.toLowerCase();
+  const components = new Set(group.components);
+  return (
+    /tool.*footer|approval.*footer|footer.*action/.test(label) ||
+    (components.has("ToolCardFooter") && components.has("ToolFooterActions"))
+  );
+}
+
+function isPulseMetricGroup(group: PatternGroup): boolean {
+  const label = group.label.toLowerCase();
+  const components = new Set(group.components);
+  return (
+    /pulse.*metric|metric.*card|trend.*delta/.test(label) ||
+    components.has("MetricDataCard") ||
+    components.has("ComparisonBadge")
+  );
+}
+
+function support(count: number): number {
+  return Math.min(0.99, 0.8 + count * 0.05);
+}
+
+function meaningfulComponents(components: string[]): string[] {
+  return [...new Set(components)]
+    .filter((component) => component && !GENERIC_COMPONENTS.has(component))
+    .sort();
+}
+
+function subjectPrefix(id: string): string {
+  return slug(id.split("-")[0] || id);
+}
+
+function humanize(value: string): string {
+  return value
+    .replace(/[._-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+const GENERIC_COMPONENTS = new Set([
+  "Button",
+  "Card",
+  "CardContent",
+  "div",
+  "span",
+]);

--- a/packages/ghost-fingerprint/src/core/check-proposals.ts
+++ b/packages/ghost-fingerprint/src/core/check-proposals.ts
@@ -420,6 +420,13 @@ function findLine(
     if (safeRelative.startsWith("..")) return undefined;
     const content = readFileSyncCompat(absolute);
     const lines = content.split(/\r?\n/);
+    const jsxIndex = lines.findIndex((line) =>
+      needles.some((needle) =>
+        new RegExp(`<${escapeRegExp(needle)}\\b`).test(line),
+      ),
+    );
+    if (jsxIndex >= 0) return jsxIndex + 1;
+
     const index = lines.findIndex((line) =>
       needles.some((needle) => line.includes(needle)),
     );

--- a/packages/ghost-fingerprint/src/core/index.ts
+++ b/packages/ghost-fingerprint/src/core/index.ts
@@ -17,6 +17,12 @@ function assertMarkdownPath(path: string): void {
 
 export type { BodyData } from "./body.js";
 export { parseBody } from "./body.js";
+export type {
+  CheckProposalAdvisoryPacket,
+  CheckProposalOptions,
+  CheckProposalReport,
+} from "./check-proposals.js";
+export { proposeGhostChecks } from "./check-proposals.js";
 export type { DesignDecision } from "./compose.js";
 export { mergeFingerprint } from "./compose.js";
 export {

--- a/packages/ghost-fingerprint/test/cli.test.ts
+++ b/packages/ghost-fingerprint/test/cli.test.ts
@@ -4,11 +4,14 @@ import { join } from "node:path";
 import type { Survey, SurveySource } from "@ghost/core";
 import {
   componentRowId,
+  GhostChecksSchema,
+  lintGhostChecks,
   tokenRowId,
   uiSurfaceRowId,
   valueRowId,
 } from "@ghost/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
 import { buildCli } from "../src/cli.js";
 
 const BASE_FINGERPRINT = `---
@@ -893,3 +896,314 @@ describe("ghost-fingerprint survey patterns", () => {
     expect(patterns.surface_types[0].value).toBe("settings");
   });
 });
+
+describe("ghost-fingerprint checks propose", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = join(
+      tmpdir(),
+      `ghost-fingerprint-checks-propose-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(dir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("proposes a component-pattern check from repeated sibling component sequences", async () => {
+    await writeProposalPackage(
+      dir,
+      makePatternSurvey(SOURCE_A, [
+        patternSurface(
+          "Review A",
+          "src/review/a.tsx",
+          [],
+          ["SharedPanel", "SharedActions"],
+        ),
+        patternSurface(
+          "Review B",
+          "src/review/b.tsx",
+          [],
+          ["SharedPanel", "SharedActions"],
+        ),
+      ]),
+    );
+    await writeSource(
+      dir,
+      "src/review/a.tsx",
+      "<SharedPanel>\n  <SharedActions />\n</SharedPanel>\n",
+    );
+    await writeSource(
+      dir,
+      "src/review/b.tsx",
+      "<SharedPanel>\n  <SharedActions />\n</SharedPanel>\n",
+    );
+
+    const result = await runCli(
+      ["checks", "propose", ".ghost/fingerprint"],
+      dir,
+    );
+
+    expect(result.code).toBe(0);
+    const parsed = GhostChecksSchema.parse(parseYaml(result.stdout));
+    expect(parsed.checks).toHaveLength(1);
+    expect(parsed.checks[0].status).toBe("proposed");
+    expect(parsed.checks[0].detector.type).toBe("required-regex");
+    expect(parsed.checks[0].repair_hints?.[0].replacement).toBe(
+      "SharedActions + SharedPanel",
+    );
+    expect(parsed.checks[0].evidence?.examples?.[0]).toMatchObject({
+      path: "src/review/a.tsx",
+      line: 1,
+    });
+  });
+
+  it("does not propose weak one-off patterns", async () => {
+    await writeProposalPackage(
+      dir,
+      makePatternSurvey(SOURCE_A, [
+        patternSurface(
+          "Review A",
+          "src/review/a.tsx",
+          [],
+          ["SharedPanel", "SharedActions"],
+        ),
+      ]),
+    );
+
+    const result = await runCli(
+      ["checks", "propose", ".ghost/fingerprint"],
+      dir,
+    );
+
+    expect(result.code).toBe(0);
+    const parsed = GhostChecksSchema.parse(parseYaml(result.stdout));
+    expect(parsed.checks).toHaveLength(0);
+  });
+
+  it("does not mutate checks.yml", async () => {
+    const paths = await writeProposalPackage(
+      dir,
+      makePatternSurvey(SOURCE_A, [
+        patternSurface(
+          "Review A",
+          "src/review/a.tsx",
+          [],
+          ["SharedPanel", "SharedActions"],
+        ),
+        patternSurface(
+          "Review B",
+          "src/review/b.tsx",
+          [],
+          ["SharedPanel", "SharedActions"],
+        ),
+      ]),
+    );
+    const before = await readFile(paths.checks, "utf-8");
+
+    const result = await runCli(
+      ["checks", "propose", ".ghost/fingerprint"],
+      dir,
+    );
+
+    expect(result.code).toBe(0);
+    await expect(readFile(paths.checks, "utf-8")).resolves.toBe(before);
+  });
+
+  it("produces Managerbot footer and Pulse metric proposals", async () => {
+    await writeProposalPackage(
+      dir,
+      makePatternSurvey(SOURCE_A, [
+        patternSurface(
+          "Square update preview",
+          "apps/managerbot/managerbot-web/src/components/tools/square-update-preview/square-update-preview-ui.tsx",
+          ["tool-footer-actions"],
+          [
+            "ToolCardFooter",
+            "ToolFooterActions",
+            "ToolCancelButton",
+            "ToolSubmitButton",
+          ],
+        ),
+        patternSurface(
+          "Square remove preview",
+          "apps/managerbot/managerbot-web/src/components/tools/square-remove-preview/square-remove-preview-ui.tsx",
+          ["tool-footer-actions"],
+          [
+            "ToolCardFooter",
+            "ToolFooterActions",
+            "ToolCancelButton",
+            "ToolSubmitButton",
+          ],
+        ),
+        patternSurface(
+          "Pulse gross sales",
+          "apps/managerbot/managerbot-web/src/components/pages/Pulse/gross-sales.tsx",
+          ["pulse-metric-card"],
+          ["MetricDataCard", "ComparisonBadge"],
+        ),
+        patternSurface(
+          "Pulse refunds",
+          "apps/managerbot/managerbot-web/src/components/pages/Pulse/refunds.tsx",
+          ["pulse-metric-card"],
+          ["MetricDataCard", "ComparisonBadge"],
+        ),
+      ]),
+      "managerbot-ui",
+    );
+
+    const result = await runCli(
+      ["checks", "propose", ".ghost/fingerprint", "--format", "json"],
+      dir,
+    );
+
+    expect(result.code).toBe(0);
+    const report = JSON.parse(result.stdout);
+    const checks = GhostChecksSchema.parse(report.checks);
+    expect(checks.checks.map((check) => check.id)).toEqual([
+      "use-managerbot-tool-footer-actions",
+      "use-pulse-metric-components",
+    ]);
+    expect(report.advisory_packet.proposal_count).toBe(2);
+
+    const promoted = {
+      ...checks,
+      checks: checks.checks.map((check) => ({ ...check, status: "active" })),
+    };
+    expect(lintGhostChecks(promoted).errors).toBe(0);
+  });
+});
+
+async function writeProposalPackage(
+  dir: string,
+  survey: Survey,
+  id = "local",
+): Promise<{ checks: string }> {
+  const packageDir = join(dir, ".ghost", "fingerprint");
+  await mkdir(packageDir, { recursive: true });
+  await writeFile(join(packageDir, "map.md"), proposalMap(id));
+  await writeFile(
+    join(packageDir, "profile.md"),
+    fingerprintWithId(id.replace(/-/g, "_")),
+  );
+  await writeFile(
+    join(packageDir, "survey.json"),
+    JSON.stringify(survey, null, 2),
+  );
+  const checks = join(packageDir, "checks.yml");
+  await writeFile(
+    checks,
+    `schema: ghost.checks/v1
+id: ${id}
+checks: []
+`,
+  );
+  return { checks };
+}
+
+async function writeSource(dir: string, path: string, content: string) {
+  const target = join(dir, path);
+  await mkdir(join(target, ".."), { recursive: true });
+  await writeFile(target, content);
+}
+
+function proposalMap(id: string): string {
+  return `---
+schema: ghost.map/v2
+id: ${id}
+repo: local
+mapped_at: 2026-05-07
+platform: web
+languages:
+  - { name: typescript, files: 4, share: 1 }
+build_system: pnpm
+package_manifests:
+  - package.json
+composition:
+  frameworks:
+    - { name: react }
+  rendering: react
+  styling:
+    - tailwindcss
+design_system:
+  paths:
+    - src/components
+  status: active
+surface_sources:
+  render_strategy: static-source
+  include:
+    - "**/*.tsx"
+  exclude:
+    - "**/node_modules/**"
+feature_areas:
+  - name: app
+    paths:
+      - .
+scopes:
+  - id: managerbot-product-surfaces
+    name: Managerbot product surfaces
+    kind: product-surface
+    paths:
+      - apps/managerbot/managerbot-web/src/components
+      - src/review
+orientation_files:
+  - README.md
+---
+
+## Identity
+
+Local test map.
+
+## Topology
+
+Local test topology.
+
+## Conventions
+
+Local test conventions.
+`;
+}
+
+function makePatternSurvey(
+  source: SurveySource,
+  surfaces: Survey["ui_surfaces"],
+): Survey {
+  return {
+    schema: "ghost.survey/v2",
+    sources: [source],
+    values: [],
+    tokens: [],
+    components: [],
+    ui_surfaces: surfaces,
+  };
+}
+
+function patternSurface(
+  name: string,
+  file: string,
+  layoutPatterns: string[],
+  components: string[],
+): Survey["ui_surfaces"][number] {
+  return {
+    id: uiSurfaceRowId(SOURCE_A, name, "source", file),
+    source: SOURCE_A,
+    name,
+    kind: "source",
+    locator: file,
+    renderability: "source-only",
+    files: [file],
+    classification: {
+      intent: "review",
+      surface_type: "tools",
+      density: "standard",
+      layout_shape: "control-surface",
+      confidence: 0.9,
+    },
+    signals: {
+      dominant_components: components,
+      layout_patterns: layoutPatterns,
+    },
+  };
+}


### PR DESCRIPTION
🤖 Raised by Codex on behalf of Nahiyan.

## Summary

- Adds deterministic repair hints for Tailwind drift review output.
- Adds GitHub inline drift comment support and review command guidance.
- Adds fingerprint check proposals, improves JSX line selection, and tightens proposal sources.

## Notes

Stacked on `codex/ghost-drift-repair-hints-current` so the shared fingerprint-package refactor is not duplicated in this PR.

## Validation

- Not run in this pass; this PR packages existing local branch work.