### PR TITLE
[codex] Emit context bundles from fingerprint yml

### DIFF
--- a/.changeset/fingerprint-context-bundle.md
+++ b/.changeset/fingerprint-context-bundle.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": major
+---
+
+Emit package context bundles from fingerprint.yml memory by default.

--- a/apps/docs/src/generated/cli-manifest.json
+++ b/apps/docs/src/generated/cli-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-24T20:39:47.948Z",
+  "generatedAt": "2026-05-25T03:08:24.462Z",
   "tools": [
     {
       "tool": "ghost",
@@ -53,7 +53,7 @@
             {
               "rawName": "--root <dir>",
               "name": "root",
-              "description": "Optional target root used to resolve resources.yml local paths (default: cwd)",
+              "description": "Optional target root used to resolve fingerprint.yml evidence paths (default: cwd)",
               "default": null,
               "takesValue": true,
               "negated": false
@@ -180,7 +180,7 @@
             {
               "rawName": "-f, --fingerprint <path>",
               "name": "fingerprint",
-              "description": "Source legacy direct fingerprint markdown file (required for review-command; optional legacy mode for context-bundle)",
+              "description": "Source legacy direct fingerprint markdown file (required for review-command; legacy mode for context-bundle)",
               "default": null,
               "takesValue": true,
               "negated": false
@@ -204,7 +204,7 @@
             {
               "rawName": "--no-tokens",
               "name": "tokens",
-              "description": "Skip tokens.css output (legacy direct fingerprint context-bundle)",
+              "description": "Skip tokens.css output (legacy direct fingerprint context-bundle only)",
               "default": true,
               "takesValue": false,
               "negated": true
@@ -228,7 +228,7 @@
             {
               "rawName": "--name <name>",
               "name": "name",
-              "description": "Override the skill name (default: package or fingerprint id) (context-bundle)",
+              "description": "Override the skill name (default: fingerprint.yml product or fingerprint id) (context-bundle)",
               "default": null,
               "takesValue": true,
               "negated": false

--- a/packages/ghost/src/scan-emit-command.ts
+++ b/packages/ghost/src/scan-emit-command.ts
@@ -41,7 +41,7 @@ export function registerEmitCommand(cli: CAC): void {
     )
     .option(
       "-f, --fingerprint <path>",
-      "Source legacy direct fingerprint markdown file (required for review-command; optional legacy mode for context-bundle)",
+      "Source legacy direct fingerprint markdown file (required for review-command; legacy mode for context-bundle)",
     )
     .option(
       "-o, --out <path>",
@@ -54,13 +54,13 @@ export function registerEmitCommand(cli: CAC): void {
     // context-bundle flags:
     .option(
       "--no-tokens",
-      "Skip tokens.css output (legacy direct fingerprint context-bundle)",
+      "Skip tokens.css output (legacy direct fingerprint context-bundle only)",
     )
     .option("--readme", "Include README.md (context-bundle)")
     .option("--prompt-only", "Emit only prompt.md (context-bundle)")
     .option(
       "--name <name>",
-      "Override the skill name (default: package or fingerprint id) (context-bundle)",
+      "Override the skill name (default: fingerprint.yml product or first scope) (context-bundle)",
     )
     .action(async (kind: string, opts) => {
       try {

--- a/packages/ghost/src/scan/context/package-writer.ts
+++ b/packages/ghost/src/scan/context/package-writer.ts
@@ -1,18 +1,19 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import type { Dirent } from "node:fs";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
-  formatSurveySummaryMarkdown,
-  lintSurvey,
-  type Survey,
-  summarizeSurvey,
+  type GhostFingerprintDocument,
+  type GhostProposalDocument,
+  lintGhostFingerprint,
+  lintGhostProposal,
 } from "#ghost-core";
 import type { FingerprintPackagePaths } from "../fingerprint-package.js";
 import type { WriteContextResult } from "./writer.js";
 
 export interface WritePackageContextOptions {
   outDir: string;
-  /** Override the skill/package name. Default: resources.yml id. */
+  /** Override the skill/package name. Default: fingerprint.yml summary product. */
   name?: string;
   /** Emit only prompt.md. Default: false. */
   promptOnly?: boolean;
@@ -22,12 +23,11 @@ export interface WritePackageContextOptions {
 
 interface PackageContext {
   name: string;
-  resources: string;
-  map: string;
-  surveySummary: string;
-  patterns: string;
+  fingerprint: GhostFingerprintDocument;
+  fingerprintRaw: string;
   checks?: string;
   intent?: string;
+  openProposals: GhostProposalDocument[];
 }
 
 export async function writePackageContextBundle(
@@ -53,24 +53,19 @@ export async function writePackageContextBundle(
   await writeContextFile(
     options.outDir,
     files,
-    "resources.yml",
-    context.resources,
-  );
-  await writeContextFile(options.outDir, files, "map.md", context.map);
-  await writeContextFile(
-    options.outDir,
-    files,
-    "survey-summary.md",
-    context.surveySummary,
-  );
-  await writeContextFile(
-    options.outDir,
-    files,
-    "patterns.yml",
-    context.patterns,
+    "fingerprint.yml",
+    context.fingerprintRaw,
   );
   if (context.checks) {
     await writeContextFile(options.outDir, files, "checks.yml", context.checks);
+  }
+  if (context.openProposals.length > 0) {
+    await writeContextFile(
+      options.outDir,
+      files,
+      "open-proposals.md",
+      formatOpenProposals(context.openProposals),
+    );
   }
   if (context.intent) {
     await writeContextFile(options.outDir, files, "intent.md", context.intent);
@@ -91,43 +86,75 @@ async function loadPackageContext(
   paths: FingerprintPackagePaths,
   nameOverride?: string,
 ): Promise<PackageContext> {
-  const [resources, map, surveyRaw, patterns, checks, intent] =
-    await Promise.all([
-      readFile(paths.resources, "utf-8"),
-      readFile(paths.map, "utf-8"),
-      readFile(paths.survey, "utf-8"),
-      readFile(paths.patterns, "utf-8"),
-      readOptional(paths.checks),
-      readOptional(paths.intent),
-    ]);
+  const [fingerprintRaw, checks, intent, openProposals] = await Promise.all([
+    readFile(paths.fingerprintYml, "utf-8"),
+    readOptional(paths.checks),
+    readOptional(paths.intent),
+    readOpenProposals(paths.proposals),
+  ]);
 
-  const survey = parseSurvey(surveyRaw);
-  const report = lintSurvey(survey);
+  const parsed = parseYamlSafe(fingerprintRaw, "fingerprint.yml");
+  const report = lintGhostFingerprint(parsed);
   if (report.errors > 0) {
+    const first = report.issues.find((issue) => issue.severity === "error");
+    const suffix = first?.path ? ` @ ${first.path}` : "";
     throw new Error(
-      `survey.json failed lint with ${report.errors} error(s); fix before emitting a context bundle.`,
+      `fingerprint.yml failed lint with ${report.errors} error(s): ${
+        first?.message ?? "invalid fingerprint"
+      }${suffix}`,
     );
   }
 
+  const fingerprint = parsed as GhostFingerprintDocument;
   return {
-    name: sanitizeName(nameOverride ?? inferPackageName(resources, map)),
-    resources,
-    map,
-    surveySummary: formatSurveySummaryMarkdown(
-      summarizeSurvey(survey, { budget: "compact" }),
-    ),
-    patterns,
+    name: sanitizeName(nameOverride ?? inferPackageName(fingerprint)),
+    fingerprint,
+    fingerprintRaw,
     checks,
     intent,
+    openProposals,
   };
 }
 
-function parseSurvey(raw: string): Survey {
+async function readOpenProposals(
+  dirPath: string,
+): Promise<GhostProposalDocument[]> {
+  let entries: Dirent[];
   try {
-    return JSON.parse(raw) as Survey;
+    entries = await readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const proposals: GhostProposalDocument[] = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isFile()) continue;
+    if (entry.name.startsWith(".")) continue;
+    if (!/\.ya?ml$/i.test(entry.name)) continue;
+
+    const path = resolve(dirPath, entry.name);
+    const parsed = parseYamlSafe(await readFile(path, "utf-8"), path);
+    const report = lintGhostProposal(parsed);
+    if (report.errors > 0) {
+      const first = report.issues.find((issue) => issue.severity === "error");
+      const suffix = first?.path ? ` @ ${first.path}` : "";
+      throw new Error(
+        `${path} failed proposal lint: ${first?.message ?? "invalid proposal"}${suffix}`,
+      );
+    }
+    const proposal = parsed as GhostProposalDocument;
+    if (proposal.status === "open") proposals.push(proposal);
+  }
+
+  return proposals;
+}
+
+function parseYamlSafe(raw: string, label: string): unknown {
+  try {
+    return parseYaml(raw);
   } catch (err) {
     throw new Error(
-      `survey.json is not valid JSON: ${
+      `${label} is not valid YAML: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
@@ -153,33 +180,11 @@ async function writeContextFile(
   files.push(outPath);
 }
 
-function inferPackageName(resources: string, map: string): string {
-  const fromResources = parseYamlSafe(resources);
-  if (isRecord(fromResources) && typeof fromResources.id === "string") {
-    return fromResources.id;
-  }
-
-  const frontmatter = map.match(/^---\n([\s\S]*?)\n---/)?.[1];
-  if (frontmatter) {
-    const fromMap = parseYamlSafe(frontmatter);
-    if (isRecord(fromMap) && typeof fromMap.id === "string") {
-      return fromMap.id;
-    }
-  }
-
+function inferPackageName(fingerprint: GhostFingerprintDocument): string {
+  if (fingerprint.summary.product) return fingerprint.summary.product;
+  const firstScope = fingerprint.topology.scopes?.[0]?.id;
+  if (firstScope) return firstScope;
   return "ghost-package";
-}
-
-function parseYamlSafe(raw: string): unknown {
-  try {
-    return parseYaml(raw);
-  } catch {
-    return undefined;
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function sanitizeName(value: string): string {
@@ -193,81 +198,97 @@ function sanitizeName(value: string): string {
 function buildPackageSkillMd(context: PackageContext): string {
   return `---
 name: ${context.name}
-description: Use this root Ghost fingerprint package to preserve design identity during UI generation and review.
+description: Use this Ghost product-experience memory to preserve on-brand UI generation and review.
 user-invocable: true
 ---
 
-This skill grounds work in the **${context.name}** root Ghost fingerprint package.
+This skill grounds work in the **${context.name}** Ghost fingerprint.
 
 Read the files in this order:
 
-1. \`intent.md\` when present - human-approved direction.
-2. \`map.md\` - topology, scopes, surface families, and routing.
-3. \`patterns.yml\` - operational composition grammar backed by survey evidence.
-4. \`checks.yml\` when present - deterministic gates or proposed gates.
-5. \`survey-summary.md\` - compact evidence digest from \`survey.json\`.
-6. \`resources.yml\` - what counted as source evidence.
+1. \`fingerprint.yml\` - canonical product-experience memory.
+2. \`checks.yml\` when present - deterministic gates; only \`active\` checks block.
+3. \`open-proposals.md\` when present - unresolved missing memory, intentional divergences, experience gaps, or check candidates.
+4. \`intent.md\` when present - supplemental human-approved context.
 
-When generating or reviewing UI, identify the map scope and surface type first,
-then apply matching composition patterns. Treat survey rows as evidence, not
-taste. Treat checks as gates only when their status is \`active\`; proposed
-checks are advisory until promoted by a human.
+When generating or reviewing UI, select the relevant situation, principles,
+experience contracts, patterns, and substrate from \`fingerprint.yml\`. Treat
+proposals as unresolved context, not canonical truth.
 `;
 }
 
 function buildPackagePromptMd(context: PackageContext): string {
   const parts = [
-    `You are working inside the **${context.name}** design language as captured by a root Ghost fingerprint package.`,
+    `You are working inside the **${context.name}** product experience as captured by Ghost.`,
   ];
 
-  if (context.intent?.trim()) {
-    parts.push(`# Intent\n\n${context.intent.trim()}`);
+  parts.push(`# Fingerprint Memory
+
+\`\`\`yaml
+${context.fingerprintRaw.trim()}
+\`\`\``);
+
+  if (context.checks?.trim()) {
+    parts.push(`# Active Checks
+
+\`\`\`yaml
+${context.checks.trim()}
+\`\`\``);
   }
 
-  parts.push(`# Use The Package
+  if (context.openProposals.length > 0) {
+    parts.push(formatOpenProposals(context.openProposals));
+  }
 
-- Start with \`map.md\` to route the task to scopes, surface families, and examples.
-- Use \`patterns.yml\` for composition decisions; cite evidence when reviewing.
-- Use \`checks.yml\` for deterministic gates. Only \`active\` checks block.
-- Use \`survey-summary.md\` for observed tokens, values, components, and surfaces.
-- Use \`resources.yml\` to understand what evidence was included or excluded.
-- Do not invent tokens, components, or surface patterns when the package provides an observed option.`);
+  if (context.intent?.trim()) {
+    parts.push(`# Human Context
 
-  parts.push(`# Package Files
+\`\`\`markdown
+${context.intent.trim()}
+\`\`\``);
+  }
 
-- \`resources.yml\`
-- \`map.md\`
-- \`survey-summary.md\`
-- \`patterns.yml\`
-${context.checks ? "- `checks.yml`\n" : ""}${context.intent ? "- `intent.md`\n" : ""}`);
+  parts.push(`# Use This Context
 
-  parts.push(`# Review Posture
-
-Before calling drift, classify the changed file by \`map.md\` scope. For UI
-generation, preserve matching \`patterns.yml\` anatomy and prefer values from
-the survey's token/value digest. If a divergence is intentional, name it in the
-package rather than hiding it in generated UI.`);
+- Select the relevant situation before generating or reviewing UI.
+- Preserve applicable principles, experience contracts, patterns, and substrate.
+- Only active checks are blocking.
+- Treat open proposals as unresolved context that may explain gaps or intentional divergence.
+- If the task exposes missing or contradictory memory, propose a \`missing-memory\`, \`intentional-divergence\`, \`experience-gap\`, or \`check-candidate\` update instead of rewriting canonical memory silently.`);
 
   return `${parts.join("\n\n")}\n`;
+}
+
+function formatOpenProposals(proposals: GhostProposalDocument[]): string {
+  const lines = ["# Open Proposals", ""];
+  for (const proposal of proposals) {
+    lines.push(`## ${proposal.title}`);
+    lines.push("");
+    lines.push(`- **ID:** \`${proposal.id}\``);
+    lines.push(`- **Kind:** ${proposal.kind}`);
+    lines.push(`- **Target:** ${proposal.proposed_action.target}`);
+    lines.push(`- **Claim:** ${proposal.claim}`);
+    lines.push(`- **Rationale:** ${proposal.rationale}`);
+    lines.push(`- **Proposed action:** ${proposal.proposed_action.summary}`);
+    lines.push("");
+  }
+  return lines.join("\n");
 }
 
 function buildPackageReadmeMd(context: PackageContext): string {
   return `# ${context.name} context bundle
 
-Generated by \`ghost emit context-bundle\` from a root Ghost
-fingerprint package.
+Generated by \`ghost emit context-bundle\` from a root Ghost fingerprint
+package.
 
 ## Files
 
 - \`SKILL.md\` - agent skill manifest.
-- \`prompt.md\` - portable prompt distilled from the package.
-- \`resources.yml\` - evidence sources.
-- \`map.md\` - topology and routing.
-- \`survey-summary.md\` - compact survey evidence.
-- \`patterns.yml\` - composition grammar.
-${context.checks ? "- `checks.yml` - deterministic gates and proposed gates.\n" : ""}${context.intent ? "- `intent.md` - human-approved direction.\n" : ""}
-The full \`survey.json\` stays in the source package by default because it can
-be large; regenerate this bundle when the survey changes.
+- \`prompt.md\` - portable prompt distilled from \`fingerprint.yml\`.
+- \`fingerprint.yml\` - canonical product-experience memory.
+${context.checks ? "- `checks.yml` - deterministic gates.\n" : ""}${context.openProposals.length > 0 ? "- `open-proposals.md` - unresolved candidate memory updates.\n" : ""}${context.intent ? "- `intent.md` - supplemental human-approved context.\n" : ""}
+Regenerate this bundle when \`fingerprint.yml\`, active checks, or open
+proposals change.
 `;
 }
 

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -354,6 +354,14 @@ describe("ghost CLI", () => {
     expect(reviewCommand.stdout).toContain("design-review.md");
     expect(contextBundle.code).toBe(0);
     expect(contextBundle.stdout).toContain("prompt.md");
+    expect(contextBundle.stdout).toContain("fingerprint.yml");
+    expect(contextBundle.stdout).not.toContain("survey-summary.md");
+    await expect(
+      readFile(join(dir, "ghost-context", "fingerprint.yml"), "utf-8"),
+    ).resolves.toContain("schema: ghost.fingerprint/v1");
+    await expect(
+      readFile(join(dir, "ghost-context", "prompt.md"), "utf-8"),
+    ).resolves.toContain("Fingerprint Memory");
   });
 
   it("installs the unified ghost skill bundle", async () => {


### PR DESCRIPTION
🤖 Draft stack PR opened by my AI agent.

## Summary
- Adds context-bundle emission backed by fingerprint YAML memory.
- Updates package context assembly and writer behavior for canonical fingerprint packages.
- Covers the new emit path in CLI/docs/tests.

## Impact
Host agents can request deterministic context bundles from the canonical `.ghost/fingerprint.yml` memory package.

## Stack
- Branch stack position: 8 of 11
- PR stack position: 7 of 10
- Base: `codex/fingerprint-skill-docs-reset`
- Head: `codex/fingerprint-context-bundle`
- Previous PR: #93

## Validation
- `/opt/homebrew/bin/pnpm build`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm check`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm test` (493 tests passed)