### PR TITLE
[codex] Reset skill docs around fingerprint yml

### DIFF
--- a/.changeset/fingerprint-skill-docs-reset.md
+++ b/.changeset/fingerprint-skill-docs-reset.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Update bundled Ghost skill recipes around fingerprint.yml-centered memory.

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -36,7 +36,7 @@ validation, comparison, routing, and handoff packets.
 | `ghost inventory [path]` | Emit raw repo signals for map authoring. |
 | `ghost lint [file-or-dir]` | Validate a bundle or individual artifact. |
 | `ghost verify [dir] --root <dir>` | Validate fingerprint evidence, checks, and optional decisions/proposals. |
-| `ghost survey <op>` | Survey ops: `merge`, `fix-ids`, `summarize`, `catalog`, `patterns`. |
+| `ghost survey <op>` | Legacy/cache survey helpers for optional inventory workflows. |
 | `ghost check --base <ref>` | Run active deterministic gates against a diff. |
 | `ghost review --base <ref>` | Emit an advisory review packet grounded in bundle evidence. |
 | `ghost compare <a> <b> [...more]` | Compare root bundles or direct fingerprints. |
@@ -47,9 +47,7 @@ validation, comparison, routing, and handoff packets.
 ## Workflows
 
 - Fingerprint Capture: follow [references/capture.md](references/capture.md).
-- Map the repo: follow [references/map.md](references/map.md).
-- Survey design evidence: follow [references/survey.md](references/survey.md).
-- Derive composition grammar: follow [references/patterns.md](references/patterns.md).
+- Author fingerprint patterns: follow [references/patterns.md](references/patterns.md).
 - Recall accepted product-experience context: follow [references/recall.md](references/recall.md).
 - Shape a pre-generation brief: follow [references/brief.md](references/brief.md).
 - Critique generated or changed work: follow [references/critique.md](references/critique.md).

--- a/packages/ghost/src/skill-bundle/references/brief.md
+++ b/packages/ghost/src/skill-bundle/references/brief.md
@@ -1,30 +1,36 @@
 ---
 name: brief
-description: Shape a pre-generation brief from the Ghost fingerprint.
+description: Shape a pre-generation brief from .ghost/fingerprint.yml.
 ---
 
 # Brief From The Ghost Fingerprint
 
-Use this before generating or implementing UI. The goal is to help the human and
-agent understand the experience problem, not just load style constraints.
+Use this before generating or implementing product UI. The goal is to turn
+repo-local memory into a concise working brief: what the agent should preserve,
+where it has freedom, and what needs human judgment.
 
 ## Steps
 
-1. Run the recall workflow for the requested task.
-2. Identify the likely map scope, surface type, and composition pattern.
-3. Name the product-experience decisions at stake.
-4. Call out risks: accidental drift, incomplete fingerprint context, or intentional change.
-5. Write prompt material for the generator or implementation agent.
+1. Read `.ghost/fingerprint.yml`.
+2. Select the relevant `situation` for the task, or state that none fits.
+3. Pull applicable `principles`, `experience_contracts`, `patterns`, and
+   `substrate` entries.
+4. Read `.ghost/checks.yml` for active deterministic gates.
+5. Skim `.ghost/proposals/*.yml` for open gaps or intentional divergences.
+6. Name missing or contradictory memory explicitly.
 
 ## Output
 
 Produce:
 
-- Task framing.
-- Relevant fingerprint context with citations.
+- Task framing and selected situation.
+- Relevant principles and experience contracts.
+- Product-native pattern guidance.
+- Substrate constraints: tokens, components, accessibility, responsive policy.
+- Active checks to run afterward.
+- Open proposals or known gaps.
 - Decisions the human should make before generation.
-- Product-native generation guidance.
-- Drift checks to run afterward.
 
-Do not invent fingerprint context. If context is missing, say what proposal
-should be recorded after the work.
+Do not invent fingerprint context. If memory is missing, say which proposal
+type should be recorded after the work: `missing-memory`,
+`intentional-divergence`, `experience-gap`, or `check-candidate`.

--- a/packages/ghost/src/skill-bundle/references/capture.md
+++ b/packages/ghost/src/skill-bundle/references/capture.md
@@ -1,135 +1,118 @@
 ---
 name: capture
-description: Drive Ghost Fingerprint Capture to produce .ghost/{resources.yml,map.md,survey.json,patterns.yml} plus optional checks.yml and intent.md.
+description: Capture repo-local Ghost product-experience memory in .ghost/fingerprint.yml.
 handoffs:
-  - label: Inspect stage status
+  - label: Inspect memory status
     command: ghost scan
-    prompt: What fingerprint capture stage should I run next?
-  - label: Run deterministic drift checks
+    prompt: What fingerprint memory is present and what is missing?
+  - label: Run deterministic checks
     command: ghost check
     prompt: Run ghost check against this bundle
 ---
 
 # Recipe: Capture A Ghost Fingerprint
 
-**Goal:** capture the product's repo-local Ghost fingerprint:
+**Goal:** produce durable product-experience memory that helps agents build,
+review, and repair on-brand work.
 
 ```text
 .ghost/
-  resources.yml
-  map.md
-  survey.json
-  patterns.yml
-  checks.yml
-  intent.md        # optional
+  fingerprint.yml  # canonical product-experience memory
+  checks.yml       # optional deterministic gates
+  proposals/       # candidate memory changes
+  cache/           # optional generated inventory
+  intent.md        # optional human-approved context
 ```
 
-## Overview
-
-```text
-resources -> map -> survey -> patterns
-```
-
-- `resources.yml`: references that define the product.
-- `map.md`: topology and routing.
-- `survey.json`: observed factual evidence.
-- `patterns.yml`: operational composition grammar backed by survey evidence.
-- `checks.yml`: optional human-promoted deterministic gates.
-- `intent.md`: optional human-authored or human-approved product intent.
-
-Fingerprint Capture is a BYOA workflow: the host agent reads, interprets, and
-writes the fingerprint artifacts; the `ghost` CLI supplies deterministic status,
-validation, derivation, and review helpers.
-
-`ghost scan --format json` reports capture progress and `readiness.state`. A
-capture can be structurally complete while still being `substrate-only` or
-`component-demo`; in those states, use tokens, components, and demo evidence,
-but do not treat product composition, hierarchy, surface flow, or product
-rhythm as observed.
+`fingerprint.yml` answers what matters and why. Generated inventory answers
+what exists right now. Keep those separate: inventory may be refreshed or
+discarded, but canonical memory changes only through deliberate edits.
 
 ## Steps
 
-### 0. Initialize
+### 1. Initialize
 
 ```bash
 ghost init
 ghost scan
 ```
 
-Use `--with-intent` only when you have human-authored or human-approved intent
-to record.
+Use `--with-intent` only when you have human-authored or human-approved context
+to preserve. New projects may start with an empty but valid fingerprint and add
+memory as product choices become real.
 
-### 1. Resources
+### 2. Orient
 
-Run when `ghost scan` recommends `resources`.
+Read the product, not just the component library. Look for the surfaces, docs,
+tests, stories, routes, screenshots, or examples that reveal identity,
+hierarchy, behavior, copy, accessibility, and trust.
 
-Author `.ghost/resources.yml` from the target, any design-system repositories,
-canonical screenshots, docs, resolver sources, and include/exclude boundaries.
+Optional helpers:
 
-### 2. Map
+```bash
+ghost inventory . > .ghost/cache/inventory.json
+```
 
-Run when `ghost scan` recommends `map`.
+Treat cache output as scratch material. Do not promote raw inventory into
+fingerprint memory without judgment.
 
-Follow [map.md](map.md). Write `.ghost/map.md`, then validate:
+### 3. Author `fingerprint.yml`
+
+Fill the smallest useful memory:
+
+- `summary`: product identity, audience, goals, anti-goals, tradeoffs, tone.
+- `topology`: scopes, surface types, and representative examples.
+- `situations`: user/task/state moments that change obligations.
+- `principles`: durable product-experience truths.
+- `experience_contracts`: behavior, disclosure, failure, recovery, and trust.
+- `patterns`: visual, behavioral, content, and composition patterns.
+- `substrate`: tokens, components, accessibility, and responsive policy.
+- `review_policy`: proposal and experience-gap handling.
+
+Prefer a few high-confidence entries over a comprehensive but noisy catalog.
+Every accepted entry should be useful to a future agent making or reviewing a
+product change.
+
+### 4. Add Checks Sparingly
+
+`checks.yml` is the executable appendix. Add only deterministic checks with a
+typed `derives_from` reference into `fingerprint.yml`.
+
+```yaml
+derives_from: pattern:resource-index-stays-tabular
+```
+
+Candidate checks belong in `.ghost/proposals/` as `kind: check-candidate` until
+a human promotes them.
+
+### 5. Validate
 
 ```bash
 ghost lint .ghost
-```
-
-### 3. Survey
-
-Run when `ghost scan` recommends `survey`.
-
-Follow [survey.md](survey.md). Write `.ghost/survey.json`, then finalize and
-validate:
-
-```bash
-ghost survey fix-ids .ghost/survey.json -o .ghost/survey.json
-ghost lint .ghost
-```
-
-### 4. Patterns
-
-Run when `ghost scan` recommends `patterns`.
-
-Follow [patterns.md](patterns.md). Start from the derived pattern draft:
-
-```bash
-ghost survey patterns .ghost/survey.json -o .ghost/patterns.yml
-```
-
-Curate names, anatomy, variants, anti-patterns, confidence, and evidence. Then:
-
-```bash
 ghost verify .ghost --root <target>
-ghost lint .ghost
-```
-
-If readiness is `substrate-only` or `component-demo`, keep `patterns.yml`
-honest about that limited authority. Empty `composition_patterns` is acceptable
-when no implemented product surfaces exist.
-
-### Optional. Checks
-
-First captures may leave `checks.yml` with `checks: []`. Candidate checks belong
-in your response or capture notes until a human curator promotes them.
-
-When checks are promoted, validate and smoke-test:
-
-```bash
-ghost lint .ghost
 ghost check --base HEAD
 ```
 
