### PR TITLE
ci: support npm authenticated publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,4 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN || secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GHOST_NPM_PUBLISH_TOKEN || secrets.NPM_PUBLISH_TOKEN || secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -39,11 +39,10 @@ jobs:
       - name: Create Release PR or publish
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
-          publish: pnpm --filter @anarchitecture/ghost publish --access public --no-git-checks
+          publish: npm publish ./packages/ghost --access public --provenance
           version: pnpm changeset version
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN || secrets.NPM_TOKEN }}


### PR DESCRIPTION
🤖 This PR updates the Release workflow so `@anarchitecture/ghost` can publish through either repo-provided npm credentials or npm Trusted Publishing.

Changes:
- Updates `actions/setup-node` to v6 and uses Node 24 for a modern npm CLI.
- Publishes the package with `npm publish ./packages/ghost --access public --provenance` so npm OIDC/trusted publishing can work.
- Reads the npm token from either `NPM_PUBLISH_TOKEN` or the conventional `NPM_TOKEN` GitHub Actions secret.
- Removes the separate `NODE_AUTH_TOKEN` env because Changesets writes npm auth from `NPM_TOKEN` when a token is present.

Local verification:
- `pnpm check`
- `pnpm build`
- `pnpm test` via pre-push, 479 tests passing
- `npm_config_cache=/private/tmp/ghost-npm-cache npm pack ./packages/ghost --dry-run --ignore-scripts`

Remaining setup before merging the release PR:
- Add a repo secret named `NPM_PUBLISH_TOKEN` or `NPM_TOKEN` containing an npm publish token for `@anarchitecture/ghost`; or
- Configure npm Trusted Publishing for package `@anarchitecture/ghost` with owner `block`, repository `ghost`, workflow `Release`, and branch `main`.