### PR TITLE
[codex] Rename proposals for self-healing memory

### DIFF
--- a/.changeset/fingerprint-self-healing-proposals.md
+++ b/.changeset/fingerprint-self-healing-proposals.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": major
+---
+
+Rename proposal kinds around missing memory, intentional divergence, experience gaps, and check candidates.

--- a/packages/ghost/src/ghost-core/memory/schema.ts
+++ b/packages/ghost/src/ghost-core/memory/schema.ts
@@ -59,7 +59,7 @@ export const GhostDecisionSchema = z
 
 export const GhostProposalActionSchema = z
   .object({
-    target: z.enum(["decisions", "patterns", "checks", "intent"]),
+    target: z.enum(["fingerprint", "checks", "review_policy"]),
     summary: z.string().min(1),
   })
   .strict();
@@ -69,7 +69,12 @@ export const GhostProposalSchema = z
     schema: z.literal(GHOST_PROPOSAL_SCHEMA),
     id: SlugIdSchema,
     status: z.enum(["open", "accepted", "rejected", "superseded"]),
-    kind: z.enum(["decision", "pattern", "check", "intent"]),
+    kind: z.enum([
+      "missing-memory",
+      "intentional-divergence",
+      "experience-gap",
+      "check-candidate",
+    ]),
     title: z.string().min(1),
     claim: z.string().min(1),
     rationale: z.string().min(1),

--- a/packages/ghost/src/ghost-core/memory/types.ts
+++ b/packages/ghost/src/ghost-core/memory/types.ts
@@ -10,12 +10,12 @@ export type GhostProposalStatus =
   | "accepted"
   | "rejected"
   | "superseded";