-## Resumability
+`lint` validates shape, `verify` validates evidence paths and typed check refs,
+and `check` runs only active deterministic gates.
 
-Run `ghost scan` between stages. To force a stage rerun, delete or replace that
-artifact and re-run status. Do not move forward from a failed lint or verify
-result.
+## Gaps
+
+If the repo does not yet contain enough product experience to capture, say so.
+For missing or contradictory memory, write a proposal with one of:
+
+- `missing-memory`
+- `intentional-divergence`
+- `experience-gap`
+- `check-candidate`
+
+Humans promote durable truth. Agents do not silently rewrite canonical memory.
 
 ## Never
 
 - Never describe root-level `fingerprint.md` as canonical.
-- Never invent values or composition observations absent from `survey.json`.
-- Never promote subjective composition prose directly into `checks.yml`; make it
+- Never treat generated inventory as canonical memory.
+- Never invent product-experience obligations absent from evidence or human
+  direction.
+- Never promote subjective judgment directly into `checks.yml`; make it
   deterministic or keep it advisory.

--- a/packages/ghost/src/skill-bundle/references/critique.md
+++ b/packages/ghost/src/skill-bundle/references/critique.md
@@ -1,28 +1,31 @@
 ---
 name: critique
-description: Critique generated or changed work using the Ghost fingerprint and CLI.
+description: Critique generated or changed work using .ghost/fingerprint.yml and the Ghost CLI.
 ---
 
 # Critique With The Ghost Fingerprint
 
 Use this after generated or changed UI exists. `ghost` emits deterministic
-checks and advisory packets; the fingerprint supplies role-aware interpretation.
+checks and advisory packets; `fingerprint.yml` supplies product-experience
+memory.
 
 ## Steps
 
 1. Run `ghost check` for deterministic gates when a diff is available.
 2. Run `ghost review --include-memory` for advisory critique.
-3. Read the review packet and accepted decisions.
+3. Read the review packet, accepted decisions, and open proposals.
 4. Separate findings by role:
-   - design: feel, hierarchy, flow, density, tone
+   - design: hierarchy, flow, density, tone, accessibility
    - engineering: implementation choices that preserve experience
-   - pm: product promise and tradeoffs
+   - pm: product promise, tradeoffs, trust, disclosure
    - qa: experience commitments and edge states
-5. Classify each issue as fix, intentional divergence, or missing fingerprint context.
+5. Classify each issue as `fix`, `intentional-divergence`,
+   `missing-memory`, `experience-gap`, or `eval-uncertainty`.
 
 ## Output
 
-Lead with actionable findings. Cite diff locations, patterns, survey evidence,
-intent, accepted decisions, and repairs where relevant.
+Lead with actionable findings. Cite diff locations, fingerprint memory, active
+checks, open proposals, accepted decisions, and repairs where relevant.
 
-Never fail a build on advisory-only context. Only active `checks.yml` gates block.
+Never fail a build on advisory-only context. Only active `checks.yml` gates
+block.

--- a/packages/ghost/src/skill-bundle/references/map.md
+++ b/packages/ghost/src/skill-bundle/references/map.md
@@ -1,156 +1,57 @@
 ---
 name: map
-description: Author the map.md for a target - Ghost's topology card. The first stage of Fingerprint Capture.
+description: Use repo topology as optional source material for fingerprint.yml.
 handoffs:
-  - label: Survey values into survey.json
-    command: (next stage — survey recipe)
-    prompt: Survey the target's design values into survey.json
-  - label: Validate the map
-    command: ghost lint map.md
-    prompt: Lint the map.md I just wrote
+  - label: Capture fingerprint memory
+    skill: capture
+    prompt: Use topology observations to update .ghost/fingerprint.yml
 ---
 
-# Recipe: Author a target's map.md
+# Recipe: Read Topology For Ghost
 
-**Goal:** produce a valid `.ghost/map.md` (`ghost.map/v2`) that captures the *topology* of the target - what platform it ships on, what it builds with, where the design system lives, and where implemented UI can actually be observed. `map.md` is the topology stage of Fingerprint Capture: later stages (`survey.json`, `patterns.yml`, and optional `checks.yml`) read it to skip rediscovery and route changes.
+`map.md` is no longer the canonical fingerprint stage. Topology belongs in
+`.ghost/fingerprint.yml` under `topology`.
 
-This recipe is *your* job. Ghost's CLI provides `ghost inventory` (deterministic raw signals) and `ghost lint <map.md>` (validation), but you do the synthesis.
+Use this recipe when an older workflow, existing repo, or migration still has a
+`.ghost/map.md`, or when you need to orient before writing `fingerprint.yml`.
 
-## Steps
+## What To Capture
 
-### 1. Gather raw signals
+Look for facts that help agents route product-experience judgment:
 
-**Preferred (CLI present):**
+- product scopes and owned paths
+- surface types
+- representative examples
+- frameworks, platforms, and rendering constraints
+- design-system or component-library locations
+- places where UI can actually be observed
 
