### PR TITLE
fix(changeset): retarget compare-gate changeset at @anarchitecture/ghost

### DIFF
--- a/.changeset/add-compare-gate-mode.md
+++ b/.changeset/add-compare-gate-mode.md
@@ -1,5 +1,5 @@
 ---
-"ghost-drift": minor
+"@anarchitecture/ghost": minor
 ---
 
-Add `--gate` mode to `ghost-drift compare` that reads `.ghost-sync.json` and reports per-dimension verdicts (aligned / covered / reconverging / uncovered). Exits 0 when no uncovered drift, 1 when uncovered, 2 on hard error. Versioned JSON output via `--format json` (schema: `ghost.compare.gate/v1`). Composes over existing `compareFingerprints`, `readSyncManifest`, and `checkBounds` — no new orchestration.
+Add `--gate` mode to `ghost compare` that reads `.ghost-sync.json` and reports per-dimension verdicts (aligned / covered / reconverging / uncovered). Exits 0 when no uncovered drift, 1 when uncovered, 2 on hard error. Versioned JSON output via `--format json` (schema: `ghost.compare.gate/v1`). Composes over existing `compareFingerprints`, `readSyncManifest`, and `checkBounds` — no new orchestration.


### PR DESCRIPTION
## What

Retargets `.changeset/add-compare-gate-mode.md` from `ghost-drift` (the pre-unification workspace package name) to `@anarchitecture/ghost` (the unified package on `main`).

## Why

The Release workflow that fired on the #78 merge commit failed in the `Create Release PR or publish` step:

```
🦋  error Error: Found changeset add-compare-gate-mode for package ghost-drift which is not in the workspace
```

Failing run: https://github.com/block/ghost/actions/runs/26118777942/job/76814916209

The changeset for PR #78 was written against the pre-unification package name `ghost-drift`. When I rebased #78 onto `main` after the unified-package refactor landed, I updated the code (`@ghost/core` → `#ghost-core`, file paths under `packages/ghost/`, regenerated the cli-manifest) but missed updating the changeset frontmatter. The error only surfaces post-merge because the Release workflow only runs on `main`.

## Fix

- Update the changeset's package key from `ghost-drift` to `@anarchitecture/ghost`
- Update the prose body from `ghost-drift compare` to `ghost compare` to match the unified CLI surface

## Verification

```
$ pnpm changeset status
🦋  info Packages to be bumped at minor:
🦋  - @anarchitecture/ghost
``"

Once this lands, the Release workflow should produce a normal Version Packages PR for `@anarchitecture/ghost` at minor (which is the intended `--gate`-mode-shipped version bump).