-export type GhostProposalKind = "decision" | "pattern" | "check" | "intent";
-export type GhostProposalTarget =
-  | "decisions"
-  | "patterns"
-  | "checks"
-  | "intent";
+export type GhostProposalKind =
+  | "missing-memory"
+  | "intentional-divergence"
+  | "experience-gap"
+  | "check-candidate";
+export type GhostProposalTarget = "fingerprint" | "checks" | "review_policy";
 
 export interface GhostExperienceScope {
   roles?: string[];

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -13,30 +13,29 @@ Ghost captures product identity in a repo-local fingerprint bundle:
 
 ```text
 .ghost/
-  resources.yml
-  map.md
-  survey.json
-  patterns.yml
+  fingerprint.yml
   checks.yml        # optional deterministic gates
   intent.md         # optional human-approved intent
   decisions/        # optional accepted/rejected rationale
   proposals/        # optional candidate updates
+  cache/            # optional generated caches
 ```
 
-Survey grounds the bundle. Patterns make composition operational. Checks are
-deterministic gates. Intent and decisions preserve human-approved product
-experience context. The host agent reads and writes the fingerprint; the CLI
-provides deterministic validation, comparison, routing, and handoff packets.
+`fingerprint.yml` is the canonical product-experience memory. Checks are
+deterministic gates. Proposals capture missing memory, intentional divergence,
+experience gaps, and check candidates until a human promotes them. The host
+agent reads and writes the fingerprint; the CLI provides deterministic
+validation, comparison, routing, and handoff packets.
 
 ## CLI Verbs
 
 | Verb | Purpose |
 |---|---|
-| `ghost init [dir] [--with-intent]` | Create the root `.ghost` bundle skeleton. |
-| `ghost scan [dir] [--format json]` | Report fingerprint capture progress and the next BYOA step. |
+| `ghost init [dir] [--with-intent]` | Create the root `.ghost` memory skeleton. |
+| `ghost scan [dir] [--format json]` | Report fingerprint memory presence and readiness. |
 | `ghost inventory [path]` | Emit raw repo signals for map authoring. |
 | `ghost lint [file-or-dir]` | Validate a bundle or individual artifact. |
-| `ghost verify [dir] --root <dir>` | Validate resources, pattern evidence, checks, and optional decisions/proposals. |
+| `ghost verify [dir] --root <dir>` | Validate fingerprint evidence, checks, and optional decisions/proposals. |
 | `ghost survey <op>` | Survey ops: `merge`, `fix-ids`, `summarize`, `catalog`, `patterns`. |
 | `ghost check --base <ref>` | Run active deterministic gates against a diff. |
 | `ghost review --base <ref>` | Emit an advisory review packet grounded in bundle evidence. |
@@ -71,6 +70,6 @@ provides deterministic validation, comparison, routing, and handoff packets.
 ## Never
 
 - Never treat advisory composition judgment as a CI gate.
-- Never invent values or composition patterns absent from `survey.json`.
+- Never invent product-experience memory absent from `fingerprint.yml`.
 - Never treat `intent.md` as authoritative unless human-authored or human-approved.
 - Never treat proposals or rejected decisions as canonical inputs.

--- a/packages/ghost/src/skill-bundle/references/promote.md
+++ b/packages/ghost/src/skill-bundle/references/promote.md
@@ -12,14 +12,15 @@ the decision.
 
 1. Read the proposal in `.ghost/proposals/`.
 2. Choose the target from `proposed_action.target`.
-3. For `decisions`, create `.ghost/decisions/<id>.yml` with schema
-   `ghost.decision/v1` and `status: accepted`.
-4. For `patterns`, update `.ghost/patterns.yml` only when survey evidence
-   supports the pattern.
-5. For `checks`, update `.ghost/checks.yml` only with deterministic detectors.
-6. For `intent`, update `.ghost/intent.md` only with human-approved direction.
+3. For `fingerprint`, update `.ghost/fingerprint.yml` with the smallest
+   durable principle, situation, experience contract, pattern, or substrate
+   addition.
+4. For `checks`, update `.ghost/checks.yml` only with deterministic detectors
+   and typed `derives_from` references.
+5. For `review_policy`, update only the proposal or review rules in
+   `fingerprint.yml`.
 7. Mark the proposal `status: accepted` or leave a note if it was superseded.
-8. Run `ghost lint .ghost`.
+8. Run `ghost lint .ghost` and `ghost verify .ghost --root <target>`.
 
 Canonical promotion should be deliberate. Keep rejected or unresolved ideas in
-proposals, not in `patterns.yml`, `checks.yml`, or `intent.md`.
+proposals, not in `fingerprint.yml` or `checks.yml`.

--- a/packages/ghost/src/skill-bundle/references/propose.md
+++ b/packages/ghost/src/skill-bundle/references/propose.md
@@ -12,7 +12,7 @@ reveals a product-experience decision that may belong in the Ghost fingerprint.
 
 1. Confirm the observation is about product experience: perceived, used,
    trusted, understood, or safely changed.
-2. Check whether accepted decisions, patterns, checks, or intent already cover it.
+2. Check whether `fingerprint.yml`, active checks, or open proposals already cover it.
 3. If it is new, write `.ghost/proposals/<slug>.yml`.
 4. Use schema `ghost.proposal/v1`.
 5. Run `ghost lint .ghost`.
@@ -23,7 +23,7 @@ reveals a product-experience decision that may belong in the Ghost fingerprint.
 schema: ghost.proposal/v1
 id: saved-payment-empty-state
 status: open
-kind: decision
+kind: missing-memory
 title: Saved payment empty state should teach recovery
 claim: Empty states for saved payment methods should prioritize recovery over education.
 rationale: The user is blocked from paying, not browsing product concepts.
@@ -33,8 +33,10 @@ scope:
 evidence:
   - path: apps/payments/empty-state.tsx
 proposed_action:
-  target: decisions
-  summary: Promote into an accepted product-experience decision if repeated.
+  target: fingerprint
+  summary: Promote into fingerprint.yml if repeated.
 ```
 
-Do not write accepted decisions without human approval.
+Use `missing-memory`, `intentional-divergence`, `experience-gap`, or
+`check-candidate`. Do not rewrite `fingerprint.yml` or `checks.yml` without
+human approval.

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -4,58 +4,54 @@ Canonical package:
 
 ```text
 .ghost/
-  resources.yml  ghost.resources/v1
-  map.md         ghost.map/v2
-  survey.json    ghost.survey/v2
-  patterns.yml   ghost.patterns/v1
+  fingerprint.yml ghost.fingerprint/v1
   checks.yml     optional ghost.checks/v1 gates
   intent.md      optional human intent
   decisions/     optional ghost.decision/v1 rationale
   proposals/     optional ghost.proposal/v1 candidates
+  cache/         optional generated caches
 ```
 
-## `resources.yml`
+## `fingerprint.yml`
 
 ```yaml
-schema: ghost.resources/v1
-id: my-project
-primary:
-  target: .
-  paths: [src]
-design_system:
-  - id: ui
-    target: ../ui
-    paths: [packages/ui]
-surfaces:
-  - id: settings
-    locator: /settings
-    paths: [src/routes/settings.tsx]
-include: ["src/**"]
-exclude: ["**/node_modules/**"]
-```
-
-## `patterns.yml`
-
-```yaml
-schema: ghost.patterns/v1
-id: my-project
-surface_types:
-  - id: settings
-    preferred_patterns: [settings-stack]
+schema: ghost.fingerprint/v1
+summary:
+  product: Example dashboard
+  goals:
+    - Preserve dense comparison workflows.
+  anti_goals:
+    - Do not turn operational screens into marketing pages.
+topology:
+  scopes:
+    - id: orders
+      paths: [src/orders]
+      surface_types: [resource-index]
+situations:
+  - id: triaging-orders
+    title: Triaging orders
+    product_obligation: Keep status, owner, and recovery actions visible.
+principles:
+  - id: density-supports-comparison
+    status: accepted
+    principle: Dense work surfaces prioritize scanning and comparison.
+experience_contracts:
+  - id: destructive-actions-disclose-consequence
+    status: accepted
+    contract: Destructive actions disclose consequence and recovery path.
+patterns:
+  - id: resource-index-stays-tabular
+    status: accepted
+    kind: composition
+    pattern: Resource index views stay tabular when comparison is the task.
     evidence:
-      - surface_id: settings-account
-composition_patterns:
-  - id: settings-stack
-    surface_types: [settings]
-    frequency: 4
-    confidence: 0.8
-    anatomy:
-      ordered: [shell, compact-header, sections, actions]
-      required: [sections]
-      forbidden: [oversized-hero]
-    evidence:
-      - surface_id: settings-account
-        locator: /settings/account
+      - path: src/orders/index.tsx
+substrate:
+  tokens: [color.background, color.text]
+  components: [DataTable]
+review_policy:
+  proposal_policy:
+    - Agents propose memory changes; humans promote durable truth.
 ```
 
 ## `checks.yml`
@@ -118,7 +114,7 @@ decided_at: "2026-05-17T00:00:00.000Z"
 schema: ghost.proposal/v1
 id: saved-payment-empty-state
 status: open
-kind: decision
+kind: missing-memory
 title: Saved payment empty state should teach recovery
 claim: Empty states for saved payment methods should prioritize recovery over education.
 rationale: The user is blocked from paying, not browsing product concepts.
@@ -128,8 +124,8 @@ scope:
 evidence:
   - path: apps/payments/empty-state.tsx
 proposed_action:
-  target: decisions
-  summary: Promote into an accepted product-experience decision if repeated.
+  target: fingerprint
+  summary: Promote into fingerprint.yml if repeated.
 ```
 
 ## Validation
@@ -141,6 +137,6 @@ ghost check --base main
 ```
 
 `lint` validates artifact shape. `verify` validates cross-artifact fidelity:
-resources resolve, patterns cite survey evidence, and checks reference known
-pattern IDs. Optional decisions/proposals are linted when present. `ghost
-check` is the deterministic pass/fail gate.
+fingerprint evidence paths resolve and checks reference known fingerprint
+memory. Optional decisions/proposals are linted when present. `ghost check` is
+the deterministic pass/fail gate.

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -631,15 +631,15 @@ decided_at: "2026-05-17T00:00:00.000Z"
     `schema: ghost.proposal/v1
 id: saved-payment-empty-state
 status: accepted
-kind: decision
+kind: missing-memory
 title: Saved payment empty state should teach recovery
 claim: Empty states for saved payment methods should prioritize recovery.
 rationale: The user is blocked from paying, not browsing product concepts.
 evidence:
   - path: apps/payments/empty-state.tsx
 proposed_action:
-  target: decisions
-  summary: Promote into an accepted product-experience decision if repeated.
+  target: fingerprint
+  summary: Promote into fingerprint.yml if repeated.
 `,
   );
 }


### PR DESCRIPTION
🤖 Draft stack PR opened by my AI agent.

## Summary
- Reframes staged proposal terminology around self-healing fingerprint memory.
- Updates package status and proposal guidance to match the new memory model.
- Adds the changeset for the public package wording change.

## Impact
The proposal surface better describes Ghost’s role as a memory-maintenance loop instead of a legacy survey/pattern staging area.

## Stack
- Branch stack position: 6 of 11
- PR stack position: 5 of 10
- Base: `codex/fingerprint-review-packet`
- Head: `codex/fingerprint-self-healing-proposals`
- Previous PR: #91

## Validation
- `/opt/homebrew/bin/pnpm build`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm check`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm test` (493 tests passed)