-Run `ghost inventory [path]` from (or pointed at) the target root. It returns deterministic JSON: package manifests, language histogram, candidate config files, registry presence, top-level tree, git remote, plus best-effort platform and build-system hints. Read it as the foundation — reproducible from inputs.
-
-**Prose fallback (no CLI):**
-
-Build the inventory yourself with `Glob` / `Read` / `Bash`:
-
-- **Package manifests:** `Glob: **/{package.json,pnpm-workspace.yaml,Cargo.toml,go.mod,Package.swift,build.gradle*,pyproject.toml,requirements.txt}` — exclude `node_modules`. Read each; record `name` and top-level dep names.
-- **Language histogram:** `Bash: find . -type f -name '*.tsx' -o -name '*.ts' -o -name '*.swift' -o -name '*.kt' …` (extension list per the kinds you care about) and count. Convert to `{name, files, share}` rows where `share = files / total`.
-- **Candidate config files:** `Glob` for `tailwind.config.*`, `tsconfig*.json`, `vite.config.*`, `next.config.*`, `tokens/**`, `theme/**`, etc.
-- **Registry presence:** check `Read: <path>/registry.json` — if it parses and has `name` + `items[]`, record its path.
-- **Top-level tree:** `Bash: ls -la <path>` for one level deep.
-- **Git remote:** `Bash: git -C <path> remote get-url origin` (best-effort, fine if absent).
-
-Format as a JSON object so the rest of the recipe can quote from it. Skip fields you can't determine; partial inventory is fine.
-
-### 2. Resolve the schema fields
-
-The `ghost.map/v2` frontmatter requires:
-
-- **`schema: ghost.map/v2`** (literal)
-- **`id`** — slug (lowercase alphanumeric plus `.` `_` `-`, leading alphanumeric). For fleet scans, this is the fleet target id.
-- **`repo`** — GitHub `org/repo`, or any source identifier that uniquely names this target.
-- **`subject`** — optional `{id, target}` that names the single thing this bundle will describe. Use it when capture needs multiple sources; `subject` stays the primary claim.
-- **`sources`** — optional capture source graph. Each source is `{id?, role, target, resolves?, paths?}` where `role` is `primary` or `resolver`. `primary` supplies usage/salience; `resolver` supplies concrete meaning for imported symbols. Declare exactly one primary when `sources[]` is present.
-- **`mapped_at`** — current ISO date (`YYYY-MM-DD`) or full datetime.
-- **`platform`** — one of `web`, `ios`, `android`, `desktop`, `flutter`, `mixed`, `other`, or an array spanning multiple. The inventory's `platform_hints` is your starting point — accept it when consistent, override when you have evidence.
-- **`languages`** — array of `{name, files, share}` from the inventory histogram. `share` is fraction in [0,1].
-- **`build_system`** — one of `gradle`, `bazel`, `xcode`, `pnpm`, `npm`, `yarn`, `cargo`, `go`, `maven`, `sbt`, `cmake`, `style-dictionary`, `vite`, `webpack`, `parcel`, `rollup`, `turbopack`, `esbuild`, `nx`, `turbo`, `mixed`, `other`, or an array. The inventory's `build_system_hints` plus lockfile presence (`pnpm-lock.yaml` → `pnpm`, `yarn.lock` → `yarn`, `package-lock.json` → `npm`) usually answers this.
-- **`package_manifests`** — array of paths from the inventory.
-- **`composition.frameworks`** — array of `{name, version?}` (e.g. `react`, `next`, `swiftui`, `compose`, `style-dictionary`).
-- **`composition.rendering`** — short slug (`react-spa`, `next-app-router`, `swiftui`, `compose`, `static`, `mixed`, …).
-- **`composition.styling`** — array (e.g. `["tailwindcss"]`, `["scss-modules"]`, `["styled-components"]`).
-- **`composition.navigation`** — optional short slug (`next-router`, `react-router`, `swiftui-navigation`, …).
-- **`registry`** — optional `{path, components}` if a shadcn-style registry exists. Component registries are substrate evidence; they do not imply product surfaces by themselves.
-- **`design_system`** — `{paths[], entry_files?, derived_files?, path_patterns?, token_source?, upstream?, status}`. `token_source` is `inline` / `external` / `mixed`. `status` is `active` / `mixed` / `unclear`. Set `upstream` when `token_source` is `external` or `mixed`, and prefer representing each upstream as a `sources[]` resolver when the capture author can inspect it.
-- **`surface_sources`** — `{render_strategy, include[], exclude[], coverage_gaps?}` — globs for implemented UI plus how the surveyor can observe it. `render_strategy` is one of `browser`, `storybook`, `docs`, `native-screenshot`, `static-source`, `mixed`, or `unknown`.
-- **`feature_areas`** — array of `{name, paths[], sub_areas?[]}` describing sampling clusters for implemented surfaces. These are product or documentation surfaces, not just folders. For component-library-only repos, use areas like `components`, `tokens`, `stories`, or `docs` so the survey can record substrate/demo evidence without pretending product flows exist.
-- **`orientation_files`** — array of files an agent should read first to understand the target.
-
-### 3. Use a manifest if one is provided
-
-If a `manifest.yaml` is present in CWD (some fleet orchestrators inject hand-curated sampling manifests for big repos), treat it as authoritative for `feature_areas`, `module_signals`, and `design_system.path_patterns`. Don't contradict it without evidence.
-
-If no manifest is provided, derive `feature_areas` and `surface_sources` from the inventory's `top_level_tree` and your own brief exploration: which directories represent observable product surfaces (e.g. `apps/dashboard`, `apps/docs`, `src/routes`, `src/features/*`, `stories/**`, native screenshot fixtures)?
-
-#### Render strategy
-
-Choose the strongest observation path the target supports:
-
-- `browser` — app routes can be launched and inspected in a browser.
-- `storybook` — Storybook or equivalent component stories are the primary observable demo surface.
-- `docs` — docs/catalogue examples are the primary observable demo surface.
-- `native-screenshot` — native UI is represented by screenshot fixtures or simulator captures.
-- `static-source` — no renderer is available; surveyor must infer from source files.
-- `mixed` — more than one strategy is materially needed.
-- `unknown` — no trustworthy implemented UI surface is discoverable. Use only with `coverage_gaps` explaining what is missing.
-
-`coverage_gaps` should list important blind spots ("no product screens exist yet", "native screens require simulator access", "marketing routes are generated from CMS", "no screenshots checked in"). Empty or absent means the capture author believes the declared sources are enough for the survey stage.
-
-### 3a. Source graph for split repos
-
-Use a source graph when the target's design language is only observable through dependencies (apps consuming token packages, native apps importing design-system modules, wrappers over upstream registries). The bundle still has one subject; Fingerprint Capture may have many sources.
-
-Rule:
-
-> Primary sources determine salience. Resolver sources determine meaning.
-
-Example:
+Promote only durable routing facts into `fingerprint.yml`:
 
 ```yaml
-subject:
-  id: cash-ios
-  target: github:squareup/cash-ios
-sources:
-  - id: cash-ios
-    role: primary
-    target: github:squareup/cash-ios
-  - id: arcade-ios-package
-    role: resolver
-    target: github:squareup/arcade-ios-package
-    resolves: [color, spacing, typography]
+topology:
+  scopes:
+    - id: checkout
+      paths: [src/checkout]
+      surface_types: [payment-review]
+  surface_types: [payment-review, empty-state]
+  examples:
+    - path: src/checkout/review.tsx
+      surface_type: payment-review
 ```
 
-Use `design_system.upstream` as the compatibility breadcrumb, but `sources[]` is the richer contract the survey recipe consumes. A resolver source should not make unused upstream tokens important; it only resolves symbols observed in the primary source.
+## Optional Inventory
 
-### 4. Body sections
+```bash
+mkdir -p .ghost/cache
+ghost inventory . > .ghost/cache/inventory.json
+```
 
-`map.md` requires a short prose body with three sections — keep them tight, two-to-four sentences each. The body explains the map; the frontmatter stores the structured data. Sections must appear in this order:
+Inventory is cache. Read it for hints, then author `fingerprint.yml` by
+judgment. Do not treat file counts, manifests, or candidate config files as
+product-experience memory by themselves.
 
-- `## Identity` — what is this repo, what does it produce, who consumes it?
-- `## Topology` — how is the codebase organized? Where does the design system live relative to product code?
-- `## Conventions` — notable patterns (token pipelines, registry, framework choices, language mixes) that shape how someone navigates.
+## Legacy Maps
 
-### 5. Validate
-
-**Preferred (CLI present):**
-
-    ghost lint map.md
-
-Fix any errors. Lint passing is the success gate — do not declare done until it exits 0.
-
-**Prose fallback (no CLI):**
-
-Walk the file yourself against the schema in [schema.md](schema.md). Required checks:
-
-- Frontmatter parses as valid YAML.
-- `schema: ghost.map/v2` literal present.
-- Required fields populated: `id` (slug), `repo`, `mapped_at`, `platform`, `languages`, `build_system`, `package_manifests`, `composition.frameworks`, `composition.rendering`, `composition.styling`, `design_system.paths`, `design_system.status`, `surface_sources.render_strategy`, `surface_sources.include`, `feature_areas[]`, `orientation_files[]`.
-- `id` matches `^[a-z0-9][a-z0-9._-]*$`.
-- Body sections appear in order: `## Identity`, `## Topology`, `## Conventions`. No other `##` headings between them.
-- If `design_system.token_source` is `external` or `mixed`, `design_system.upstream` is set.
-- If `sources[]` is present, it has exactly one `role: primary`; resolver sources declare `resolves` where possible.
-
-Common errors regardless of path:
-
-- Body section out of order (`## Identity` must precede `## Topology` etc.)
-- Missing `entry_files` AND `derived_files` under `design_system` (warning — fine if neither exists, but check)
-- `token_source: external` without `upstream` set
-- `id` not a slug
-
-## Always
-
-- Cite real paths the inventory returned. Do not invent files.
-- Prefer the array form (`platform: [web, ios]`) over `mixed` when the repo genuinely spans multiple platforms.
-- If there is no design system in the repo (a backend-only app, a marketing site without a tokens layer), say so in `## Identity`, set `design_system.status: unclear`, and omit `entry_files`. Don't fabricate a design-system structure.
-- For fleet scans, resolve `id` and `repo` from environment variables when the orchestrator passes them (`TARGET_ID`, `TARGET_REPO`).
-
-## Never
-
-- Never put prose into frontmatter or structural data into the body.
-- Never duplicate the inventory's content in the body. The body is interpretation, not data.
-- Never declare done before `ghost lint map.md` exits 0.
+If `.ghost/map.md` already exists, read it as source material. Do not require a
+new project to create one before `fingerprint.yml`.

--- a/packages/ghost/src/skill-bundle/references/patterns.md
+++ b/packages/ghost/src/skill-bundle/references/patterns.md
@@ -1,46 +1,67 @@
 ---
 name: patterns
-description: Interpret .ghost/survey.json surface evidence into .ghost/patterns.yml, the operational composition grammar.
+description: Author product-experience patterns inside .ghost/fingerprint.yml.
 handoffs:
   - label: Verify bundle
     command: ghost verify .ghost --root .
     prompt: Verify the root fingerprint bundle
 ---
 
-# Recipe: Write `patterns.yml`
+# Recipe: Author Fingerprint Patterns
 
-**Goal:** produce `.ghost/patterns.yml` (`ghost.patterns/v1`) from
-`.ghost/survey.json`.
+**Goal:** write useful `patterns[]` entries in `.ghost/fingerprint.yml`.
 
