### PR TITLE
ci: pass npm token to setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,5 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GHOST_NPM_PUBLISH_TOKEN || secrets.NPM_PUBLISH_TOKEN || secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GHOST_NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GHOST_NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
🤖 This PR fixes the npm publish auth path after the `@anarchitecture/ghost@0.1.0` release job reached npm but failed with `E404`.

Root cause hypothesis:
- `actions/setup-node` sets `NPM_CONFIG_USERCONFIG` to a temp `.npmrc`.
- That temp `.npmrc` is wired to `NODE_AUTH_TOKEN`.
- The workflow only set `NPM_TOKEN`, so Changesets wrote `~/.npmrc`, but `npm publish` was still using setup-node's temp userconfig.
- The failed job logs showed both `NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc` and a placeholder-looking `NODE_AUTH_TOKEN`, which explains npm acting unauthenticated/unauthorized even though `NPM_TOKEN` existed.

Change:
- Sets both `NPM_TOKEN` and `NODE_AUTH_TOKEN` from `GHOST_NPM_PUBLISH_TOKEN`.
- Removes fallback to org-level `NPM_PUBLISH_TOKEN` / `NPM_TOKEN` so we know exactly which secret is used.

Validation:
- `pnpm check`
- pre-push `pnpm build`, `pnpm check`, `pnpm test` with 479 tests passing