### PR TITLE
[codex] Remove invariant references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Ghost
 
-Agents can write UI. What they cannot reliably preserve is the identity of the product that UI belongs to. The failure mode is structural: models generate by matching local patterns, not by maintaining global invariants, so they reproduce components, tokens, and layouts while losing the higher-order decisions that make a surface feel intentional.
+Agents can write UI. What they cannot reliably preserve is the identity of the product that UI belongs to. The failure mode is structural: models generate by matching local patterns, so they reproduce components, tokens, and layouts while losing the higher-order decisions that make a surface feel intentional.
 
 Ghost introduces a second layer: a repository-local, versioned fingerprint that captures the product's composition policy — the constraints, preferences, recurring decisions, and anti-patterns that shape how the design system is actually used. Agents read `fingerprint.md` before generating, compare against it after, and either correct drift or codify the divergence as a deliberate change. A scan runs in three stages — map (`map.md`) → survey (`survey.json`) → express (`fingerprint.md`) — all owned by `ghost-fingerprint`. Four tools plus a reference design system split the loop:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Agents can write UI. What they cannot reliably preserve is the identity of the product that UI belongs to.
 
-The failure mode is structural. Large language models generate by matching local patterns, not by maintaining global invariants. They reproduce components, tokens, and layouts, but they do not consistently preserve the higher-order decisions that make a surface feel intentional: hierarchy, density, restraint, repetition, and refusal.
+The failure mode is structural. Large language models generate by matching local patterns. They reproduce components, tokens, and layouts, but they do not consistently preserve the higher-order decisions that make a surface feel intentional: hierarchy, density, restraint, repetition, and refusal.
 
 Most design systems encode product inventory: colors, type scales, components. That inventory is necessary, but not sufficient. The same system can produce many different products. What is missing is the policy that governs how those parts are composed.
 

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -34,12 +34,11 @@ export default function Home() {
             </p>
             <p className="thesis-item">
               The failure mode is structural. Large language models generate by
-              matching local patterns, not by maintaining global invariants.
-              They reproduce components, tokens, and layouts, but they do not
-              consistently preserve the higher-order decisions that make a
-              surface feel intentional: its hierarchy, its density, its
-              restraint, the specific ways it repeats and the specific ways it
-              refuses.
+              matching local patterns. They reproduce components, tokens, and
+              layouts, but they do not consistently preserve the higher-order
+              decisions that make a surface feel intentional: its hierarchy, its
+              density, its restraint, the specific ways it repeats and the
+              specific ways it refuses.
             </p>
             <p className="thesis-item">
               Most design systems encode the inventory of a product: colors,

--- a/docs/cli-consolidation-plan.md
+++ b/docs/cli-consolidation-plan.md
@@ -167,7 +167,7 @@ review suite [fingerprint]
 - Docs: biggest rewrite here — review is now three pages, not three commands
 - Tests: expand review test to cover scope dispatch; keep verify/comply tests targeting the library APIs
 
-**Library API invariant:** `review()`, `verify()`, and `Director.comply()` all stay exported from `@ghost/core`. This is what the GitHub Action uses. The CLI restructure is presentation-layer only.
+**Library API contract:** `review()`, `verify()`, and `Director.comply()` all stay exported from `@ghost/core`. This is what the GitHub Action uses. The CLI restructure is presentation-layer only.
 
 **Exit criteria:** 10 verbs (9 after removing deprecation shims). The four drift verbs are now one.
 

--- a/docs/ideas/ghost-fleet.md
+++ b/docs/ideas/ghost-fleet.md
@@ -133,7 +133,7 @@ A modular repo therefore produces N+1 fingerprints: N module-level + 1 rollup. B
 
 **Skill recipe layering:**
 
-The existing prompts assemble from fragments — preamble + cli-usage + manifest-injection + (holistic | module | rollup) guidance + output-format. The fleet world-model skill should mirror that fragment architecture rather than ship one monolithic recipe. Three guidance fragments at minimum: how to reason over targets, modules, and rollups respectively. The neutral-profile invariant depends on getting that calibration right.
+The existing prompts assemble from fragments — preamble + cli-usage + manifest-injection + (holistic | module | rollup) guidance + output-format. The fleet world-model skill should mirror that fragment architecture rather than ship one monolithic recipe. Three guidance fragments at minimum: how to reason over targets, modules, and rollups respectively. The neutral-profile rule depends on getting that calibration right.
 
 ## Group-by — the axes that matter
 
@@ -168,14 +168,14 @@ After studying `~/Development/ghost-fleet`, here's what the prior art confirmed 
 - Member-as-elevation read-only over (map.md, fingerprint.md) pairs.
 - Group-by axes from map.md (platform, build_system, registry, rendering, styling).
 - Tracks-graph belongs in fleet but tracking *relationships* are authored in per-repo `.ghost-sync.json` — fleet just reads them.
-- Neutral / equal-weight profile pass is the core invariant. No hierarchy phases.
+- Neutral / equal-weight profile pass is the core rule. No hierarchy phases.
 - Vendored snapshot beats live fetch for reproducibility.
 - Visualization stays external (the existing `apps/viz` is a downstream JSON consumer; fleet doesn't own it).
 
 **What shifted:**
 - **Three profiling modes (target / module / rollup), not one.** Captured above as its own section. This is the single biggest miss in the original draft.
 - **Schema narrows.** Today's `fleet.distances.json` is `{ pairwise: [{a, b, distance}] }` — flat pairwise array, no clusters. Clustering is a skill/viz-layer projection over the matrix, not orchestrator output. My initial schema overspecified `clusters:` in frontmatter; it's been moved to body-only narrative.
-- **Layered prompt fragments are the architecture, not a stylistic choice.** Preamble + cli-usage + manifest-injection + (holistic | module | rollup) guidance + output-format. The world-model skill should mirror this layering. A monolithic recipe will conflate the three modes and break the neutral-profile invariant.
+- **Layered prompt fragments are the architecture, not a stylistic choice.** Preamble + cli-usage + manifest-injection + (holistic | module | rollup) guidance + output-format. The world-model skill should mirror this layering. A monolithic recipe will conflate the three modes and break the neutral-profile calibration.
 - **Mode signaling.** A member's profiling mode (monolithic vs modular) and its module list must be declared somewhere fleet can read deterministically. Likely map.md frontmatter (`profiling_mode`, `modules`). Original draft didn't surface this.
 - **CLI contract for modular repos.** `ghost fleet view` consumes rollups by default; `--include-modules` widens. Original draft treated members as atomic.
 

--- a/docs/ideas/ghost-map.md
+++ b/docs/ideas/ghost-map.md
@@ -32,7 +32,7 @@ The verb is LLM-driven; the CLI is deterministic scaffolding.
 | `ghost map lint` (CLI) | Validate map.md against `ghost.map/v2`, flag missing sections | CLI |
 | `ghost map describe` (CLI) | Print sections + token estimates for selective loading | CLI |
 
-Same shape as `ghost fingerprint` (profile drives, lint/describe support). BYOA invariant holds at the CLI line.
+Same shape as `ghost fingerprint` (profile drives, lint/describe support). The BYOA boundary holds at the CLI line.
 
 ## Schema — `ghost.map/v2`
 

--- a/map.md
+++ b/map.md
@@ -87,7 +87,6 @@ feature_areas:
 orientation_files:
   - README.md
   - CLAUDE.md
-  - INVARIANTS.md
   - docs/fingerprint-format.md
   - docs/ideas/phase-0-decisions.md
 ---
@@ -136,10 +135,9 @@ is the MCP server re-exposing the registry to AI assistants.
 catalogue site.
 
 Orientation reading order is `README.md` → `CLAUDE.md` (agent context) →
-`INVARIANTS.md` (hard constraints — read before any non-trivial change) →
 `docs/fingerprint-format.md` (the canonical artifact spec) →
-`docs/ideas/phase-0-decisions.md` (the decomposition plan that
-contextualizes ghost-map's existence).
+`docs/ideas/phase-0-decisions.md` (the decomposition plan that contextualizes
+ghost-map's existence).
 
 ## Conventions
 

--- a/packages/ghost-core/test/perceptual-prior.test.ts
+++ b/packages/ghost-core/test/perceptual-prior.test.ts
@@ -218,7 +218,7 @@ describe("resolveTolerance", () => {
   });
 });
 
-describe("perceptual-prior tier-coverage invariant", () => {
+describe("perceptual-prior tier coverage", () => {
   it("every canonical dimension lands in one of three tiers", () => {
     const tiers = new Set<PerceptualTier>(["loud", "structural", "rhythmic"]);
     for (const dim of CANONICAL_DECISION_DIMENSIONS) {


### PR DESCRIPTION
🤖 Summary

- Remove stale references to `INVARIANTS.md` from the repo map.
- Reword remaining docs and docs-site copy to avoid invariant terminology.
- Rename the perceptual-prior test suite label without changing behavior.

Validation

- `pnpm --filter @ghost/core test -- perceptual-prior`
- Pre-commit: `pnpm check`, formatter
- Pre-push: `pnpm build`, `pnpm check`, `pnpm test`