-`patterns.yml` is operational composition grammar. It names surface types,
-composition patterns, anatomy, variants, anti-patterns, confidence, and evidence
-so generation and advisory review have stable handles. It is not human intent;
-use optional `intent.md` for accepted product strategy.
+Patterns are durable product-experience memory. They may describe visual,
+behavioral, content, or composition choices. They are not a raw inventory of
+everything the repo does.
 
-## Start From Survey Evidence
+## When To Add A Pattern
 
-```bash
-ghost survey patterns .ghost/survey.json -o .ghost/patterns.yml
+Add a pattern when it helps a future agent choose or review:
+
+- a repeated layout or surface structure
+- a content or disclosure convention
+- a behavior or recovery flow
+- a visual treatment tied to product meaning
+- a restraint rule that preserves hierarchy, density, trust, or pacing
+
+Do not add a pattern just because a value or component exists. Put raw
+observations in `.ghost/cache/` or keep them in scratch notes.
+
+## Shape
+
+```yaml
+patterns:
+  - id: resource-index-stays-tabular
+    status: accepted
+    kind: composition
+    pattern: Resource index views stay tabular when comparison is the task.
+    applies_to:
+      surface_types: [resource-index]
+      paths: [src/orders]
+    guidance:
+      - Preserve row density and sortable columns.
+      - Avoid decorative card grids for primary comparison views.
+    evidence:
+      - path: src/orders/index.tsx
 ```
 
-Then curate the draft. Keep every pattern evidence-backed.
+Allowed `kind` values:
 
-If `ghost scan --format json` reports `readiness.state: substrate-only`, leave
-`composition_patterns` empty and keep advisory expectations focused on
-tokens/components/values. If readiness is `component-demo`, mark patterns as
-demo or component-anatomy evidence; do not present them as product composition,
-surface flow, or hierarchy.
+- `visual`
+- `behavioral`
+- `content`
+- `composition`
 
 ## Authoring Rules
 
-- Use stable slugs: `resource-index`, `dense-resource-index`, `settings-stack`.
-- Record surface type selection policy in `surface_types[].preferred_patterns`.
-- Record pattern anatomy in `composition_patterns[].anatomy`.
-- Put sparse but important differences in `variants` or `anti_patterns`.
-- Use `confidence` for observed support, not taste.
-- Cite `survey.ui_surfaces` via `surface_id`, `locator`, or `path`.
-- Keep subjective or strategic rationale out of `patterns.yml`; put approved
-  intent in `intent.md`.
+- Use stable slugs.
+- Keep the pattern actionable for generation and review.
+- Cite paths, locators, or notes as evidence.
+- Put obligations that affect failure, disclosure, recovery, or trust in
+  `experience_contracts`, not only `patterns`.
+- Put broad product judgment in `principles`.
+- Add `check_refs` only when a deterministic check exists in `checks.yml`.
 
 ## Validate
 
@@ -49,4 +70,5 @@ ghost lint .ghost
 ghost verify .ghost --root .
 ```
 
-Verification fails when composition patterns lack survey-backed evidence.
+If a pattern is speculative, record a proposal instead of adding it as accepted
+memory.

--- a/packages/ghost/src/skill-bundle/references/recall.md
+++ b/packages/ghost/src/skill-bundle/references/recall.md
@@ -10,21 +10,27 @@ handles a surface, or what constraints matter before work begins.
 
 ## Steps
 
-1. Read `.ghost/intent.md` when present.
-2. Read `.ghost/map.md` to identify likely scopes and surface types.
-3. Read `.ghost/patterns.yml` for matching surface and composition patterns.
-4. Read `.ghost/checks.yml` for active or proposed deterministic gates.
-5. Read `.ghost/decisions/*.yml`; include only `status: accepted` as canonical.
-6. Skim `.ghost/proposals/*.yml` separately as unresolved candidate updates.
+1. Read `.ghost/fingerprint.yml`.
+2. Identify matching topology scopes, surface types, situations, and examples.
+3. Select relevant principles, experience contracts, patterns, and substrate.
+4. Read `.ghost/checks.yml` for active deterministic gates.
+5. Read `.ghost/decisions/*.yml`; include only `status: accepted` as
+   supplemental rationale.
+6. Skim `.ghost/proposals/*.yml`; include only open proposals as unresolved
+   context.
 
 ## Output
 
 Return a short, cited recall packet:
 
-- Relevant intent.
-- Matching surface patterns.
+- Relevant situation.
+- Product-experience principles.
+- Applicable experience contracts.
+- Matching patterns.
+- Substrate constraints.
 - Active checks.
-- Accepted decisions.
-- Open proposals or unresolved tensions.
+- Accepted rationale.
+- Open proposals or known gaps.
 
-Do not edit files during recall.
+Do not edit files during recall. If the fingerprint does not cover the task,
+say that plainly and suggest the smallest proposal type to record later.

--- a/packages/ghost/src/skill-bundle/references/remediate.md
+++ b/packages/ghost/src/skill-bundle/references/remediate.md
@@ -1,6 +1,6 @@
 ---
 name: remediate
-description: Given drift findings (from review or compare) and the offending diff, suggest the minimal targeted fixes that close the gap.
+description: Given drift findings and the offending diff, suggest the minimal targeted fixes that close the gap.
 handoffs:
   - label: Re-review after applying the suggested fixes
     skill: review
@@ -13,76 +13,82 @@ handoffs:
     prompt: Record an intentional divergence on a specific dimension so it stops flagging
 ---
 
-# Recipe: Remediate drift
+# Recipe: Remediate Drift
 
-**Goal:** turn drift findings into a small, surgical patch — the minimal code change that closes the gap between the working tree and the root fingerprint bundle. Remediate is the loop after `review`: review *finds* drift; remediate *proposes the fix*.
+**Goal:** turn drift findings into a small, targeted patch that brings the
+working tree back inside `.ghost/fingerprint.yml` and active checks.
 
-Ghost has no `ghost remediate` CLI command. You — the host agent — read the findings, weigh them against `patterns.yml`, `survey.json`, optional `intent.md`, and active checks, then write the patch.
+Ghost has no `ghost remediate` CLI command. You, the host agent, read the
+findings, weigh them against `fingerprint.yml`, active checks, accepted
+rationale, and open proposals, then write the smallest useful patch.
 
 ## Steps
 
-### 1. Gather inputs
+### 1. Gather Inputs
 
 You need:
 
-- The **drift output** — either the JSON from `ghost compare --semantic --format json` or the structured findings from a [review](review.md) pass.
-- The **offending diff** — `git diff <base> -- <file>` for each flagged file.
-- The **fingerprint bundle** — `.ghost/patterns.yml`, `.ghost/survey.json`, optional `.ghost/intent.md`, and `.ghost/checks.yml` for active gates.
-- The **sync manifest** if present (`.ghost-sync.json`) — anything stance:`diverging` is intentional and must NOT be remediated.
+- The drift output from `ghost review`, `ghost check`, or compare.
+- The offending diff: `git diff <base> -- <file>`.
+- `.ghost/fingerprint.yml`.
+- `.ghost/checks.yml` for active gates.
+- `.ghost/proposals/*.yml` for known gaps or accepted divergence candidates.
+- `.ghost-sync.json` when present; anything stance:`diverging` is intentional
+  and must not be remediated as accidental drift.
 
-### 2. Match each finding to a token
+### 2. Match Findings To Memory
 
-For every drift finding, identify the token the code *should* have used:
+For every finding, identify the relevant fingerprint entry:
 
-- Hardcoded `#3b82f6` → token or value evidenced in `survey.json`. If nothing fits, the bundle is silent and the right move is to add evidence or human intent, not a remediation.
-- Off-pattern composition → restore the `patterns.yml` anatomy or use an allowed variant.
-- Off-grid `padding: 14px` → nearest survey-backed spacing/token value. Prefer rounding *down* unless the surrounding rhythm suggests otherwise.
-- Hard-coded radius not evidenced in `survey.json` → snap to a survey-backed radius or flag for human review.
-- Behavioral drift → propose removing the offending property; cite the relevant pattern or intent.
+- Token drift -> `substrate.tokens`, related pattern, or active check.
+- Component drift -> `substrate.components` or applicable pattern.
+- Hierarchy/density drift -> principle, situation, or composition pattern.
+- Disclosure/recovery drift -> experience contract.
+- Copy/trust drift -> principle, experience contract, or review policy.
 
-### 3. Score by impact
+If no entry applies, do not invent one inside the code patch. Report a
+`missing-memory` or `experience-gap` proposal.
 
-Rank findings by how much distance they close:
+### 3. Score By Impact
 
-- **Load-bearing** — fixes that restore required pattern anatomy, token usage, or active checks. Patch first.
-- **Snap-to-grid** — off-scale spacing/radii values. Patch in the same pass.
-- **Cosmetic** — values that drift slightly (`16px` vs `15px`) but don't break a decision. Group these into one cleanup commit.
+Rank findings by how much product experience they restore:
 
