### PR TITLE
[codex] Ground checks in fingerprint memory

### DIFF
--- a/.changeset/checks-grounding.md
+++ b/.changeset/checks-grounding.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": minor
+---
+
+Add typed fingerprint grounding for active ghost.checks/v1 checks.

--- a/packages/ghost/src/core/check.ts
+++ b/packages/ghost/src/core/check.ts
@@ -223,7 +223,8 @@ async function loadCheckPackage(
         .join("; ")}`,
     );
   }
-  const checkLint = lintGhostChecks(checksResult.data, { map });
+  const checks = checksResult.data as GhostChecksDocument;
+  const checkLint = lintGhostChecks(checks, { map });
   if (checkLint.errors > 0) {
     throw new Error(
       `checks.yml failed lint with ${checkLint.errors} error(s): ${checkLint.issues
@@ -232,7 +233,7 @@ async function loadCheckPackage(
         .join("; ")}`,
     );
   }
-  return { dir: paths.dir, map, checks: checksResult.data };
+  return { dir: paths.dir, map, checks };
 }
 
 async function readOptional(path: string): Promise<string | undefined> {

--- a/packages/ghost/src/ghost-core/checks/index.ts
+++ b/packages/ghost/src/ghost-core/checks/index.ts
@@ -6,12 +6,14 @@ export {
   routeGhostPathToScopes,
 } from "./routing.js";
 export {
+  GhostCheckDerivesFromSchema,
   GhostCheckSchema,
   GhostChecksSchema,
 } from "./schema.js";
 export type {
   GhostCheck,
   GhostCheckAppliesTo,
+  GhostCheckDerivesFrom,
   GhostCheckDetector,
   GhostCheckDetectorType,
   GhostCheckEvidence,

--- a/packages/ghost/src/ghost-core/checks/lint.ts
+++ b/packages/ghost/src/ghost-core/checks/lint.ts
@@ -9,6 +9,14 @@ import type {
 } from "./types.js";
 
 const SUPPORT_FLOOR = 0.85;
+const GROUNDING_PREFIXES = [
+  "principle",
+  "situation",
+  "experience_contract",
+  "pattern",
+  "substrate",
+] as const;
+type GroundingPrefix = (typeof GROUNDING_PREFIXES)[number];
 
 export function lintGhostChecks(
   input: unknown,
@@ -65,6 +73,7 @@ function checkOne(
 ): void {
   const path = `checks[${index}]`;
   checkDetector(check, path, issues);
+  checkGrounding(check, path, options, issues);
 
   if (check.status === "disabled") return;
 
@@ -137,6 +146,62 @@ function checkOne(
       path: `${path}.evidence.examples`,
     });
   }
+}
+
+function checkGrounding(
+  check: GhostCheck,
+  path: string,
+  options: GhostChecksLintOptions,
+  issues: GhostChecksLintIssue[],
+): void {
+  if (check.status === "active" && !check.derives_from) {
+    issues.push({
+      severity: "error",
+      rule: "check-grounding-missing",
+      message:
+        "Active checks must declare derives_from with a typed fingerprint.yml reference.",
+      path: `${path}.derives_from`,
+    });
+    return;
+  }
+
+  if (!check.derives_from || !options.fingerprint) return;
+
+  const parsed = parseGroundingRef(check.derives_from);
+  if (!parsed) return;
+
+  const targets = collectFingerprintTargets(options.fingerprint);
+  if (targets[parsed.prefix].has(parsed.id)) return;
+
+  issues.push({
+    severity: check.status === "active" ? "error" : "warning",
+    rule: "check-grounding-unknown",
+    message: `Check derives_from references unknown fingerprint memory '${check.derives_from}'.`,
+    path: `${path}.derives_from`,
+  });
+}
+
+function parseGroundingRef(
+  ref: string,
+): { prefix: GroundingPrefix; id: string } | undefined {
+  const [prefix, id] = ref.split(":");
+  if (!prefix || !id) return undefined;
+  if (!GROUNDING_PREFIXES.includes(prefix as GroundingPrefix)) return undefined;
+  return { prefix: prefix as GroundingPrefix, id };
+}
+
+function collectFingerprintTargets(
+  fingerprint: NonNullable<GhostChecksLintOptions["fingerprint"]>,
+): Record<GroundingPrefix, Set<string>> {
+  return {
+    principle: new Set(fingerprint.principles.map((entry) => entry.id)),
+    situation: new Set(fingerprint.situations.map((entry) => entry.id)),
+    experience_contract: new Set(
+      fingerprint.experience_contracts.map((entry) => entry.id),
+    ),
+    pattern: new Set(fingerprint.patterns.map((entry) => entry.id)),
+    substrate: new Set(Object.keys(fingerprint.substrate)),
+  };
 }
 
 function checkDetector(

--- a/packages/ghost/src/ghost-core/checks/schema.ts
+++ b/packages/ghost/src/ghost-core/checks/schema.ts
@@ -4,6 +4,17 @@ import { GHOST_CHECKS_SCHEMA } from "./types.js";
 const GhostCheckStatusSchema = z.enum(["active", "proposed", "disabled"]);
 const GhostCheckSeveritySchema = z.enum(["critical", "serious", "nit"]);
 
+export const GhostCheckDerivesFromSchema = z
+  .string()
+  .min(1)
+  .regex(
+    /^(principle|situation|experience_contract|pattern|substrate):[a-z0-9][a-z0-9._-]*$/,
+    {
+      message:
+        "derives_from must use a typed fingerprint ref, e.g. principle:dense-workflows",
+    },
+  );
+
 const GhostCheckAppliesToSchema = z
   .object({
     scopes: z.array(z.string().min(1)).optional(),
@@ -58,6 +69,7 @@ export const GhostCheckSchema = z
     title: z.string().min(1),
     status: GhostCheckStatusSchema,
     severity: GhostCheckSeveritySchema,
+    derives_from: GhostCheckDerivesFromSchema.optional(),
     applies_to: GhostCheckAppliesToSchema.optional(),
     detector: GhostCheckDetectorSchema,
     evidence: GhostCheckEvidenceSchema.optional(),

--- a/packages/ghost/src/ghost-core/checks/types.ts
+++ b/packages/ghost/src/ghost-core/checks/types.ts
@@ -1,3 +1,7 @@
+import type {
+  GhostFingerprintDocument,
+  GhostFingerprintRef,
+} from "../fingerprint/index.js";
 import type { MapFrontmatter, MapScope } from "../map/index.js";
 
 export const GHOST_CHECKS_SCHEMA = "ghost.checks/v1" as const;
@@ -5,6 +9,14 @@ export const GHOST_CHECKS_FILENAME = "checks.yml" as const;
 
 export type GhostCheckStatus = "active" | "proposed" | "disabled";
 export type GhostCheckSeverity = "critical" | "serious" | "nit";
+export type GhostCheckDerivesFrom = Extract<
+  GhostFingerprintRef,
+  | `principle:${string}`
+  | `situation:${string}`
+  | `experience_contract:${string}`
+  | `pattern:${string}`
+  | `substrate:${string}`
+>;
 
 export type GhostCheckDetectorType =
   | "forbidden-regex"
@@ -38,6 +50,7 @@ export interface GhostCheck {
   title: string;
   status: GhostCheckStatus;
   severity: GhostCheckSeverity;
+  derives_from?: GhostCheckDerivesFrom;
   applies_to?: GhostCheckAppliesTo;
   detector: GhostCheckDetector;
   evidence?: GhostCheckEvidence;
@@ -68,6 +81,7 @@ export interface GhostChecksLintReport {
 
 export interface GhostChecksLintOptions {
   map?: Pick<MapFrontmatter, "scopes" | "feature_areas">;
+  fingerprint?: GhostFingerprintDocument;
 }
 
 export interface RoutedGhostCheck {

--- a/packages/ghost/src/ghost-core/index.ts
+++ b/packages/ghost/src/ghost-core/index.ts
@@ -3,6 +3,7 @@
 export type {
   GhostCheck,
   GhostCheckAppliesTo,
+  GhostCheckDerivesFrom,
   GhostCheckDetector,
   GhostCheckDetectorType,
   GhostCheckEvidence,
@@ -19,6 +20,7 @@ export type {
 export {
   GHOST_CHECKS_FILENAME,
   GHOST_CHECKS_SCHEMA,
+  GhostCheckDerivesFromSchema,
   GhostCheckSchema,
   GhostChecksSchema,
   lintGhostChecks,

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -68,6 +68,7 @@ checks:
     title: Use design tokens for UI color
     status: active
     severity: serious
+    derives_from: pattern:tokenized-ui-color
     applies_to:
       scopes: [checkout]
       paths: [src/checkout]

--- a/packages/ghost/test/checks-grounding.test.ts
+++ b/packages/ghost/test/checks-grounding.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  GHOST_CHECKS_SCHEMA,
+  GHOST_FINGERPRINT_SCHEMA,
+  type GhostChecksDocument,
+  type GhostFingerprintDocument,
+  lintGhostChecks,
+} from "../src/ghost-core/index.js";
+
+describe("ghost.checks/v1 grounding", () => {
+  it("requires active checks to declare derives_from", () => {
+    const doc = checksDocument({
+      derives_from: undefined,
+    });
+
+    const report = lintGhostChecks(doc);
+
+    expect(report.errors).toBe(1);
+    expect(report.issues[0]).toMatchObject({
+      rule: "check-grounding-missing",
+      path: "checks[0].derives_from",
+    });
+  });
+
+  it("accepts active checks grounded in fingerprint.yml memory", () => {
+    const report = lintGhostChecks(checksDocument(), {
+      fingerprint: fingerprintDocument(),
+    });
+
+    expect(report.errors).toBe(0);
+    expect(report.warnings).toBe(0);
+  });
+
+  it("reports active checks grounded in missing fingerprint.yml memory", () => {
+    const doc = checksDocument({
+      derives_from: "principle:missing-principle",
+    });
+
+    const report = lintGhostChecks(doc, {
+      fingerprint: fingerprintDocument(),
+    });
+
+    expect(report.errors).toBe(1);
+    expect(report.issues[0]).toMatchObject({
+      rule: "check-grounding-unknown",
+      path: "checks[0].derives_from",
+    });
+  });
+
+  it("downgrades proposed check grounding misses to warnings", () => {
+    const doc = checksDocument({
+      status: "proposed",
+      derives_from: "principle:missing-principle",
+    });
+
+    const report = lintGhostChecks(doc, {
+      fingerprint: fingerprintDocument(),
+    });
+
+    expect(report.errors).toBe(0);
+    expect(report.warnings).toBe(1);
+    expect(report.issues[0]).toMatchObject({
+      rule: "check-grounding-unknown",
+    });
+  });
+
+  it("rejects untyped derives_from references at schema level", () => {
+    const doc = checksDocument({
+      derives_from: "dense-workflows-prioritize-scanning",
+    });
+
+    const report = lintGhostChecks(doc);
+
+    expect(report.errors).toBe(1);
+    expect(report.issues[0]?.rule).toBe("schema/invalid_format");
+  });
+});
+
+function checksDocument(
+  overrides: Partial<GhostChecksDocument["checks"][number]> = {},
+): GhostChecksDocument {
+  return {
+    schema: GHOST_CHECKS_SCHEMA,
+    id: "example",
+    checks: [
+      {
+        id: "no-decorative-card-grid-for-dense-table",
+        title: "Do not replace dense tables with decorative cards",
+        status: "active",
+        severity: "serious",
+        derives_from: "principle:dense-workflows-prioritize-scanning",
+        applies_to: {
+          paths: ["apps/dashboard/**"],
+        },
+        detector: {
+          type: "forbidden-regex",
+          pattern: "decorativeCardGrid",
+        },
+        evidence: {
+          support: 0.94,
+          observed_count: 3,
+          examples: ["apps/dashboard/src/routes/orders/page.tsx"],
+        },
+        ...overrides,
+      },
+    ],
+  };
+}
+
+function fingerprintDocument(): GhostFingerprintDocument {
+  return {
+    schema: GHOST_FINGERPRINT_SCHEMA,
+    summary: {},
+    topology: {},
+    situations: [],
+    principles: [
+      {
+        id: "dense-workflows-prioritize-scanning",
+        status: "accepted",
+        principle:
+          "Dense workflows optimize for comparison, speed, and recovery.",
+      },
+    ],
+    experience_contracts: [],
+    patterns: [],
+    substrate: {},
+    review_policy: {},
+  };
+}

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -537,6 +537,7 @@ checks:
     title: Use design tokens for UI color
     status: active
     severity: serious
+    derives_from: pattern:tokenized-ui-color
     applies_to:
       scopes: [lending]
       paths: [Code/Features/Lending]


### PR DESCRIPTION
🤖 Draft stack PR opened by my AI agent.

## Summary
- Grounds deterministic checks in the new fingerprint memory model.
- Extends check schema, linting, and type surfaces for typed fingerprint references.
- Adds focused tests for check refs and evidence grounding.

## Impact
Checks can now validate against the canonical fingerprint package instead of drifting across legacy memory structures.

## Stack
- Branch stack position: 3 of 11
- PR stack position: 2 of 10
- Base: `codex/fingerprint-schema-foundation`
- Head: `codex/fingerprint-checks-grounding`
- Previous PR: #88

## Validation
- `/opt/homebrew/bin/pnpm build`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm check`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm test` (493 tests passed)