### PR TITLE
[codex] Wire commands to fingerprint yml memory

### DIFF
--- a/.changeset/fingerprint-command-integration.md
+++ b/.changeset/fingerprint-command-integration.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": major
+---
+
+Make fingerprint.yml the canonical package artifact for init, lint, scan, verify, and check grounding.

--- a/apps/docs/src/generated/cli-manifest.json
+++ b/apps/docs/src/generated/cli-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-19T16:33:13.019Z",
+  "generatedAt": "2026-05-24T20:39:47.948Z",
   "tools": [
     {
       "tool": "ghost",
@@ -8,7 +8,7 @@
           "tool": "ghost",
           "name": "lint",
           "rawName": "lint [file]",
-          "description": "Validate a root fingerprint bundle, resources.yml, map.md, survey.json, patterns.yml, checks.yml, or markdown — defaults to .ghost",
+          "description": "Validate a root Ghost memory bundle, fingerprint.yml, checks.yml, or legacy markdown — defaults to .ghost",
           "options": [
             {
               "rawName": "--format <fmt>",
@@ -24,7 +24,7 @@
           "tool": "ghost",
           "name": "init",
           "rawName": "init [dir]",
-          "description": "Create a root .ghost fingerprint bundle skeleton (resources.yml, map.md, survey.json, patterns.yml, checks.yml)",
+          "description": "Create a root .ghost product experience memory skeleton (fingerprint.yml, checks.yml, proposals/, cache/)",
           "options": [
             {
               "rawName": "--with-intent",
@@ -48,7 +48,7 @@
           "tool": "ghost",
           "name": "verify",
           "rawName": "verify [dir]",
-          "description": "Verify a root fingerprint bundle: resources are reachable, patterns are survey-backed, and checks reference known patterns.",
+          "description": "Verify a root Ghost memory bundle: fingerprint evidence paths and checks are grounded.",
           "options": [
             {
               "rawName": "--root <dir>",

--- a/packages/ghost/src/core/check.ts
+++ b/packages/ghost/src/core/check.ts
@@ -6,6 +6,8 @@ import {
   type GhostCheck,
   type GhostChecksDocument,
   GhostChecksSchema,
+  type GhostFingerprintDocument,
+  GhostFingerprintSchema,
   lintGhostChecks,
   type MapFrontmatter,
   MapFrontmatterSchema,
@@ -64,7 +66,7 @@ export interface GhostDriftCheckReport {
 
 interface LoadedCheckPackage {
   dir: string;
-  map: MapFrontmatter;
+  map: Pick<MapFrontmatter, "scopes" | "feature_areas">;
   checks: GhostChecksDocument;
 }
 
@@ -198,11 +200,23 @@ async function loadCheckPackage(
   cwd: string,
 ): Promise<LoadedCheckPackage> {
   const paths = resolveFingerprintPackage(packageDir, cwd);
-  const [mapRaw, checksRaw] = await Promise.all([
-    readFile(paths.map, "utf-8"),
+  const [fingerprintRaw, mapRaw, checksRaw] = await Promise.all([
+    readFile(paths.fingerprintYml, "utf-8"),
+    readOptional(paths.map),
     readOptional(paths.checks),
   ]);
-  const map = parseMap(mapRaw);
+  const fingerprintResult = GhostFingerprintSchema.safeParse(
+    parseYaml(fingerprintRaw),
+  );
+  if (!fingerprintResult.success) {
+    throw new Error(
+      `fingerprint.yml failed validation: ${fingerprintResult.error.issues
+        .map((issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
+        .join("; ")}`,
+    );
+  }
+  const fingerprint = fingerprintResult.data as GhostFingerprintDocument;
+  const map = mapRaw ? parseMap(mapRaw) : mapFromFingerprint(fingerprint);
   if (checksRaw === undefined) {
     return {
       dir: paths.dir,
@@ -224,7 +238,7 @@ async function loadCheckPackage(
     );
   }
   const checks = checksResult.data as GhostChecksDocument;
-  const checkLint = lintGhostChecks(checks, { map });
+  const checkLint = lintGhostChecks(checks, { fingerprint, map });
   if (checkLint.errors > 0) {
     throw new Error(
       `checks.yml failed lint with ${checkLint.errors} error(s): ${checkLint.issues
@@ -257,6 +271,20 @@ function parseMap(raw: string): MapFrontmatter {
     );
   }
   return result.data;
+}
+
+function mapFromFingerprint(
+  fingerprint: GhostFingerprintDocument,
+): Pick<MapFrontmatter, "scopes" | "feature_areas"> {
+  return {
+    scopes: fingerprint.topology.scopes?.map((scope) => ({
+      id: scope.id,
+      name: scope.id,
+      kind: "fingerprint-topology",
+      paths: [...scope.paths],
+    })),
+    feature_areas: [],
+  };
 }
 
 async function readGitDiff(

--- a/packages/ghost/src/ghost-core/fingerprint-package.ts
+++ b/packages/ghost/src/ghost-core/fingerprint-package.ts
@@ -1,13 +1,16 @@
 export const FINGERPRINT_PACKAGE_DIR = ".ghost" as const;
 export const RESOURCES_FILENAME = "resources.yml" as const;
 export const PATTERNS_FILENAME = "patterns.yml" as const;
+export const FINGERPRINT_YML_FILENAME = "fingerprint.yml" as const;
 export const INTENT_FILENAME = "intent.md" as const;
 export const FINGERPRINT_FILENAME = "fingerprint.md" as const;
 export const DECISIONS_DIRNAME = "decisions" as const;
 export const PROPOSALS_DIRNAME = "proposals" as const;
+export const CACHE_DIRNAME = "cache" as const;
 
 export interface FingerprintPackagePaths {
   dir: string;
+  fingerprintYml: string;
   resources: string;
   map: string;
   survey: string;
@@ -18,4 +21,5 @@ export interface FingerprintPackagePaths {
   intent: string;
   decisions: string;
   proposals: string;
+  cache: string;
 }

--- a/packages/ghost/src/ghost-core/index.ts
+++ b/packages/ghost/src/ghost-core/index.ts
@@ -102,9 +102,11 @@ export {
 } from "./fingerprint/index.js";
 // --- Map (ghost.map/v2) ---
 export {
+  CACHE_DIRNAME,
   DECISIONS_DIRNAME,
   FINGERPRINT_FILENAME,
   FINGERPRINT_PACKAGE_DIR,
+  FINGERPRINT_YML_FILENAME,
   type FingerprintPackagePaths,
   INTENT_FILENAME,
   PATTERNS_FILENAME,

--- a/packages/ghost/src/scan-commands.ts
+++ b/packages/ghost/src/scan-commands.ts
@@ -8,6 +8,7 @@ import {
   formatSurveySummaryMarkdown,
   type GhostPatternsDocument,
   lintGhostChecks,
+  lintGhostFingerprint,
   lintGhostPatterns,
   lintGhostResources,
   lintSurvey,
@@ -57,7 +58,7 @@ export function registerScanCommands(cli: CAC): void {
   cli
     .command(
       "lint [file]",
-      "Validate a root fingerprint bundle, resources.yml, map.md, survey.json, patterns.yml, checks.yml, or markdown — defaults to .ghost",
+      "Validate a root Ghost memory bundle, fingerprint.yml, checks.yml, or legacy markdown — defaults to .ghost",
     )
     .option("--format <fmt>", "Output format: cli or json", { default: "cli" })
     .action(async (path: string | undefined, opts) => {
@@ -78,15 +79,17 @@ export function registerScanCommands(cli: CAC): void {
         report =
           kind === "survey"
             ? lintSurveyFile(raw)
-            : kind === "map"
-              ? lintMap(raw)
-              : kind === "resources"
-                ? lintResourcesFile(raw)
-                : kind === "patterns"
-                  ? lintPatternsFile(raw)
-                  : kind === "checks"
-                    ? lintChecksFile(raw)
-                    : lintFingerprint(raw);
+            : kind === "fingerprint-yml"
+              ? lintFingerprintYmlFile(raw)
+              : kind === "map"
+                ? lintMap(raw)
+                : kind === "resources"
+                  ? lintResourcesFile(raw)
+                  : kind === "patterns"
+                    ? lintPatternsFile(raw)
+                    : kind === "checks"
+                      ? lintChecksFile(raw)
+                      : lintFingerprint(raw);
 
         if (kind === "fingerprint" && hasExtends(raw) && report.errors === 0) {
           try {
@@ -116,7 +119,7 @@ export function registerScanCommands(cli: CAC): void {
   cli
     .command(
       "init [dir]",
-      "Create a root .ghost fingerprint bundle skeleton (resources.yml, map.md, survey.json, patterns.yml, checks.yml)",
+      "Create a root .ghost product experience memory skeleton (fingerprint.yml, checks.yml, proposals/, cache/)",
     )
     .option(
       "--with-intent",
@@ -129,16 +132,17 @@ export function registerScanCommands(cli: CAC): void {
           withIntent: Boolean(opts.withIntent),
         });
         if (opts.format === "json") {
-          process.stdout.write(`${JSON.stringify(paths, null, 2)}\n`);
+          process.stdout.write(
+            `${JSON.stringify(initCommandOutput(paths, Boolean(opts.withIntent)), null, 2)}\n`,
+          );
         } else {
           process.stdout.write(
             `Initialized fingerprint package: ${paths.dir}\n`,
           );
-          process.stdout.write(`  resources.yml: ${paths.resources}\n`);
-          process.stdout.write(`  map.md: ${paths.map}\n`);
-          process.stdout.write(`  survey.json: ${paths.survey}\n`);
-          process.stdout.write(`  patterns.yml: ${paths.patterns}\n`);
+          process.stdout.write(`  fingerprint.yml: ${paths.fingerprintYml}\n`);
           process.stdout.write(`  checks.yml: ${paths.checks}\n`);
+          process.stdout.write(`  proposals/: ${paths.proposals}\n`);
+          process.stdout.write(`  cache/: ${paths.cache}\n`);
           if (opts.withIntent) {
             process.stdout.write(`  intent.md: ${paths.intent}\n`);
           }
@@ -156,11 +160,11 @@ export function registerScanCommands(cli: CAC): void {
   cli
     .command(
       "verify [dir]",
-      "Verify a root fingerprint bundle: resources are reachable, patterns are survey-backed, and checks reference known patterns.",
+      "Verify a root Ghost memory bundle: fingerprint evidence paths and checks are grounded.",
     )
     .option(
       "--root <dir>",
-      "Optional target root used to resolve resources.yml local paths (default: cwd)",
+      "Optional target root used to resolve fingerprint.yml evidence paths (default: cwd)",
     )
     .option("--format <fmt>", "Output format: cli or json", { default: "cli" })
     .action(async (dirArg: string | undefined, opts) => {
@@ -214,19 +218,16 @@ export function registerScanCommands(cli: CAC): void {
             state === "present" ? "present" : "missing";
           process.stdout.write(`capture dir: ${status.dir}\n\n`);
           process.stdout.write(
-            `  resources  (resources.yml): ${fmt(status.resources.state)}\n`,
+            `  fingerprint (fingerprint.yml): ${fmt(status.fingerprint.state)}\n`,
           );
           process.stdout.write(
-            `  map        (map.md):        ${fmt(status.map.state)}\n`,
+            `  checks      (checks.yml):      ${fmt(status.checks.state)}\n`,
           );
           process.stdout.write(
-            `  survey     (survey.json):   ${fmt(status.survey.state)}\n`,
+            `  proposals   (proposals/):      ${fmt(status.proposals.state)}\n`,
           );
           process.stdout.write(
-            `  patterns   (patterns.yml):  ${fmt(status.patterns.state)}\n`,
-          );
-          process.stdout.write(
-            `  checks     (checks.yml):    ${fmt(status.checks.state)}\n\n`,
+            `  cache       (cache/):          ${fmt(status.cache.state)}\n`,
           );
           process.stdout.write(
             `  intent     (intent.md):     ${fmt(status.intent.state)}\n\n`,
@@ -541,27 +542,58 @@ export function registerScanCommands(cli: CAC): void {
   registerEmitCommand(cli);
 }
 
+function initCommandOutput(
+  paths: ReturnType<typeof resolveFingerprintPackage>,
+  includeIntent: boolean,
+): Record<string, string> {
+  return {
+    dir: paths.dir,
+    fingerprintYml: paths.fingerprintYml,
+    checks: paths.checks,
+    proposals: paths.proposals,
+    cache: paths.cache,
+    ...(includeIntent ? { intent: paths.intent } : {}),
+  };
+}
+
 /**
  * Decide whether a file is a bundle artifact. JSON paths/contents route to
  * the survey linter; markdown with `schema: ghost.map/v2` in frontmatter
- * routes to the map linter; YAML schemas route to resources/patterns/checks;
- * everything else stays on the direct fingerprint markdown path.
+ * routes to the map linter; YAML schemas route to fingerprint.yml,
+ * resources/patterns/checks; everything else stays on the direct fingerprint
+ * markdown path.
  */
 function detectFileKind(
   path: string,
   raw: string,
-): "survey" | "map" | "fingerprint" | "checks" | "resources" | "patterns" {
+):
+  | "survey"
+  | "map"
+  | "fingerprint"
+  | "fingerprint-yml"
+  | "checks"
+  | "resources"
+  | "patterns" {
   if (path.toLowerCase().endsWith(".json")) return "survey";
+  if (path.toLowerCase().endsWith("fingerprint.yml")) {
+    return "fingerprint-yml";
+  }
+  if (path.toLowerCase().endsWith("fingerprint.yaml")) {
+    return "fingerprint-yml";
+  }
   if (path.toLowerCase().endsWith("resources.yml")) return "resources";
   if (path.toLowerCase().endsWith("resources.yaml")) return "resources";
   if (path.toLowerCase().endsWith("patterns.yml")) return "patterns";
   if (path.toLowerCase().endsWith("patterns.yaml")) return "patterns";
-  if (path.toLowerCase().endsWith(".yml")) return "checks";
-  if (path.toLowerCase().endsWith(".yaml")) return "checks";
   if (raw.trimStart().startsWith("{")) return "survey";
+  if (/^\s*schema:\s*ghost\.fingerprint\/v1\b/m.test(raw)) {
+    return "fingerprint-yml";
+  }
   if (/^\s*schema:\s*ghost\.resources\/v1\b/m.test(raw)) return "resources";
   if (/^\s*schema:\s*ghost\.patterns\/v1\b/m.test(raw)) return "patterns";
   if (/^\s*schema:\s*ghost\.checks\/v1\b/m.test(raw)) return "checks";
+  if (path.toLowerCase().endsWith(".yml")) return "checks";
+  if (path.toLowerCase().endsWith(".yaml")) return "checks";
   // Cheap markdown frontmatter sniff for `schema: ghost.map/v2`. We don't
   // parse YAML here; the linter does the heavy lift.
   const fmEnd = raw.indexOf("\n---", 3);
@@ -604,6 +636,29 @@ function lintChecksFile(raw: string): ReturnType<typeof lintFingerprint> {
           severity: "error",
           rule: "checks-not-yaml",
           message: `checks file is not valid YAML: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+      errors: 1,
+      warnings: 0,
+      info: 0,
+    };
+  }
+}
+
+function lintFingerprintYmlFile(
+  raw: string,
+): ReturnType<typeof lintFingerprint> {
+  try {
+    return lintGhostFingerprint(parseYaml(raw));
+  } catch (err) {
+    return {
+      issues: [
+        {
+          severity: "error",
+          rule: "fingerprint-yml-not-yaml",
+          message: `fingerprint.yml is not valid YAML: ${
             err instanceof Error ? err.message : String(err)
           }`,
         },

--- a/packages/ghost/src/scan/constants.ts
+++ b/packages/ghost/src/scan/constants.ts
@@ -7,6 +7,9 @@ export const RESOURCES_FILENAME = "resources.yml";
 /** Canonical filename for operational composition grammar. */
 export const PATTERNS_FILENAME = "patterns.yml";
 
+/** Canonical product experience memory artifact. */
+export const FINGERPRINT_YML_FILENAME = "fingerprint.yml";
+
 /** Optional filename for human-authored or human-approved intent. */
 export const INTENT_FILENAME = "intent.md";
 
@@ -27,3 +30,6 @@ export const DECISIONS_DIRNAME = "decisions";
 
 /** Optional directory containing candidate product-experience memory changes. */
 export const PROPOSALS_DIRNAME = "proposals";
+
+/** Optional directory containing generated, non-canonical caches. */
+export const CACHE_DIRNAME = "cache";

--- a/packages/ghost/src/scan/fingerprint-package.ts
+++ b/packages/ghost/src/scan/fingerprint-package.ts
@@ -4,31 +4,32 @@ import { join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
   GHOST_CHECKS_FILENAME,
+  GHOST_FINGERPRINT_SCHEMA,
+  type GhostFingerprintDocument,
+  GhostFingerprintSchema,
   lintGhostChecks,
   lintGhostDecision,
-  lintGhostPatterns,
+  lintGhostFingerprint,
   lintGhostProposal,
-  lintGhostResources,
-  lintSurvey,
   MAP_FILENAME,
-  type MapFrontmatter,
-  MapFrontmatterSchema,
   SURVEY_FILENAME,
 } from "#ghost-core";
 import {
+  CACHE_DIRNAME,
   DECISIONS_DIRNAME,
   FINGERPRINT_FILENAME,
   FINGERPRINT_PACKAGE_DIR,
+  FINGERPRINT_YML_FILENAME,
   INTENT_FILENAME,
   PATTERNS_FILENAME,
   PROPOSALS_DIRNAME,
   RESOURCES_FILENAME,
 } from "./constants.js";
 import type { LintIssue, LintReport } from "./lint.js";
-import { lintMap } from "./lint-map.js";
 
 export interface FingerprintPackagePaths {
   dir: string;
+  fingerprintYml: string;
   resources: string;
   map: string;
   survey: string;
@@ -39,6 +40,7 @@ export interface FingerprintPackagePaths {
   intent: string;
   decisions: string;
   proposals: string;
+  cache: string;
 }
 
 export interface InitFingerprintPackageOptions {
@@ -52,6 +54,7 @@ export function resolveFingerprintPackage(
   const dir = resolve(cwd, dirArg ?? FINGERPRINT_PACKAGE_DIR);
   return {
     dir,
+    fingerprintYml: join(dir, FINGERPRINT_YML_FILENAME),
     resources: join(dir, RESOURCES_FILENAME),
     map: join(dir, MAP_FILENAME),
     survey: join(dir, SURVEY_FILENAME),
@@ -61,6 +64,7 @@ export function resolveFingerprintPackage(
     intent: join(dir, INTENT_FILENAME),
     decisions: join(dir, DECISIONS_DIRNAME),
     proposals: join(dir, PROPOSALS_DIRNAME),
+    cache: join(dir, CACHE_DIRNAME),
   };
 }
 
@@ -71,12 +75,10 @@ export async function initFingerprintPackage(
 ): Promise<FingerprintPackagePaths> {
   const paths = resolveFingerprintPackage(dirArg, cwd);
   await mkdir(paths.dir, { recursive: true });
-  const now = new Date().toISOString();
   await Promise.all([
-    writeFile(paths.resources, templateResources(), "utf-8"),
-    writeFile(paths.map, templateMap(now), "utf-8"),
-    writeFile(paths.survey, templateSurvey(now), "utf-8"),
-    writeFile(paths.patterns, templatePatterns(), "utf-8"),
+    mkdir(paths.proposals, { recursive: true }),
+    mkdir(paths.cache, { recursive: true }),
+    writeFile(paths.fingerprintYml, templateFingerprintYml(), "utf-8"),
     writeFile(paths.checks, templateChecks(), "utf-8"),
     ...(options.withIntent
       ? [writeFile(paths.intent, templateIntent(), "utf-8")]
@@ -92,16 +94,9 @@ export async function lintFingerprintPackage(
   const paths = resolveFingerprintPackage(dirArg, cwd);
   const issues: LintIssue[] = [];
 
-  const resourcesRaw = await readRequired(
-    paths.resources,
-    "resources.yml",
-    issues,
-  );
-  const mapRaw = await readRequired(paths.map, "map.md", issues);
-  const surveyRaw = await readRequired(paths.survey, "survey.json", issues);
-  const patternsRaw = await readRequired(
-    paths.patterns,
-    "patterns.yml",
+  const fingerprintRaw = await readRequired(
+    paths.fingerprintYml,
+    "fingerprint.yml",
     issues,
   );
   const checksRaw = await readOptional(paths.checks);
@@ -121,41 +116,23 @@ export async function lintFingerprintPackage(
     issues,
   );
 
-  if (resourcesRaw !== undefined) {
-    const resources = parseYamlSafe(resourcesRaw, "resources.yml", issues);
-    if (resources !== undefined) {
-      const resourcesReport = lintGhostResources(resources);
-      issues.push(...prefixIssues("resources.yml", resourcesReport.issues));
-    }
-  }
-
-  let mapFrontmatter: MapFrontmatter | undefined;
-  if (mapRaw !== undefined) {
-    const mapReport = lintMap(mapRaw);
-    issues.push(...prefixIssues("map.md", mapReport.issues));
-    mapFrontmatter = parseMapFrontmatter(mapRaw, issues);
-  }
-
-  if (surveyRaw !== undefined) {
-    const survey = parseJson(surveyRaw, "survey.json", issues);
-    if (survey !== undefined) {
-      const surveyReport = lintSurvey(survey);
-      issues.push(...prefixIssues("survey.json", surveyReport.issues));
-    }
-  }
-
-  if (patternsRaw !== undefined) {
-    const patterns = parseYamlSafe(patternsRaw, "patterns.yml", issues);
-    if (patterns !== undefined) {
-      const patternsReport = lintGhostPatterns(patterns);
-      issues.push(...prefixIssues("patterns.yml", patternsReport.issues));
+  let fingerprint: GhostFingerprintDocument | undefined;
+  if (fingerprintRaw !== undefined) {
+    const parsed = parseYamlSafe(fingerprintRaw, "fingerprint.yml", issues);
+    if (parsed !== undefined) {
+      const fingerprintReport = lintGhostFingerprint(parsed);
+      issues.push(...prefixIssues("fingerprint.yml", fingerprintReport.issues));
+      const result = GhostFingerprintSchema.safeParse(parsed);
+      fingerprint = result.success
+        ? (result.data as GhostFingerprintDocument)
+        : undefined;
     }
   }
 
   if (checksRaw !== undefined) {
     const checks = parseYamlSafe(checksRaw, "checks.yml", issues);
     if (checks !== undefined) {
-      const checksReport = lintGhostChecks(checks, { map: mapFrontmatter });
+      const checksReport = lintGhostChecks(checks, { fingerprint });
       issues.push(...prefixIssues("checks.yml", checksReport.issues));
     }
   }
@@ -256,26 +233,6 @@ async function readOptional(path: string): Promise<string | undefined> {
   }
 }
 
-function parseJson(
-  raw: string,
-  label: string,
-  issues: LintIssue[],
-): unknown | undefined {
-  try {
-    return JSON.parse(raw);
-  } catch (err) {
-    issues.push({
-      severity: "error",
-      rule: "package-json-invalid",
-      message: `${label} is not valid JSON: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-      path: label,
-    });
-    return undefined;
-  }
-}
-
 function parseYamlSafe(
   raw: string,
   label: string,
@@ -294,17 +251,6 @@ function parseYamlSafe(
     });
     return undefined;
   }
-}
-
-function parseMapFrontmatter(
-  raw: string,
-  issues: LintIssue[],
-): MapFrontmatter | undefined {
-  const block = raw.match(/^---\n([\s\S]*?)\n---/)?.[1];
-  if (!block) return undefined;
-  const parsed = parseYamlSafe(block, "map.md", issues);
-  const result = MapFrontmatterSchema.safeParse(parsed);
-  return result.success ? result.data : undefined;
 }
 
 function prefixIssues(
@@ -333,98 +279,24 @@ function finalize(issues: LintIssue[]): LintReport {
   };
 }
 
-function templateResources(): string {
-  return `schema: ghost.resources/v1
-id: local
-primary:
-  target: .
-  paths:
-    - .
-design_system: []
-surfaces: []
-screenshots: []
-docs: []
-resolvers: []
-upstreams: []
-include:
-  - "**/*"
-exclude:
-  - "**/node_modules/**"
-`;
-}
-
-function templateMap(now: string): string {
-  return `---
-schema: ghost.map/v2
-id: local
-repo: local
-mapped_at: ${now}
-platform: other
-languages:
-  - { name: unknown, files: 0, share: 0 }
-build_system: other
-package_manifests:
-  - package.json
-composition:
-  frameworks:
-    - { name: unknown }
-  rendering: unknown
-  styling:
-    - unknown
-design_system:
-  paths: []
-  status: unclear
-surface_sources:
-  render_strategy: unknown
-  include:
-    - "**/*"
-  exclude:
-    - "**/node_modules/**"
-feature_areas:
-  - name: app
-    paths:
-      - .
-orientation_files:
-  - README.md
----
-
-## Identity
-
-Local fingerprint package awaiting map authoring.
-
-## Topology
-
-The topology has not been mapped yet.
-
-## Conventions
-
-No conventions have been recorded yet.
-`;
-}
-
-function templateSurvey(now: string): string {
-  return `${JSON.stringify(
-    {
-      schema: "ghost.survey/v2",
-      sources: [{ target: ".", scanned_at: now }],
-      values: [],
-      tokens: [],
-      components: [],
-      ui_surfaces: [],
-    },
-    null,
-    2,
-  )}\n`;
-}
-
-function templatePatterns(): string {
-  return `schema: ghost.patterns/v1
-id: local
-surface_types: []
-composition_patterns: []
-advisory:
-  review_expectations:
-    - Cite survey evidence and pattern evidence for composition findings.
+function templateFingerprintYml(): string {
+  return `schema: ${GHOST_FINGERPRINT_SCHEMA}
+summary: {}
+topology: {}
+situations: []
+principles: []
+experience_contracts: []
+patterns: []
+substrate: {}
+review_policy:
+  proposal_policy:
+    - Agents create proposals for missing memory, intentional divergences, experience gaps, and check candidates.
+    - Humans promote durable memory into fingerprint.yml and checks.yml.
+  experience_gap_categories:
+    - missing-memory
+    - intentional-divergence
+    - experience-gap
+    - check-candidate
 `;
 }
 

--- a/packages/ghost/src/scan/index.ts
+++ b/packages/ghost/src/scan/index.ts
@@ -20,9 +20,11 @@ export { parseBody } from "./body.js";
 export type { DesignDecision } from "./compose.js";
 export { mergeFingerprint } from "./compose.js";
 export {
+  CACHE_DIRNAME,
   CHECKS_FILENAME,
   FINGERPRINT_FILENAME,
   FINGERPRINT_PACKAGE_DIR,
+  FINGERPRINT_YML_FILENAME,
   FINGERPRINTS_DIRNAME,
   INTENT_FILENAME,
   PATTERNS_FILENAME,

--- a/packages/ghost/src/scan/scan-status.ts
+++ b/packages/ghost/src/scan/scan-status.ts
@@ -3,38 +3,31 @@ import { join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
   GHOST_CHECKS_FILENAME,
-  GHOST_PATTERNS_FILENAME,
-  GHOST_RESOURCES_FILENAME,
+  GHOST_FINGERPRINT_YML_FILENAME,
   getEffectiveMapScopes,
+  lintGhostFingerprint,
   MAP_FILENAME,
   type MapFrontmatter,
   MapFrontmatterSchema,
   SURVEY_FILENAME,
-  type Survey,
 } from "#ghost-core";
 import {
+  CACHE_DIRNAME,
   FINGERPRINTS_DIRNAME,
   INTENT_FILENAME,
+  PROPOSALS_DIRNAME,
   SCOPE_SURVEYS_DIRNAME,
 } from "./constants.js";
 
-/**
- * Per-stage state in a fingerprint capture directory.
- *
- *   `missing` — the artifact doesn't exist yet.
- *   `present` — the artifact exists. Existence is the only signal this
- *     surfaces; hash-based freshness (`stale` vs `present`) is a planned
- *     enhancement once `.scan-meta.json` is in play.
- */
 export type ScanStageState = "missing" | "present";
 
 export interface ScanStageReport {
   state: ScanStageState;
-  /** Absolute path to the artifact (whether it exists or not). */
+  /** Absolute path to the artifact or directory. */
   path: string;
 }
 
-export type ScanStage = "resources" | "map" | "survey" | "patterns";
+export type ScanStage = "fingerprint";
 
 export interface ScanScopeReport {
   id: string;
@@ -47,10 +40,8 @@ export interface ScanScopeReport {
 
 export type ScanReadinessState =
   | "pending"
-  | "product-observed"
-  | "component-demo"
-  | "substrate-only"
-  | "unobservable"
+  | "memory-empty"
+  | "memory-ready"
   | "unknown";
 
 export interface ScanReadinessReport {
@@ -72,91 +63,53 @@ export interface ScanStatusOptions {
 }
 
 export interface ScanStatus {
-  /** Absolute path to the fingerprint capture directory. */
+  /** Absolute path to the Ghost memory directory. */
   dir: string;
-  resources: ScanStageReport;
-  map: ScanStageReport;
-  survey: ScanStageReport;
-  patterns: ScanStageReport;
+  fingerprint: ScanStageReport;
   checks: ScanStageReport;
   intent: ScanStageReport;
+  proposals: ScanStageReport;
+  cache: ScanStageReport;
   scopes?: ScanScopeReport[];
   scope_error?: string;
-  /**
-   * Best-effort evidence maturity derived from map.md + survey.json. This is
-   * advisory: invalid or missing artifacts still surface through lint/verify.
-   */
   readiness: ScanReadinessReport;
-  /**
-   * The next stage an orchestrator should run, or `null` if every required
-   * stage is `present`. Stages run in order:
-   * resources → map → survey → patterns. `checks.yml` and `intent.md` are
-   * reported but optional, so they never block completion.
-   */
   recommended_next: ScanStage | null;
 }
 
 /**
- * Inspect a fingerprint capture directory and report which stages have produced
- * artifacts.
- *
- * Existence-only check today. The artifacts checked are:
- *
- *   - resources → `resources.yml`
- *   - map       → `map.md`
- *   - survey    → `survey.json`
- *   - patterns  → `patterns.yml`
- *   - checks    → optional `checks.yml`
- *   - intent    → optional `intent.md`
- *
- * Hash-keyed freshness (`.scan-meta.json` with input/output hashes per
- * stage) is the planned enhancement. For now, orchestrators that want
- * "force rerun" behavior delete the artifact themselves before calling
- * scan — same idiom design-world-model already uses.
+ * Inspect a Ghost memory directory and report whether the canonical
+ * `fingerprint.yml` exists. Generated inventory is cache, not a prerequisite:
+ * the durable product-experience memory is fingerprint.yml plus optional
+ * checks/proposals.
  */
 export async function scanStatus(
   dirPath: string,
   options: ScanStatusOptions = {},
 ): Promise<ScanStatus> {
   const dir = resolve(dirPath);
-  const resourcesPath = resolve(dir, GHOST_RESOURCES_FILENAME);
-  const mapPath = resolve(dir, MAP_FILENAME);
-  const surveyPath = resolve(dir, SURVEY_FILENAME);
-  const patternsPath = resolve(dir, GHOST_PATTERNS_FILENAME);
+  const fingerprintPath = resolve(dir, GHOST_FINGERPRINT_YML_FILENAME);
   const checksPath = resolve(dir, GHOST_CHECKS_FILENAME);
   const intentPath = resolve(dir, INTENT_FILENAME);
+  const proposalsPath = resolve(dir, PROPOSALS_DIRNAME);
+  const cachePath = resolve(dir, CACHE_DIRNAME);
 
   const [
-    resourcesPresent,
-    mapPresent,
-    surveyPresent,
-    patternsPresent,
+    fingerprintPresent,
     checksPresent,
     intentPresent,
+    proposalsPresent,
+    cachePresent,
   ] = await Promise.all([
-    pathExists(resourcesPath),
-    pathExists(mapPath),
-    pathExists(surveyPath),
-    pathExists(patternsPath),
-    pathExists(checksPath),
-    pathExists(intentPath),
+    pathExists(fingerprintPath, "file"),
+    pathExists(checksPath, "file"),
+    pathExists(intentPath, "file"),
+    pathExists(proposalsPath, "directory"),
+    pathExists(cachePath, "directory"),
   ]);
 
-  const resources: ScanStageReport = {
-    state: resourcesPresent ? "present" : "missing",
-    path: resourcesPath,
-  };
-  const map: ScanStageReport = {
-    state: mapPresent ? "present" : "missing",
-    path: mapPath,
-  };
-  const survey: ScanStageReport = {
-    state: surveyPresent ? "present" : "missing",
-    path: surveyPath,
-  };
-  const patterns: ScanStageReport = {
-    state: patternsPresent ? "present" : "missing",
-    path: patternsPath,
+  const fingerprint: ScanStageReport = {
+    state: fingerprintPresent ? "present" : "missing",
+    path: fingerprintPath,
   };
   const checks: ScanStageReport = {
     state: checksPresent ? "present" : "missing",
@@ -166,35 +119,30 @@ export async function scanStatus(
     state: intentPresent ? "present" : "missing",
     path: intentPath,
   };
-
-  let recommended_next: ScanStage | null = null;
-  if (resources.state === "missing") recommended_next = "resources";
-  else if (map.state === "missing") recommended_next = "map";
-  else if (survey.state === "missing") recommended_next = "survey";
-  else if (patterns.state === "missing") recommended_next = "patterns";
-
-  const readiness = await scanReadiness({
-    mapPath,
-    mapPresent,
-    surveyPath,
-    surveyPresent,
-  });
+  const proposals: ScanStageReport = {
+    state: proposalsPresent ? "present" : "missing",
+    path: proposalsPath,
+  };
+  const cache: ScanStageReport = {
+    state: cachePresent ? "present" : "missing",
+    path: cachePath,
+  };
 
   const status: ScanStatus = {
     dir,
-    resources,
-    map,
-    survey,
-    patterns,
+    fingerprint,
     checks,
     intent,
-    readiness,
-    recommended_next,
+    proposals,
+    cache,
+    readiness: await scanReadiness(fingerprintPath, fingerprintPresent),
+    recommended_next: fingerprintPresent ? null : "fingerprint",
   };
 
   if (options.includeScopes) {
     try {
-      status.scopes = await scanScopes(dir, mapPath, map.state === "present");
+      const mapPath = resolve(dir, MAP_FILENAME);
+      status.scopes = await scanScopes(dir, mapPath, await pathExists(mapPath));
     } catch (err) {
       status.scope_error = err instanceof Error ? err.message : String(err);
       status.scopes = [];
@@ -204,142 +152,108 @@ export async function scanStatus(
   return status;
 }
 
-async function scanReadiness(options: {
-  mapPath: string;
-  mapPresent: boolean;
-  surveyPath: string;
-  surveyPresent: boolean;
-}): Promise<ScanReadinessReport> {
-  const reasons: string[] = [];
-
-  if (!options.mapPresent || !options.surveyPresent) {
-    if (!options.mapPresent) {
-      reasons.push("map.md is missing, so observation paths are unknown.");
-    }
-    if (!options.surveyPresent) {
-      reasons.push("survey.json is missing, so evidence rows are unknown.");
-    }
+async function scanReadiness(
+  fingerprintPath: string,
+  fingerprintPresent: boolean,
+): Promise<ScanReadinessReport> {
+  if (!fingerprintPresent) {
     return readinessReport("pending", {
-      reasons,
-      can_review: [],
-      cannot_review: [],
+      reasons: [
+        "fingerprint.yml is missing, so product-experience memory is unavailable.",
+      ],
+      cannot_review: [
+        "product identity",
+        "surface behavior",
+        "copy",
+        "accessibility",
+        "trust",
+      ],
     });
   }
 
-  let map: MapFrontmatter | undefined;
+  let doc: unknown;
   try {
-    map = await readMapFrontmatter(options.mapPath);
-  } catch (err) {
-    reasons.push(
-      `map.md could not be read for readiness: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-
-  let survey: Pick<Survey, "values" | "tokens" | "components" | "ui_surfaces">;
-  try {
-    survey = await readSurveyEvidence(options.surveyPath);
+    doc = parseYaml(await readFile(fingerprintPath, "utf-8"));
   } catch (err) {
     return readinessReport("unknown", {
       reasons: [
-        `survey.json could not be read for readiness: ${
+        `fingerprint.yml could not be read: ${
           err instanceof Error ? err.message : String(err)
         }`,
       ],
-      can_review: [],
+    });
+  }
+
+  const lint = lintGhostFingerprint(doc);
+  if (lint.errors > 0) {
+    return readinessReport("unknown", {
+      reasons: [
+        `fingerprint.yml has ${lint.errors} lint error(s); run ghost lint for details.`,
+      ],
       cannot_review: [
-        "product composition",
-        "surface flow",
-        "tokens",
-        "components",
+        "product identity",
+        "surface behavior",
+        "copy",
+        "accessibility",
+        "trust",
       ],
     });
   }
 
-  const productSurfaceCount = survey.ui_surfaces.filter((surface) =>
-    isProductSurfaceKind(surface.kind),
-  ).length;
-  const demoSurfaceCount = survey.ui_surfaces.filter((surface) =>
-    isDemoSurfaceKind(surface.kind),
-  ).length;
-  const substrateRows = {
-    values: survey.values.length,
-    tokens: survey.tokens.length,
-    components: survey.components.length,
+  const fingerprint = doc as {
+    situations?: unknown[];
+    principles?: unknown[];
+    experience_contracts?: unknown[];
+    patterns?: unknown[];
+    topology?: { examples?: unknown[] };
+    substrate?: {
+      tokens?: unknown[];
+      components?: unknown[];
+      accessibility?: unknown[];
+      responsive?: unknown[];
+    };
   };
-  const substrateRowCount =
-    substrateRows.values + substrateRows.tokens + substrateRows.components;
+  const substrateRows = {
+    values:
+      (fingerprint.substrate?.accessibility?.length ?? 0) +
+      (fingerprint.substrate?.responsive?.length ?? 0),
+    tokens: fingerprint.substrate?.tokens?.length ?? 0,
+    components: fingerprint.substrate?.components?.length ?? 0,
+  };
+  const memoryCount =
+    (fingerprint.situations?.length ?? 0) +
+    (fingerprint.principles?.length ?? 0) +
+    (fingerprint.experience_contracts?.length ?? 0) +
+    (fingerprint.patterns?.length ?? 0) +
+    substrateRows.values +
+    substrateRows.tokens +
+    substrateRows.components;
 
-  if (productSurfaceCount > 0) {
-    reasons.push(
-      `${productSurfaceCount} product surface(s) were observed in survey.ui_surfaces.`,
-    );
-    return readinessReport("product-observed", {
-      product_surface_count: productSurfaceCount,
-      demo_surface_count: demoSurfaceCount,
-      substrate_rows: substrateRows,
-      reasons,
-      can_review: [
-        "product composition",
-        "surface flow",
-        "tokens",
-        "components",
-        "design values",
+  if (memoryCount === 0) {
+    return readinessReport("memory-empty", {
+      reasons: [
+        "fingerprint.yml is valid but has no principles, situations, experience contracts, patterns, or substrate entries yet.",
       ],
-      cannot_review: [],
-    });
-  }
-
-  if (demoSurfaceCount > 0) {
-    reasons.push(
-      `${demoSurfaceCount} demo surface(s) were observed, but no product route, screen, screenshot, or source surface is present.`,
-    );
-    return readinessReport("component-demo", {
-      demo_surface_count: demoSurfaceCount,
-      substrate_rows: substrateRows,
-      reasons,
-      can_review: [
-        "tokens",
-        "components",
-        "design values",
-        "component demonstration composition",
-      ],
-      cannot_review: ["product composition", "surface flow"],
-    });
-  }
-
-  if (substrateRowCount > 0) {
-    reasons.push(
-      `survey.json has ${substrateRowCount} value/token/component row(s), but no UI surfaces.`,
-    );
-    if (map?.surface_sources.render_strategy === "unknown") {
-      reasons.push("map.md declares surface_sources.render_strategy: unknown.");
-    }
-    return readinessReport("substrate-only", {
-      substrate_rows: substrateRows,
-      reasons,
-      can_review: ["tokens", "components", "design values"],
       cannot_review: [
-        "product composition",
-        "surface flow",
-        "surface hierarchy",
+        "product identity",
+        "surface behavior",
+        "copy",
+        "accessibility",
+        "trust",
       ],
     });
   }
 
-  reasons.push(
-    "survey.json has no values, tokens, components, or UI surfaces to support product-experience judgment.",
-  );
-  return readinessReport("unobservable", {
-    reasons,
-    can_review: [],
-    cannot_review: [
-      "product composition",
-      "surface flow",
-      "surface hierarchy",
-      "tokens",
-      "components",
+  return readinessReport("memory-ready", {
+    product_surface_count: fingerprint.topology?.examples?.length ?? 0,
+    substrate_rows: substrateRows,
+    reasons: ["fingerprint.yml contains product-experience memory."],
+    can_review: [
+      "product identity",
+      "surface behavior",
+      "copy",
+      "accessibility",
+      "trust",
     ],
   });
 }
@@ -360,35 +274,13 @@ function readinessReport(
   };
 }
 
-async function readSurveyEvidence(
+async function pathExists(
   path: string,
-): Promise<Pick<Survey, "values" | "tokens" | "components" | "ui_surfaces">> {
-  const raw = JSON.parse(await readFile(path, "utf-8")) as Partial<Survey>;
-  return {
-    values: Array.isArray(raw.values) ? raw.values : [],
-    tokens: Array.isArray(raw.tokens) ? raw.tokens : [],
-    components: Array.isArray(raw.components) ? raw.components : [],
-    ui_surfaces: Array.isArray(raw.ui_surfaces) ? raw.ui_surfaces : [],
-  };
-}
-
-function isProductSurfaceKind(kind: string): boolean {
-  return (
-    kind === "route" ||
-    kind === "screen" ||
-    kind === "screenshot" ||
-    kind === "source"
-  );
-}
-
-function isDemoSurfaceKind(kind: string): boolean {
-  return kind === "story" || kind === "doc-example" || kind === "fixture";
-}
-
-async function pathExists(path: string): Promise<boolean> {
+  kind: "file" | "directory" = "file",
+): Promise<boolean> {
   try {
     const s = await stat(path);
-    return s.isFile() && s.size > 0;
+    return kind === "directory" ? s.isDirectory() : s.isFile() && s.size > 0;
   } catch {
     return false;
   }

--- a/packages/ghost/src/scan/verify-package.ts
+++ b/packages/ghost/src/scan/verify-package.ts
@@ -3,10 +3,11 @@ import { isAbsolute, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type {
   GhostCheck,
-  GhostPatternsDocument,
-  GhostResourcesDocument,
-  Survey,
+  GhostChecksDocument,
+  GhostFingerprintDocument,
+  GhostFingerprintEvidence,
 } from "#ghost-core";
+import { GhostChecksSchema, GhostFingerprintSchema } from "#ghost-core";
 import {
   lintFingerprintPackage,
   resolveFingerprintPackage,
@@ -40,234 +41,178 @@ export async function verifyFingerprintPackage(
   );
   if (packageLint.errors > 0) return finalize(issues);
 
-  const [resources, survey, patterns, checks] = await Promise.all([
-    readYaml<GhostResourcesDocument>(paths.resources, "resources.yml", issues),
-    readJson<Survey>(paths.survey, "survey.json", issues),
-    readYaml<GhostPatternsDocument>(paths.patterns, "patterns.yml", issues),
-    readOptionalYaml<{ checks?: GhostCheck[] }>(
-      paths.checks,
-      "checks.yml",
-      issues,
-    ),
+  const [fingerprint, checks] = await Promise.all([
+    readFingerprint(paths.fingerprintYml, issues),
+    readOptionalChecks(paths.checks, issues),
   ]);
 
-  if (resources) {
-    await verifyResourcesReachable(resources, root, issues);
+  if (fingerprint) {
+    await verifyFingerprintEvidence(fingerprint, root, issues);
   }
 
-  if (survey && patterns) {
-    verifyPatternEvidence(patterns, survey, issues);
-    verifyPatternSurfaceTypes(patterns, survey, issues);
-  }
-
-  if (patterns && checks?.checks) {
-    verifyCheckPatternReferences(patterns, checks.checks, issues);
+  if (fingerprint && checks) {
+    verifyFingerprintCheckRefs(fingerprint, checks.checks, issues);
   }
 
   return finalize(issues);
 }
 
-async function readYaml<T>(
+async function readFingerprint(
   path: string,
-  label: string,
   issues: VerifyFingerprintIssue[],
-): Promise<T | undefined> {
+): Promise<GhostFingerprintDocument | undefined> {
   try {
-    return parseYaml(await readFile(path, "utf-8")) as T;
+    const parsed = parseYaml(await readFile(path, "utf-8"));
+    const result = GhostFingerprintSchema.safeParse(parsed);
+    if (result.success) return result.data as GhostFingerprintDocument;
+    issues.push({
+      severity: "error",
+      rule: "verify-fingerprint-read-failed",
+      message: "fingerprint.yml failed schema validation after package lint.",
+      path: "fingerprint.yml",
+    });
+    return undefined;
   } catch (err) {
     issues.push({
       severity: "error",
-      rule: "verify-yaml-read-failed",
-      message: `${label} could not be read as YAML: ${
+      rule: "verify-fingerprint-read-failed",
+      message: `fingerprint.yml could not be read as YAML: ${
         err instanceof Error ? err.message : String(err)
       }`,
-      path: label,
+      path: "fingerprint.yml",
     });
     return undefined;
   }
 }
 
-async function readOptionalYaml<T>(
+async function readOptionalChecks(
   path: string,
-  label: string,
   issues: VerifyFingerprintIssue[],
-): Promise<T | undefined> {
+): Promise<GhostChecksDocument | undefined> {
   try {
-    return parseYaml(await readFile(path, "utf-8")) as T;
+    const parsed = parseYaml(await readFile(path, "utf-8"));
+    const result = GhostChecksSchema.safeParse(parsed);
+    if (result.success) return result.data as GhostChecksDocument;
+    issues.push({
+      severity: "error",
+      rule: "verify-checks-read-failed",
+      message: "checks.yml failed schema validation after package lint.",
+      path: "checks.yml",
+    });
+    return undefined;
   } catch (err) {
     if (isMissingFileError(err)) return undefined;
     issues.push({
       severity: "error",
-      rule: "verify-yaml-read-failed",
-      message: `${label} could not be read as YAML: ${
+      rule: "verify-checks-read-failed",
+      message: `checks.yml could not be read as YAML: ${
         err instanceof Error ? err.message : String(err)
       }`,
-      path: label,
+      path: "checks.yml",
     });
     return undefined;
   }
 }
 
-async function readJson<T>(
-  path: string,
-  label: string,
-  issues: VerifyFingerprintIssue[],
-): Promise<T | undefined> {
-  try {
-    return JSON.parse(await readFile(path, "utf-8")) as T;
-  } catch (err) {
-    issues.push({
-      severity: "error",
-      rule: "verify-json-read-failed",
-      message: `${label} could not be read as JSON: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-      path: label,
-    });
-    return undefined;
-  }
-}
-
-async function verifyResourcesReachable(
-  resources: GhostResourcesDocument,
+async function verifyFingerprintEvidence(
+  fingerprint: GhostFingerprintDocument,
   root: string,
   issues: VerifyFingerprintIssue[],
 ): Promise<void> {
-  const refs: Array<
-    readonly [
-      string,
-      {
-        target?: string;
-        paths?: string[];
-      },
-    ]
-  > = [
-    ["primary", resources.primary],
-    ...(resources.design_system ?? []).map(
-      (ref, index) => [`design_system[${index}]`, ref] as const,
-    ),
-    ...(resources.surfaces ?? []).map(
-      (ref, index) => [`surfaces[${index}]`, ref] as const,
-    ),
-    ...(resources.screenshots ?? []).map(
-      (ref, index) => [`screenshots[${index}]`, ref] as const,
-    ),
-    ...(resources.docs ?? []).map(
-      (ref, index) => [`docs[${index}]`, ref] as const,
-    ),
-    ...(resources.resolvers ?? []).map(
-      (ref, index) => [`resolvers[${index}]`, ref] as const,
-    ),
-    ...(resources.upstreams ?? []).map(
-      (ref, index) => [`upstreams[${index}]`, ref] as const,
-    ),
-  ];
-
-  for (const [label, ref] of refs) {
-    const target =
-      "target" in ref && typeof ref.target === "string" ? ref.target : "";
-    const candidates = [
-      ...(target && isLocalTarget(target) ? [target] : []),
-      ...(ref.paths ?? []),
+  const evidenceLists: Array<[string, GhostFingerprintEvidence[] | undefined]> =
+    [
+      ...fingerprint.situations.map(
+        (entry, index) =>
+          [`fingerprint.yml.situations[${index}].evidence`, entry.evidence] as [
+            string,
+            GhostFingerprintEvidence[] | undefined,
+          ],
+      ),
+      ...fingerprint.principles.map(
+        (entry, index) =>
+          [`fingerprint.yml.principles[${index}].evidence`, entry.evidence] as [
+            string,
+            GhostFingerprintEvidence[] | undefined,
+          ],
+      ),
+      ...fingerprint.experience_contracts.map(
+        (entry, index) =>
+          [
+            `fingerprint.yml.experience_contracts[${index}].evidence`,
+            entry.evidence,
+          ] as [string, GhostFingerprintEvidence[] | undefined],
+      ),
+      ...fingerprint.patterns.map(
+        (entry, index) =>
+          [`fingerprint.yml.patterns[${index}].evidence`, entry.evidence] as [
+            string,
+            GhostFingerprintEvidence[] | undefined,
+          ],
+      ),
     ];
-    for (const candidate of candidates) {
-      const path = isAbsolute(candidate) ? candidate : resolve(root, candidate);
-      if (await pathExists(path)) continue;
-      issues.push({
-        severity: "warning",
-        rule: "resource-unreachable",
-        message: `resource path '${candidate}' could not be resolved from ${root}.`,
-        path: `resources.yml.${label}`,
-      });
-    }
+
+  for (const [path, evidence] of evidenceLists) {
+    if (!evidence) continue;
+    await Promise.all(
+      evidence.map(async (entry, index) => {
+        if (!entry.path) return;
+        const evidencePath = isAbsolute(entry.path)
+          ? entry.path
+          : resolve(root, entry.path);
+        if (await pathExists(evidencePath)) return;
+        issues.push({
+          severity: "warning",
+          rule: "fingerprint-evidence-unreachable",
+          message: `fingerprint evidence path '${entry.path}' could not be resolved from ${root}.`,
+          path: `${path}[${index}].path`,
+        });
+      }),
+    );
   }
 }
 
-function verifyPatternEvidence(
-  patterns: GhostPatternsDocument,
-  survey: Survey,
-  issues: VerifyFingerprintIssue[],
-): void {
-  patterns.composition_patterns.forEach((pattern, index) => {
-    const evidence = pattern.evidence ?? [];
-    if (evidence.length === 0) {
-      issues.push({
-        severity: "error",
-        rule: "pattern-evidence-missing",
-        message: `composition pattern '${pattern.id}' has no survey evidence.`,
-        path: `patterns.yml.composition_patterns[${index}].evidence`,
-      });
-      return;
-    }
-
-    const supported = evidence.some((entry) =>
-      survey.ui_surfaces.some((surface) => {
-        if (entry.surface_id && surface.id === entry.surface_id) return true;
-        if (entry.locator && surface.locator === entry.locator) return true;
-        if (entry.path && surface.files.includes(entry.path)) return true;
-        return false;
-      }),
-    );
-    if (!supported) {
-      issues.push({
-        severity: "error",
-        rule: "pattern-evidence-unbacked",
-        message: `composition pattern '${pattern.id}' evidence does not match any survey surface id, locator, or file.`,
-        path: `patterns.yml.composition_patterns[${index}].evidence`,
-      });
-    }
-  });
-}
-
-function verifyPatternSurfaceTypes(
-  patterns: GhostPatternsDocument,
-  survey: Survey,
-  issues: VerifyFingerprintIssue[],
-): void {
-  const surveyedTypes = new Set(
-    survey.ui_surfaces
-      .map((surface) => surface.classification?.surface_type)
-      .filter((value): value is string => Boolean(value)),
-  );
-  patterns.surface_types.forEach((surfaceType, index) => {
-    if (surveyedTypes.size === 0 || surveyedTypes.has(surfaceType.id)) return;
-    issues.push({
-      severity: "warning",
-      rule: "surface-type-unobserved",
-      message: `surface type '${surfaceType.id}' is not observed in survey.ui_surfaces[].classification.surface_type.`,
-      path: `patterns.yml.surface_types[${index}].id`,
-    });
-  });
-}
-
-function verifyCheckPatternReferences(
-  patterns: GhostPatternsDocument,
+function verifyFingerprintCheckRefs(
+  fingerprint: GhostFingerprintDocument,
   checks: GhostCheck[],
   issues: VerifyFingerprintIssue[],
 ): void {
-  const patternIds = new Set(
-    patterns.composition_patterns.map((pattern) => pattern.id),
-  );
-  checks.forEach((check, checkIndex) => {
-    check.applies_to?.pattern_ids?.forEach((patternId, patternIndex) => {
-      if (patternIds.has(patternId)) return;
+  const checkIds = new Set(checks.map((check) => check.id));
+  const checkRefLists: Array<[string, string[] | undefined]> = [
+    ...fingerprint.principles.map(
+      (entry, index) =>
+        [
+          `fingerprint.yml.principles[${index}].check_refs`,
+          entry.check_refs,
+        ] as [string, string[] | undefined],
+    ),
+    ...fingerprint.experience_contracts.map(
+      (entry, index) =>
+        [
+          `fingerprint.yml.experience_contracts[${index}].check_refs`,
+          entry.check_refs,
+        ] as [string, string[] | undefined],
+    ),
+    ...fingerprint.patterns.map(
+      (entry, index) =>
+        [`fingerprint.yml.patterns[${index}].check_refs`, entry.check_refs] as [
+          string,
+          string[] | undefined,
+        ],
+    ),
+  ];
+
+  checkRefLists.forEach(([path, refs]) => {
+    refs?.forEach((ref, index) => {
+      const [, id] = ref.split(":");
+      if (id && checkIds.has(id)) return;
       issues.push({
         severity: "error",
-        rule: "check-pattern-unknown",
-        message: `check '${check.id}' references unknown composition pattern '${patternId}'.`,
-        path: `checks.yml.checks[${checkIndex}].applies_to.pattern_ids[${patternIndex}]`,
+        rule: "fingerprint-check-unknown",
+        message: `fingerprint.yml references unknown check '${ref}'.`,
+        path: `${path}[${index}]`,
       });
     });
   });
-}
-
-function isLocalTarget(target: string): boolean {
-  return (
-    target === "." ||
-    target.startsWith("./") ||
-    target.startsWith("../") ||
-    target.startsWith("/")
-  );
 }
 
 async function pathExists(path: string): Promise<boolean> {

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -229,16 +229,17 @@ describe("ghost CLI", () => {
 
     expect(init.code).toBe(0);
     expect(
-      await readFile(join(dir, ".ghost", "resources.yml"), "utf-8"),
-    ).toContain("schema: ghost.resources/v1");
+      await readFile(join(dir, ".ghost", "fingerprint.yml"), "utf-8"),
+    ).toContain("schema: ghost.fingerprint/v1");
     expect(await readFile(join(dir, ".ghost", "intent.md"), "utf-8")).toContain(
       "# Intent",
     );
     expect(scan.code).toBe(0);
     const status = JSON.parse(scan.stdout);
-    expect(status.resources.state).toBe("present");
-    expect(status.map.state).toBe("present");
-    expect(status.readiness.state).toBe("unobservable");
+    expect(status.fingerprint.state).toBe("present");
+    expect(status.proposals.state).toBe("present");
+    expect(status.cache.state).toBe("present");
+    expect(status.readiness.state).toBe("memory-empty");
   });
 
   it("runs inventory, lint, and verify from the unified cli", async () => {
@@ -498,6 +499,36 @@ async function writeCheckPackage(
 ): Promise<void> {
   const pkg = join(dir, ".ghost");
   await mkdir(pkg, { recursive: true });
+  await writeFile(
+    join(pkg, "fingerprint.yml"),
+    `schema: ghost.fingerprint/v1
+summary:
+  product: Cash iOS
+topology:
+  scopes:
+    - id: lending
+      paths: [Code/Features/Lending]
+      surface_types: [native-feature]
+  surface_types: [native-feature]
+situations: []
+principles:
+  - id: tokenized-ui-color
+    status: accepted
+    principle: UI colors should come from the product token system.
+    check_refs: [check:no-hardcoded-ui-color]
+experience_contracts: []
+patterns:
+  - id: tokenized-ui-color
+    status: accepted
+    kind: visual
+    pattern: Product UI color uses semantic tokens instead of literals.
+    check_refs: [check:no-hardcoded-ui-color]
+substrate:
+  tokens: [CashTheme.primary]
+  components: []
+review_policy: {}
+`,
+  );
   await writeFile(
     join(pkg, "resources.yml"),
     `schema: ghost.resources/v1

--- a/packages/ghost/test/scan-status.test.ts
+++ b/packages/ghost/test/scan-status.test.ts
@@ -19,166 +19,76 @@ describe("scanStatus readiness", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  it("reports pending readiness before map and survey exist", async () => {
+  it("reports pending readiness before fingerprint.yml exists", async () => {
     const status = await scanStatus(dir);
 
+    expect(status.fingerprint.state).toBe("missing");
+    expect(status.recommended_next).toBe("fingerprint");
     expect(status.readiness.state).toBe("pending");
-    expect(status.readiness.reasons.join(" ")).toContain("map.md is missing");
     expect(status.readiness.reasons.join(" ")).toContain(
-      "survey.json is missing",
+      "fingerprint.yml is missing",
     );
   });
 
-  it("reports substrate-only when only values, tokens, or components exist", async () => {
-    await writeFile(join(dir, "map.md"), mapFile("unknown"));
+  it("reports empty memory when fingerprint.yml has no product-experience entries", async () => {
+    await writeFile(join(dir, "fingerprint.yml"), fingerprintFile());
+
+    const status = await scanStatus(dir);
+
+    expect(status.fingerprint.state).toBe("present");
+    expect(status.recommended_next).toBeNull();
+    expect(status.readiness.state).toBe("memory-empty");
+    expect(status.readiness.cannot_review).toContain("product identity");
+  });
+
+  it("reports ready memory when fingerprint.yml has accepted experience entries", async () => {
     await writeFile(
-      join(dir, "survey.json"),
-      JSON.stringify(
-        surveyFile({
-          components: [
-            {
-              id: "component_button",
-              source: source(),
-              name: "Button",
-              discovered_via: "registry.json",
-            },
-          ],
-          ui_surfaces: [],
-        }),
-      ),
+      join(dir, "fingerprint.yml"),
+      fingerprintFile(`
+principles:
+  - id: dense-workflows-prioritize-scanning
+    status: accepted
+    principle: Dense workflows optimize for comparison and recovery.
+patterns:
+  - id: preserve-table-density
+    status: accepted
+    kind: composition
+    pattern: Keep dense operational tables scannable.
+substrate:
+  tokens:
+    - color.background
+  components:
+    - DataTable
+`),
     );
 
     const status = await scanStatus(dir);
 
-    expect(status.readiness.state).toBe("substrate-only");
+    expect(status.readiness.state).toBe("memory-ready");
+    expect(status.readiness.substrate_rows.tokens).toBe(1);
     expect(status.readiness.substrate_rows.components).toBe(1);
-    expect(status.readiness.can_review).toContain("components");
-    expect(status.readiness.cannot_review).toContain("product composition");
-  });
-
-  it("reports component-demo when only stories or docs examples exist", async () => {
-    await writeFile(join(dir, "map.md"), mapFile("storybook"));
-    await writeFile(
-      join(dir, "survey.json"),
-      JSON.stringify(
-        surveyFile({
-          ui_surfaces: [
-            {
-              id: "surface_button_story",
-              source: source(),
-              name: "Button story",
-              kind: "story",
-              locator: "button--default",
-              renderability: "rendered",
-              files: ["src/button.stories.tsx"],
-              signals: { layout_patterns: ["button-demo"] },
-            },
-          ],
-        }),
-      ),
-    );
-
-    const status = await scanStatus(dir);
-
-    expect(status.readiness.state).toBe("component-demo");
-    expect(status.readiness.demo_surface_count).toBe(1);
-    expect(status.readiness.cannot_review).toContain("surface flow");
-  });
-
-  it("reports product-observed when route or screen evidence exists", async () => {
-    await writeFile(join(dir, "map.md"), mapFile("static-source"));
-    await writeFile(
-      join(dir, "survey.json"),
-      JSON.stringify(
-        surveyFile({
-          ui_surfaces: [
-            {
-              id: "surface_settings",
-              source: source(),
-              name: "Settings",
-              kind: "route",
-              locator: "/settings",
-              renderability: "source-only",
-              files: ["src/routes/settings.tsx"],
-              signals: { layout_patterns: ["settings-stack"] },
-            },
-          ],
-        }),
-      ),
-    );
-
-    const status = await scanStatus(dir);
-
-    expect(status.readiness.state).toBe("product-observed");
-    expect(status.readiness.product_surface_count).toBe(1);
-    expect(status.readiness.can_review).toContain("product composition");
+    expect(status.readiness.can_review).toContain("surface behavior");
   });
 });
 
-function source() {
-  return { target: ".", scanned_at: "2026-05-19T00:00:00.000Z" };
-}
-
-function surveyFile(overrides: Record<string, unknown>) {
-  return {
-    schema: "ghost.survey/v2",
-    sources: [source()],
-    values: [],
-    tokens: [],
-    components: [],
-    ui_surfaces: [],
-    ...overrides,
-  };
-}
-
-function mapFile(renderStrategy: string): string {
-  return `---
-schema: ghost.map/v2
-id: local
-repo: local
-mapped_at: 2026-05-19
-platform: web
-languages:
-  - { name: typescript, files: 1, share: 1 }
-build_system: pnpm
-package_manifests:
-  - package.json
-composition:
-  frameworks:
-    - { name: react }
-  rendering: react-spa
-  styling:
-    - css
-design_system:
-  paths:
-    - src/components
-  status: active
-surface_sources:
-  render_strategy: ${renderStrategy}
-  include:
-    - src/**
-  exclude:
-    - node_modules/**
-  coverage_gaps:
-    - no product screens exist yet
-feature_areas:
-  - name: components
-    paths:
-      - src/components
-orientation_files:
-  - README.md
----
-
-## Identity
-
-Local test target.
-
-## Topology
-
-Components live under src/components.
-
-## Conventions
-
-Tests use a compact map fixture.
-`;
+function fingerprintFile(overrides = ""): string {
+  if (overrides.trim()) {
+    return `schema: ghost.fingerprint/v1
+summary: {}
+topology: {}
+situations: []
+experience_contracts: []
+review_policy: {}
+${overrides}`;
+  }
+  return `schema: ghost.fingerprint/v1
+summary: {}
+topology: {}
+situations: []
+principles: []
+experience_contracts: []
+patterns: []
+substrate: {}
+review_policy: {}
+${overrides}`;
 }


### PR DESCRIPTION
🤖 Draft stack PR opened by my AI agent.

## Summary
- Wires CLI and scan command flows to read the fingerprint YAML package.
- Updates package verification and scan status handling around canonical fingerprint memory.
- Adds tests and docs coverage for the new command behavior.

## Impact
User-facing Ghost commands start operating on `.ghost/fingerprint.yml` as the canonical memory source, setting up later review and emit work.

## Stack
- Branch stack position: 4 of 11
- PR stack position: 3 of 10
- Base: `codex/fingerprint-checks-grounding`
- Head: `codex/fingerprint-command-integration`
- Previous PR: #89

## Validation
- `/opt/homebrew/bin/pnpm build`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm check`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm test` (493 tests passed)