-If the drift number quoted in the finding is `< 0.05`, ask before patching — it may be acceptable noise.
+- **Blocking**: active check failures.
+- **Load-bearing**: violations of principles, contracts, or required patterns.
+- **Local cleanup**: small substrate mismatches with obvious fixes.
+- **Uncertain**: advisory drift that needs human judgment.
 
-### 4. Propose the patch
+If the finding is intentional for this change, suggest an
+`intentional-divergence` proposal instead of a code patch.
+
+### 4. Propose The Patch
 
 For each finding, write a unified-diff suggestion in the form:
 
-```
-file:line   before  →  after   (closes <dimension> drift of ~0.NN)
-```
-
-Example:
-
-```
-src/components/button.tsx:42   border-radius: 12px;   →   border-radius: var(--radius-md);
-                                                          (matches surfaces.borderRadii: [4, 8, 16] — closes ~0.14 of 0.18 radius drift)
+```text
+file:line   before  ->  after   (why this satisfies fingerprint memory)
 ```
 
-Group patches by file. Keep each patch surgical — do not refactor surrounding code, do not rewrite imports, do not "clean up while you're there."
+Group patches by file. Keep each patch surgical. Do not refactor surrounding
+code, rewrite unrelated imports, or clean up nearby style while remediating.
 
-### 5. Surface what cannot be remediated
+### 5. Surface What Cannot Be Remediated
 
-Some findings have no clean fix:
+Some findings have no clean code fix:
 
-- The bundle is silent on the dimension → tell the user the bundle is missing evidence, pattern policy, or accepted intent; offer to update the bundle.
-- The drift is intentional (e.g. a brand-tier override on a single page) → suggest `ghost diverge <dimension> --reason "..."` instead of a code patch.
-- The fix would cascade across many files → flag and stop. A 30-file refactor disguised as "remediation" is a separate change with its own review.
+- The fingerprint is silent -> propose `missing-memory`.
+- The product is intentionally changing -> propose `intentional-divergence`.
+- The generated work failed to compose despite available memory -> propose
+  `experience-gap`.
+- A recurring deterministic issue can be detected -> propose `check-candidate`.
+- The fix would cascade across many files -> stop and call out the separate
+  implementation plan.
 
-### 6. Record the outcome
+### 6. Record The Outcome
 
-After the user applies (or rejects) the patches:
+After the user applies or rejects patches:
 
-- Re-run `ghost compare` — distance should drop. If it doesn't, the patches missed.
-- If the user accepts the drift instead of fixing it, run `ghost ack` (overall) or `ghost diverge <dimension>` (one axis).
-- Never silently regenerate the bundle to "absorb" the drift. That hides the act.
-
-## Why this is a recipe, not a verb
-
-Remediation requires judgment: which token is "closest", what matters enough to fix, when to escalate vs auto-patch. None of that is deterministic, so it stays in the recipe — the CLI gives you the math (`compare`), the recipe gives you the procedure, and you write the patch.
+- Re-run `ghost check` and `ghost review`.
+- If the user accepts drift instead of fixing it, run `ghost ack` or
+  `ghost diverge <dimension>`.
+- Never regenerate or rewrite `fingerprint.yml` to hide drift.

--- a/packages/ghost/src/skill-bundle/references/review.md
+++ b/packages/ghost/src/skill-bundle/references/review.md
@@ -1,18 +1,18 @@
 ---
 name: review
-description: Review PR or working-tree changes against the local Ghost fingerprint bundle.
+description: Review PR or working-tree changes against .ghost/fingerprint.yml.
 handoffs:
   - label: Suggest minimal fixes
     skill: remediate
-    prompt: Given the drift findings, suggest the minimal code changes that bring the diff back inside the .ghost bundle
+    prompt: Given the drift findings, suggest the minimal code changes that bring the diff back inside the .ghost fingerprint
   - label: Accept the drift
     command: ghost ack
     prompt: Acknowledge that the current fingerprint no longer matches and record the drift
 ---
 
-# Recipe: Review Code Changes For Design Drift
+# Recipe: Review Code Changes For Experience Drift
 
-**Goal:** combine deterministic gates with advisory design critique.
+**Goal:** combine deterministic gates with advisory product-experience critique.
 
 ## Steps
 
@@ -33,57 +33,55 @@ ghost review --base <ref>
 
 Use the emitted packet as context. It includes:
 
-- `.ghost/patterns.yml`
-- `.ghost/survey.json`
-- optional `.ghost/intent.md`
+- `.ghost/fingerprint.yml`
 - optional `.ghost/checks.yml`
+- open `.ghost/proposals/*.yml`
+- optional accepted decisions when requested with `--include-memory`
 - the diff
 
 ### 3. Write Advisory Findings
 
 Advisory findings are non-blocking unless tied to an active deterministic check.
+Classify each finding as one of:
+
+- `fix`
+- `intentional-divergence`
+- `missing-memory`
+- `experience-gap`
+- `eval-uncertainty`
+
 Each finding must cite:
 
 - diff location
-- `patterns.yml` composition pattern
-- survey evidence
-- `intent.md` when relevant
-- precedent/example
-- repair
+- `fingerprint.yml` memory
+- active check when blocking
+- open proposal when relevant
+- repair or intentional-divergence rationale
 
 Good advisory topics:
 
-- density drift
 - hierarchy mismatch
+- density drift
+- disclosure or recovery gap
 - generic composition
 - awkward action placement
-- surface metaphor mismatch
+- copy or trust-contract mismatch
+- accessibility or responsive obligation drift
 
 Bad advisory topics:
 
-- vague taste objections with no example
-- restating pattern prose without a diff location
+- vague taste objections with no diff location
+- restating fingerprint prose without applying it to the change
 - enforcing a rule that is not in `checks.yml`
 
-### 4. Deterministic gate (CI / programmatic)
+### 4. Propose Durable Memory Later
 
-When a non-interactive caller (CI, another agent, a script) needs a structured
-pass/fail signal — not advisory prose — reach for the `--gate` mode of
-`compare`. It reconciles the current pairwise distance against the recorded
-ack stance in `.ghost-sync.json` and prints a per-dimension verdict
-(`aligned` / `covered` / `reconverging` / `uncovered`).
+If a finding exposes missing or contradictory memory, write a proposal instead
+of silently editing canonical truth. Use:
 
-```bash
-ghost-drift compare <canon> <target> --gate --sync .ghost-sync.json --format json
-```
+- `missing-memory`
+- `intentional-divergence`
+- `experience-gap`
+- `check-candidate`
 
-Exit codes: `0` no uncovered drift, `1` at least one dimension is uncovered
-(or new and unacked), `2` hard error (missing manifest, malformed JSON, N≠2).
-The JSON schema is `ghost.compare.gate/v1` and is safe for programmatic
-consumers to parse.
-
-### 5. Promote Durable Rules Later
-
-If an advisory finding recurs and can be detected deterministically, propose a
-new `ghost.checks/v1` entry. Do not add it to `checks.yml` unless a human
-curator promotes it.
+Humans promote durable memory into `fingerprint.yml` or `checks.yml`.

--- a/packages/ghost/src/skill-bundle/references/survey.md
+++ b/packages/ghost/src/skill-bundle/references/survey.md
@@ -1,293 +1,58 @@
 ---
 name: survey
-description: Scan a target and produce a survey.json — the observed catalogue of design values, with no interpretation.
+description: Use observed repo facts as optional cache material for fingerprint.yml.
 handoffs:
-  - label: Interpret the survey into patterns.yml
-    command: (next stage — interpreter recipe)
-    prompt: Interpret the survey I just wrote into .ghost/patterns.yml
-  - label: Validate the survey
-    command: ghost lint survey.json
-    prompt: Lint the survey I just wrote
+  - label: Author fingerprint patterns
+    skill: patterns
+    prompt: Interpret observed facts into .ghost/fingerprint.yml patterns
+  - label: Capture fingerprint memory
+    skill: capture
+    prompt: Use observed facts to update .ghost/fingerprint.yml
 ---
 
-# Recipe: Survey a target into survey.json
+# Recipe: Survey As Optional Inventory
 
-**Goal:** produce a valid `survey.json` (`ghost.survey/v2`) that catalogues every concrete design value and implemented UI surface the target ships, with structured specs, occurrence counts, and surface evidence. **You are the surveyor, not the interpreter.** Record what is there. Do not assign meaning. Do not write prose. Do not invent.
+`survey.json` is no longer canonical Ghost memory. Use it only when an existing
+workflow or helper command needs a structured inventory of observed values,
+tokens, components, or surfaces.
 
-`survey.json` is the evidence artifact in Fingerprint Capture: resources (`resources.yml`) -> map (`map.md`) -> survey (`survey.json`) -> patterns (`patterns.yml`). The interpreter reads your survey as evidence and writes operational composition grammar. If you skip values or fabricate them here, the package downstream is wrong.
+Canonical memory lives in `.ghost/fingerprint.yml`. A survey can suggest what
+to inspect, but it does not decide what matters.
 
-The survey is an evidence ledger, not prompt context. It should be large enough to justify patterns, checks, and advisory review; the patterns stage decides what becomes generation-facing composition guidance and check candidates.
+## When To Use This
 
-## Pre-requisite
+Use an inventory pass when:
 
-A `map.md` for the target must exist (Phase 0 — see `references/map.md`). It tells you where the design system lives and where implemented UI can be observed — `design_system.entry_files`, `design_system.paths`, `surface_sources`, `feature_areas[].paths`, `composition.styling`, `composition.frameworks`. Without it you waste cycles re-discovering what the topology already specifies. **If `map.md` is missing, stop and run the map stage first.**
+- the repo is large and you need a factual starting point
+- token/component usage is scattered
+- you are migrating an old Ghost bundle
+- you need a temporary cache before writing durable memory
 
-## Survey schema
+Skip it when:
 
-A `survey.json` is `ghost.survey/v2`:
+- the project is new and has little product UI
+- the human already knows the intended product experience
+- the task is to add one small principle, contract, pattern, or check
 
-```json
-{
-  "schema": "ghost.survey/v2",
-  "sources": [{ "target": "...", "commit": "...", "scanned_at": "..." }],
-  "values":     [...],
-  "tokens":     [...],
-  "components": [...],
-  "ui_surfaces": [...]
-}
+## Rules
+
+- Record observed facts, not interpretation.
+- Keep generated output under `.ghost/cache/` unless a legacy command requires
+  `.ghost/survey.json`.
+- Promote only useful, durable conclusions into `fingerprint.yml`.
+- If observation is incomplete, write a proposal instead of pretending the
+  fingerprint is complete.
+
+## Optional Legacy Helpers
+
+The CLI still includes survey helpers for migration and cache workflows:
+
+```bash
+ghost survey summarize .ghost/survey.json
+ghost survey catalog .ghost/survey.json
+ghost survey patterns .ghost/survey.json
 ```
 
-Each row carries an `id` (deterministic SHA-256 prefix you do **not** compute by hand — see Step 7) and a `source` object (denormalize the same source entry you put in `sources[]`). Sections:
-
-- **`values[]`** — every concrete literal that ships in the design language. `kind` is open; recommended values: `color`, `spacing`, `typography`, `radius`, `shadow`, `breakpoint`, `motion`, `layout-primitive`. Other kinds (`z-index`, `opacity`, `cursor`, `gradient`, `iconography`, `aspect-ratio`) get a `value-kind-unknown` warning but are accepted — emit them when they matter.
-- **`tokens[]`** — every named token declared in source (CSS variables, theme keys, design-token entries). Each row has `name`, `alias_chain` (path through any indirection — `["--button-bg", "--color-brand-primary"]` for a two-step chain; `[]` for a leaf defined inline), `resolved_value` (end-of-chain literal), optional `by_theme` for light/dark variants.
-- **`components[]`** — every named component you can confidently identify (registry entries, exported PascalCase components with variants/sizes). Loose schema: `name`, `discovered_via` (`registry.json` / `heuristic` / etc.), optional `variants[]` and `sizes[]`.
-- **`ui_surfaces[]`** — implemented UI specimens the design language can be inferred from. Each row has `name`, `kind` (`route`, `story`, `screen`, `fixture`, `doc-example`, `screenshot`, `source`), `locator`, `renderability` (`rendered`, `screenshot`, `source-only`, `unknown`), `files[]`, optional soft `classification`, and factual `signals`. For net-new component libraries, `story`, `doc-example`, and `fixture` rows are useful demo evidence; do not classify them as product routes/screens.
-
-External libraries (icon sets, primitive collections, motion libs, charting, etc.) are intentionally *not* a survey section. Whether a system uses Radix or hand-rolls primitives doesn't change what its design language *is*. When a library matters to the design language (icon family, font sourcing), surface it in the interpreter stage as prose evidence under the relevant decision dimension instead.
-
-Every row needs `occurrences` (total count across the capture) and (for values) `files_count` (distinct files that contain the value). Optional `usage` breaks down by context: `{className: 30, css_var: 17}`. Optional `role_hypothesis` is a single tentative role tag (`brand-primary`, `surface-elevated`); **leave it empty if you are not sure** — the interpreter does role assignment, not you.
-
-`ui_surfaces[].classification` is a retrieval lens, not design truth. `intent` and `surface_type` are open strings; `density`, `layout_shape`, and `confidence` should be omitted unless evidence is clear. `ui_surfaces[].signals` contains observed facts only: `dominant_components`, `layout_patterns`, `breakpoint_behavior`, `value_refs`, and short factual `notes`.
-
-When a value is observed in the primary source but resolved through a resolver source, keep both pieces of provenance. The row's `source` is where usage was observed; `resolution` is where the concrete meaning came from:
-
-```json
-{
-  "source": { "id": "cash-ios", "role": "primary", "target": "github:squareup/cash-ios", "scanned_at": "..." },
-  "raw": "CashTheme.Color.background",
-  "value": "#ffffff",
-  "resolution": {
-    "status": "resolved",
-    "source_id": "arcade-ios-package",
-    "target": "github:squareup/arcade-ios-package",
-    "symbol": "ArcadeColor.background",
-    "chain": ["CashTheme.Color.background", "ArcadeColor.background"]
-  }
-}
-```
-
-If the resolver is unavailable or the symbol cannot be followed, still record the primary usage as a `tokens[]` row with `resolution.status: "unresolved-external"` and a `symbol` or `message`. Do not invent the concrete value.
-
-## Steps
-
-### 1. Read map.md and orient
-
-Open `map.md`. Note:
-
-- `composition.styling` — Tailwind, CSS modules, styled-components, scss, swift-tokens, etc. Drives your extraction strategy.
-- `composition.frameworks` — react, next, swiftui, compose, …
-- `design_system.entry_files` — start here. These declare the canonical token set.
-- `sources[]` — capture source graph when the target needs upstream packages to resolve symbols. `primary` supplies usage; `resolver` supplies values.
-- `design_system.paths` — directories where the design system lives.
-- `surface_sources.render_strategy` — how implemented UI can be observed.
-- `surface_sources.include` / `.exclude` — globs that bound surface discovery.
-- `feature_areas[].paths` — sampling clusters for implemented surfaces and usage counts.
-
-Decide your extraction strategy from these signals — see Step 2.
-
-## The exhaustiveness rule
-
-Recall is the failure mode and the only one. A survey missing 90% of a section's rows is a failed capture, even if every row that *is* there is well-formed — the interpreter downstream cannot recover what you didn't record.
-
-For every section (`values[]`, `tokens[]`, `components[]`, `ui_surfaces[]`):
-
-1. **Identify the strongest signal in this repo.** Where is this kind of value most reliably declared or used? It will be different in every repo — a manifest, a registry, a barrel export, a CSS declaration block, a naming convention. Use the strongest signal the repo offers.
-2. **Enumerate, don't sample.** If you can count entries from the canonical signal independently, your row count must match. 6 components when the canonical signal lists 100 is a lie.
-3. **Cross-check by a second method when one exists** (e.g., file count by glob vs. enumerated entries vs. import graph). If the two counts disagree by more than ~10%, you're missing entries — investigate before recording.
-4. **Honest absence beats partial truth.** If the section has no canonical signal in this repo, leave the array empty rather than recording a sample. Empty is honest; sampled is misleading.
-
-This applies regardless of dialect. The recipe doesn't tell you what the canonical signal is — it depends on the repo. Your job is to find it and enumerate it.
-
-### 2. Choose your extraction strategy per dialect
-
-**You write your own greps and regexes. There is no pre-built parser.** Adapt to what's actually in the repo:
-
-- **Tailwind (Tailwind v3 / v4 with `@theme`)** — class atoms are important survey evidence. The declared `--spacing-*` / `--text-*` / `--color-*` tokens in `@theme` are only half the picture; the other half is which atoms components actually use, because Tailwind synthesizes most of the rendered scale from the `--spacing` modular base (`p-2` → `padding: calc(var(--spacing) * 2)` → 8px when `--spacing: 0.25rem`). A survey built from declarations alone undercounts spacing/typography/color systematically — see the `## Tailwind class-atom pass` section below.
-- **CSS / SCSS / CSS modules** — `rg -oN '#[0-9a-fA-F]{3,8}\b' -g '*.{css,scss,sass}'` for hex; `rg -oN '\b(rgba?|hsla?|oklch|color)\([^)]+\)' -g '*.{css,scss}'` for color functions; `rg -oN '\b[0-9]+(\.[0-9]+)?(px|rem|em|%|vh|vw|fr|ch|svh|dvh)\b' -g '*.{css,scss}'` for scalars; `rg -oN -- '--[a-z0-9-]+\s*:' -g '*.{css,scss}'` for custom properties.
-- **CSS-in-JS (styled-components, emotion, vanilla-extract)** — same regex set but expand `-g '*.{ts,tsx,js,jsx}'`. Watch for template literals split across lines.
-- **iOS / Swift** — `rg -oN 'Color\([^)]+\)|UIColor\([^)]+\)|\.(red|blue|green|orange|brand[A-Za-z]*)\b' -g '*.swift'` for color sites; `rg -oN '\b[0-9]+(\.[0-9]+)?\b' -g '*.swift' | sort | uniq -c | sort -rn | head -50` for likely scalars (lots of noise; keep top-N by frequency).
-- **Android / Compose** — `rg -oN 'Color\(0x[0-9a-fA-F]+\)|colorResource\(R\.color\.[a-z_]+\)' -g '*.kt'`; same scalar approach.
-- **Token JSON / YAML** — read directly with `cat`/Read tool. Token files are usually small and structured — parse them as data, don't grep.
-
-If the repo mixes dialects (e.g. `swiftui` + `arcade`), run extraction per dialect and merge into one survey.
-
-## Resolver pass for source graphs
-
-For split repos, a local app capture is not complete until symbolic usage has been resolved through the declared resolver sources where possible. This is still an app capture: the primary source decides salience, resolver sources only supply meaning.
-
-Run this pass when `map.md` has `sources[]` with a `resolver` role, or when `design_system.token_source` is `external` / `mixed`.
-
-Procedure:
-
-1. **Scan primary usage first.** Record every local token/symbol/class usage in the primary target with occurrences and files_count. These counts are the only salience signal.
-2. **Open resolver sources.** Read the upstream package/source/build artifact named by `sources[].role: resolver` or `design_system.upstream`. Find the exported token tables, generated Swift/Kotlin/TS accessors, CSS variables, registry metadata, or other symbol definitions.
-3. **Join symbols to definitions.** Follow `CashTheme.color.background → ArcadeColor.background → #ffffff` (or equivalent) as far as source permits. Preserve the chain in `resolution.chain`.
-4. **Emit resolved rows only for observed usage.** If a resolver defines 400 colors and the primary app uses 12, the app survey gets the 12 observed values. Unused resolver inventory belongs in the resolver's own bundle, not the app's.
-5. **Mark gaps honestly.** For unresolved external symbols, emit token rows with `resolution.status: "unresolved-external"` plus `symbol` / `message`; add a scratchpad coverage note with unresolved counts by kind.
-
-Coverage gate: before declaring done, report resolved vs unresolved counts for each resolver-backed kind (color, spacing, typography, radius, shadow). Weak resolver coverage lowers confidence downstream; it is not a reason to fabricate literals.
-
-## Tailwind class-atom pass
-
-For Tailwind targets, the rendered design language lives at the intersection of *declared tokens* (`@theme {}` / `tailwind.config.*`) and *consumed atoms* (`p-2`, `bg-orange-500`, `text-sm` in components). Skipping the atom pass produces a survey where the spacing/typography/color sections look sparse and irregular even though the live UI is on a clean modular grid. **Run this pass for every Tailwind target.**
-
-The atom-to-literal resolver depends on the Tailwind version:
-
-- **Tailwind v4** — atoms resolve through `@theme {}` directives. The spacing scale is *calculated* from `--spacing` (default `0.25rem`): `p-N`, `m-N`, `gap-N`, `w-N`, `h-N`, `space-x-N`, `space-y-N`, `inset-N` all resolve to `N * --spacing`. Type scale lives in `--text-*` keys; colors in `--color-*` keys; radii in `--radius-*` keys. Custom `--spacing-N` declarations override the calculation for that N.
-- **Tailwind v3** — read `theme.spacing` / `theme.colors` / `theme.fontSize` / `theme.borderRadius` from `tailwind.config.{ts,js}`. The defaults (when keys are unset) follow the published v3 scale; pull them from `node_modules/tailwindcss/stubs/config.full.js` or the docs.
-
-Procedure:
-
-1. Grep class atoms across the UI surface: `rg -oN '\b(bg|text|border|fill|stroke|ring|outline|from|to|via|p[lrtbxy]?|m[lrtbxy]?|w|h|gap|space-[xy]|inset(-[xy])?|top|right|bottom|left|rounded(-[lrtb][lr]?)?|shadow|z|opacity)-[a-z0-9.]+(\[[^\]]+\])?' -g '*.{tsx,jsx,ts,js,html,vue,svelte}' | sort | uniq -c | sort -rn`.
-2. Resolve each atom to its literal via the table above. Skip arbitrary-value atoms (`p-[13px]`) — those don't belong to the modular scale; record them separately under `usage: { arbitrary: N }` so the interpreter can flag drift.
-3. Each distinct literal becomes a `values[]` row with `usage.className` set to the atom-occurrence count. Sum across atoms that resolve to the same literal (`p-2` and `gap-2` both → 8px).
-4. Each Tailwind-default token consumed by class atoms also becomes a `tokens[]` row, with `name` set to the canonical key (`--spacing-2`, `--color-orange-500`) and `alias_chain` empty (it's a leaf default).
-
-If a literal is produced *both* by a declared `--spacing-N` token *and* by class-atom usage, merge into one `values[]` row with `usage: { className: N, css_var: M }`. The interpreter reads both signals; the row carries the full picture.
-
-### 3. Run extraction passes — apply the exhaustiveness rule per section
-
-The exhaustiveness rule (above) governs every section. The dialect-specific tactics here are how you implement it for `values[]` and `tokens[]`. For `components[]`, the rule is the same: find the canonical signal in *this* repo and enumerate it.
-
-For values + tokens, sloppy grep undercounts silently. Discipline:
-
-- **Multiple passes per kind.** Don't trust your first regex. After your color pass, run a second pass with a slightly different pattern and check the delta. New rows = your first pass missed.
-- **Cross-check counts.** When you record a row with `occurrences: 47`, run `rg -c '\b#f97316\b' .` against the full repo and verify. If the count differs by more than ~10%, your regex is missing something — refine and re-pass.
-- **Frequency clustering.** After the first sweep, list candidate values by frequency: `rg -oN '#[0-9a-fA-F]{6}' -g '*.css' | sort | uniq -c | sort -rn`. The top values are almost always real palette entries. Long-tail values are often comments, hashes, or test fixtures — verify before recording.
-- **Spread check.** If a value appears in `files_count: 1`, it's likely incidental, not part of the design language. Note the count but don't promote with `role_hypothesis`.
-- **Resolve aliases exhaustively.** Every named token declared in the canonical token source becomes a `tokens[]` row. Don't sample tokens — count the declarations and match the row count. When a token's value is `var(--other)`, follow the chain to the literal; record the **token row** with the chain, and the **value row** for the resolved literal.
-- **Resolve external aliases when the source graph provides resolvers.** Primary usage rows keep `source.role: primary`; upstream definitions appear under `resolution`, not as salience by themselves.
-
-For components:
-
-- **Components are countable.** Count them by whatever signal the repo offers (manifest entries, barrel exports, naming pattern under a known directory). If you can count to 50 and your survey has 6 rows, you've sampled — go back and enumerate.
-
-### 4. Record implemented UI surfaces
-
-Use `surface_sources` and `feature_areas[]` from `map.md` to enumerate representative implemented surfaces. This section is required in `ghost.survey/v2`. If only component demos exist, record them honestly as `story`, `doc-example`, or `fixture` rows. If no implemented or demo surface can be observed, write `ui_surfaces: []`, ensure `map.md` uses `surface_sources.render_strategy: unknown`, and carry the coverage gap in your scratchpad for the interpreter.
-
-Surface rows are evidence, not exemplars and not prose. Record facts that the later patterns authoring pass can cluster:
-
-```json
-{
-  "id": "",
-  "source": { "target": "github:block/ghost", "commit": "abc123", "scanned_at": "2026-04-29T12:00:00Z" },
-  "name": "Account settings",
-  "kind": "route",
-  "locator": "/settings/account",
-  "renderability": "source-only",
-  "files": ["src/routes/settings/account.tsx"],
-  "classification": {
-    "intent": "configure",
-    "surface_type": "settings",
-    "density": "standard",
-    "layout_shape": "control-surface",
-    "confidence": 0.75
-  },
-  "composition": {
-    "anatomy": ["shell", "compact-header", "sectioned-form", "persistent-actions"],
-    "primary_region": "form",
-    "action_placement": ["footer"],
-    "navigation_context": "persistent-shell",
-    "responsive_behavior": ["mobile stacks sections vertically"],
-    "confidence": 0.75
-  },
-  "signals": {
-    "dominant_components": ["Tabs", "Input", "Button"],
-    "layout_patterns": ["sectioned-form", "persistent-actions"],
-    "breakpoint_behavior": ["mobile stacks sections vertically"],
-    "value_refs": ["<value-row-id-after-fix-ids-if-known>"],
-    "notes": ["Compact controls sit inside generous section spacing."]
-  }
-}
-```
-
-Discovery guidance:
-
-- For `browser`, `storybook`, or `docs`, enumerate routes/stories/examples first, then sample the source files that back them.
-- For `native-screenshot`, record the screenshot or fixture locator and the source files when known.
-- For `static-source`, use route files, screens, stories, examples, or feature entrypoints as the observable specimens.
-- Prefer 1–3 high-signal surfaces per feature area. This is not exhaustive in the same way components are; it is coverage of implemented composition families.
-- Keep `signals.notes` and `composition` factual. "Sectioned settings form with persistent action row" is survey evidence. "Feels professional and calm" belongs in `intent.md` only when human-approved.
-
-### 5. Sample feature areas for usage counts
-
-For each `feature_areas[]` entry in `map.md`, walk a few files to measure how the values you found in `entry_files` actually get used. This produces the `occurrences` and `files_count` numbers. Don't sample exhaustively — 3–5 files per feature area is usually enough; the goal is a representative count, not a perfect one.
-
-Update the `usage` breakdown when context matters. Examples: `{className: 30, css_var: 17}` for a hex used in both Tailwind classes and CSS variables; `{token-resolution: 1, inline: 46}` for a hex defined once and copy-pasted everywhere (a smell worth flagging via `role_hypothesis: "ad-hoc"` or similar).
-
-### 6. Write rows with empty IDs
-
-Build the survey file. For every row, leave `id` as an empty string `""`. You don't compute SHA-256 hashes by hand. Example value row:
-
-```json
-{
-  "id": "",
-  "source": { "target": "github:block/ghost", "commit": "abc123", "scanned_at": "2026-04-29T12:00:00Z" },
-  "kind": "color",
-  "value": "#f97316",
-  "raw": "bg-orange-500",
-  "spec": { "space": "srgb", "hex": "#f97316" },
-  "occurrences": 47,
-  "files_count": 12,
-  "usage": { "className": 30, "css_var": 17 }
-}
-```
-
-Same shape per token, component, and UI-surface row, just different content fields. **Every row gets the same `source` object** (denormalized so the row survives merges with its origin attribution). Fill `sources[]` at the top of the survey with the same single source.
-
-### 7. Populate IDs
-
-Run:
-
-    ghost survey fix-ids survey.json -o survey.json
-
-This recomputes every row's `id` from its content fields. Idempotent — running it again does nothing.
-
-### 8. Validate
-
-    ghost lint survey.json
-
-Fix everything `lint` flags as an error. Warnings (unknown `kind`, `id-mismatch` if you skipped Step 7, etc.) are signals — investigate them, but they don't block.
-
-### 9. Coverage check (gate before declaring done)
-
-Before declaring the survey done, walk each section and confirm exhaustiveness:
-
-- **`components[]`** — what's the canonical signal in this repo? Count it independently. If your row count is below that count, you've under-recorded. Either add the missing rows or, if the section truly isn't enumerable here, leave the array empty.
-- **`ui_surfaces[]`** — compare rows against `surface_sources` and `feature_areas[]`. Every major implemented surface family should have at least one row, or the coverage gap should be explicit.
-- **Readiness** — after validation, run `ghost scan --format json`. If readiness is `substrate-only`, the survey can support token/component/value guidance but not product composition. If readiness is `component-demo`, story/doc/example evidence can support component anatomy and demo composition, not product flow or hierarchy.
-- **`tokens[]`** — count the named-token declarations in the canonical token source(s) named in `map.md`. Your row count should match.
-- **`values[]`** — frequency-cluster again with a fresh grep. New top-N entries that aren't in your survey = missed.
-  For resolver-backed captures, also check unresolved symbols by kind; top unresolved symbols should either be resolved or explicitly surfaced as coverage gaps.
-The survey is **saturated** when another exhaustiveness pass adds fewer than ~2 new rows across all sections AND your component/token row counts match (or come very close to) an independent count of the canonical signal. If exhaustiveness disagrees with what you have, exhaustiveness wins — re-pass.
-
-Hard stop conditions:
-
-- ~100 files read total, OR
-- ~20 minutes wall, OR
-- ~200k tokens consumed.
-
-If you hit a hard stop with exhaustiveness *not* met, write a `# Coverage` note in your scratchpad listing exactly which sections fall short and by how much. Surface it to the interpreter — it tells them which decisions are well-grounded and which aren't. **Do not pad the survey with sampled rows to look exhaustive.**
-
-## Always
-
-- Use `survey.json` as the canonical filename.
-- Every value/token row carries `source`, `occurrences`, and (for values) `files_count`.
-- Every UI-surface row carries `source`, `name`, `kind`, `locator`, `renderability`, `files`, and factual `signals`.
-- Resolve token alias chains end-to-end. The `alias_chain` array captures the path.
-- Validate with `ghost lint survey.json` before declaring success.
-- After authoring rows with empty IDs, run `survey fix-ids` exactly once.
-- **Cross-check your component and token counts against an independent count of the canonical signal in this repo.** Disagreement = re-pass.
-
-## Never
-
-- **Never write prose.** No `description`, no rationale fields. Factual UI-surface notes are okay; interpretation prose is the interpreter's job.
-- **Never invent values.** If you didn't observe it in source, it doesn't go in the survey.
-- **Never sample.** Either enumerate exhaustively or leave the section empty. A survey with 6 components when the canonical signal has 100 is worse than no `components[]` at all.
-- **Never assign roles confidently.** `role_hypothesis` is a *hint*, optional, and tentative. The interpreter has the final word. If you're not sure, leave it empty.
-- **Never undercount silently.** If your coverage is weak (mobile dialects, custom DSLs, no canonical signal in this repo), surface it in a `# Coverage` scratchpad note and tell the interpreter.
-- **Never compute IDs by hand.** Use `survey fix-ids`.
-- **Never use placeholder/glob names.** A component row with `name: "*Button"` or `name: "<various>"` is sampling-disguised-as-a-row. Enumerate concretely.
-- **Never edit a survey after the interpreter has used it.** If you find a missed value later, re-run survey end-to-end. Treat the survey used for `patterns.yml` as frozen evidence.
+Treat their output as draft material. Curate it into `principles`,
+`experience_contracts`, `patterns`, or `substrate` in `fingerprint.yml` before
+using it for generation or review.

--- a/packages/ghost/src/skill-bundle/references/verify.md
+++ b/packages/ghost/src/skill-bundle/references/verify.md
@@ -1,20 +1,20 @@
 ---
 name: verify
-description: Confirm generated UI stays within the local Ghost fingerprint bundle; iterate if not.
+description: Confirm generated UI stays within .ghost/fingerprint.yml; iterate if not.
 handoffs:
   - label: Remediate deterministic or advisory findings
     skill: remediate
-    prompt: Given the verify findings, suggest minimal token/code changes that close the drift
+    prompt: Given the verify findings, suggest minimal code changes that close the drift
 ---
 
 # Recipe: Verify Generated UI
 
-**Goal:** run the generate → check → review → repair loop against `.ghost/`.
+**Goal:** run the generate -> check -> review -> repair loop against `.ghost/`.
 
 ## Steps
 
-1. Generate the UI using `.ghost/patterns.yml`, `.ghost/survey.json`,
-   optional `.ghost/intent.md`, nearest examples, and active checks as context.
+1. Generate the UI from a brief grounded in `.ghost/fingerprint.yml`,
+   `.ghost/checks.yml`, open proposals, nearest examples, and human context.
 2. Run the deterministic gate:
 
    ```bash
@@ -29,6 +29,9 @@ handoffs:
    ```
 
 5. Repair high-confidence advisory issues when they cite a diff location,
-   `patterns.yml` composition pattern, survey evidence, precedent/example, and repair.
+   fingerprint memory, and a concrete repair.
+6. If the review exposes missing or contradictory memory, record a proposal
+   instead of rewriting `fingerprint.yml` during verification.
 
-Patterns and optional intent shape judgment. Only active `checks.yml` failures block.
+Only active `checks.yml` failures block. Advisory findings guide judgment and
+may become proposals when they reveal durable memory gaps.


### PR DESCRIPTION
🤖 Draft stack PR opened by my AI agent.

## Summary
- Rewrites the Ghost skill bundle references around `.ghost/fingerprint.yml` workflows.
- Updates capture, promote, recall, remediate, schema, and survey guidance for the canonical package.
- Keeps agent-facing recipes aligned with the command and review surfaces below this point in the stack.

## Impact
Installed Ghost skills will teach agents the new fingerprint YAML memory flow instead of sending them back through legacy map/survey/pattern files.

## Stack
- Branch stack position: 7 of 11
- PR stack position: 6 of 10
- Base: `codex/fingerprint-self-healing-proposals`
- Head: `codex/fingerprint-skill-docs-reset`
- Previous PR: #92

## Validation
- `/opt/homebrew/bin/pnpm build`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm check`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm test` (493 tests passed)