### PR TITLE
[codex] Emit review commands from fingerprint yml

### DIFF
--- a/.changeset/fingerprint-review-command.md
+++ b/.changeset/fingerprint-review-command.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": major
+---
+
+Emit review commands from fingerprint.yml memory by default.

--- a/apps/docs/src/generated/cli-manifest.json
+++ b/apps/docs/src/generated/cli-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-25T03:08:24.462Z",
+  "generatedAt": "2026-05-25T03:16:23.560Z",
   "tools": [
     {
       "tool": "ghost",
@@ -180,7 +180,7 @@
             {
               "rawName": "-f, --fingerprint <path>",
               "name": "fingerprint",
-              "description": "Source legacy direct fingerprint markdown file (required for review-command; legacy mode for context-bundle)",
+              "description": "Source legacy direct fingerprint markdown file (legacy mode for review-command/context-bundle)",
               "default": null,
               "takesValue": true,
               "negated": false
@@ -228,7 +228,7 @@
             {
               "rawName": "--name <name>",
               "name": "name",
-              "description": "Override the skill name (default: fingerprint.yml product or fingerprint id) (context-bundle)",
+              "description": "Override the skill name (default: fingerprint.yml product or first scope) (context-bundle)",
               "default": null,
               "takesValue": true,
               "negated": false

--- a/packages/ghost/src/scan-emit-command.ts
+++ b/packages/ghost/src/scan-emit-command.ts
@@ -2,8 +2,10 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import type { CAC } from "cac";
 import {
+  emitPackageReviewCommand,
   emitReviewCommand,
   loadFingerprint,
+  loadPackageMemory,
   resolveFingerprintPackage,
   writeContextBundle,
   writePackageContextBundle,
@@ -41,7 +43,7 @@ export function registerEmitCommand(cli: CAC): void {
     )
     .option(
       "-f, --fingerprint <path>",
-      "Source legacy direct fingerprint markdown file (required for review-command; legacy mode for context-bundle)",
+      "Source legacy direct fingerprint markdown file (legacy mode for review-command/context-bundle)",
     )
     .option(
       "-o, --out <path>",
@@ -72,19 +74,26 @@ export function registerEmitCommand(cli: CAC): void {
         }
 
         const explicitFingerprint = typeof opts.fingerprint === "string";
+        const packagePaths = resolveFingerprintPackage(
+          undefined,
+          process.cwd(),
+        );
 
         if (parsed.kind === "review-command") {
-          const fingerprintPath = resolve(
-            process.cwd(),
-            opts.fingerprint ??
-              resolveFingerprintPackage(undefined, process.cwd()).fingerprint,
-          );
-          const loaded = await loadFingerprint(fingerprintPath, {
-            noEmbeddingBackfill: true,
-          });
-          const content = emitReviewCommand({
-            fingerprint: loaded.fingerprint,
-          });
+          let content: string;
+          if (explicitFingerprint) {
+            const loaded = await loadFingerprint(
+              resolve(process.cwd(), opts.fingerprint),
+              {
+                noEmbeddingBackfill: true,
+              },
+            );
+            content = emitReviewCommand({ fingerprint: loaded.fingerprint });
+          } else {
+            content = emitPackageReviewCommand({
+              memory: await loadPackageMemory(packagePaths),
+            });
+          }
 
           if (opts.stdout) {
             process.stdout.write(content);
@@ -110,15 +119,12 @@ export function registerEmitCommand(cli: CAC): void {
         );
 
         if (!explicitFingerprint) {
-          const result = await writePackageContextBundle(
-            resolveFingerprintPackage(undefined, process.cwd()),
-            {
-              outDir,
-              readme: Boolean(opts.readme),
-              promptOnly: Boolean(opts.promptOnly),
-              name: opts.name as string | undefined,
-            },
-          );
+          const result = await writePackageContextBundle(packagePaths, {
+            outDir,
+            readme: Boolean(opts.readme),
+            promptOnly: Boolean(opts.promptOnly),
+            name: opts.name as string | undefined,
+          });
 
           process.stdout.write(
             `Wrote ${result.files.length} file${

--- a/packages/ghost/src/scan/context/index.ts
+++ b/packages/ghost/src/scan/context/index.ts
@@ -1,3 +1,7 @@
+export type { PackageMemory } from "./package-memory.js";
+export { loadPackageMemory } from "./package-memory.js";
+export type { EmitPackageReviewInput } from "./package-review-command.js";
+export { emitPackageReviewCommand } from "./package-review-command.js";
 export type { WritePackageContextOptions } from "./package-writer.js";
 export { writePackageContextBundle } from "./package-writer.js";
 export type { EmitReviewInput } from "./review-command.js";

--- a/packages/ghost/src/scan/context/package-memory.ts
+++ b/packages/ghost/src/scan/context/package-memory.ts
@@ -1,0 +1,167 @@
+import type { Dirent } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import {
+  type GhostChecksDocument,
+  GhostChecksSchema,
+  type GhostFingerprintDocument,
+  GhostFingerprintSchema,
+  type GhostProposalDocument,
+  GhostProposalSchema,
+  lintGhostChecks,
+  lintGhostFingerprint,
+  lintGhostProposal,
+} from "#ghost-core";
+import type { FingerprintPackagePaths } from "../fingerprint-package.js";
+
+export interface PackageMemory {
+  name: string;
+  fingerprint: GhostFingerprintDocument;
+  fingerprintRaw: string;
+  checks?: GhostChecksDocument;
+  checksRaw?: string;
+  intent?: string;
+  openProposals: GhostProposalDocument[];
+}
+
+export async function loadPackageMemory(
+  paths: FingerprintPackagePaths,
+  nameOverride?: string,
+): Promise<PackageMemory> {
+  const [fingerprintRaw, checksRaw, intent, openProposals] = await Promise.all([
+    readFile(paths.fingerprintYml, "utf-8"),
+    readOptional(paths.checks),
+    readOptional(paths.intent),
+    readOpenProposals(paths.proposals),
+  ]);
+
+  const fingerprint = parseFingerprint(fingerprintRaw);
+  const checks = checksRaw ? parseChecks(checksRaw, fingerprint) : undefined;
+  return {
+    name: sanitizeName(nameOverride ?? inferPackageName(fingerprint)),
+    fingerprint,
+    fingerprintRaw,
+    checks,
+    checksRaw,
+    intent,
+    openProposals,
+  };
+}
+
+function parseFingerprint(raw: string): GhostFingerprintDocument {
+  const parsed = parseYamlSafe(raw, "fingerprint.yml");
+  const report = lintGhostFingerprint(parsed);
+  if (report.errors > 0) {
+    const first = report.issues.find((issue) => issue.severity === "error");
+    const suffix = first?.path ? ` @ ${first.path}` : "";
+    throw new Error(
+      `fingerprint.yml failed lint with ${report.errors} error(s): ${
+        first?.message ?? "invalid fingerprint"
+      }${suffix}`,
+    );
+  }
+
+  const result = GhostFingerprintSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error("fingerprint.yml failed schema validation.");
+  }
+  return result.data as GhostFingerprintDocument;
+}
+
+function parseChecks(
+  raw: string,
+  fingerprint: GhostFingerprintDocument,
+): GhostChecksDocument {
+  const parsed = parseYamlSafe(raw, "checks.yml");
+  const report = lintGhostChecks(parsed, { fingerprint });
+  if (report.errors > 0) {
+    const first = report.issues.find((issue) => issue.severity === "error");
+    const suffix = first?.path ? ` @ ${first.path}` : "";
+    throw new Error(
+      `checks.yml failed lint with ${report.errors} error(s): ${
+        first?.message ?? "invalid checks"
+      }${suffix}`,
+    );
+  }
+
+  const result = GhostChecksSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error("checks.yml failed schema validation.");
+  }
+  return result.data as GhostChecksDocument;
+}
+
+async function readOpenProposals(
+  dirPath: string,
+): Promise<GhostProposalDocument[]> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const proposals: GhostProposalDocument[] = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isFile()) continue;
+    if (entry.name.startsWith(".")) continue;
+    if (!/\.ya?ml$/i.test(entry.name)) continue;
+
+    const path = resolve(dirPath, entry.name);
+    const parsed = parseYamlSafe(await readFile(path, "utf-8"), path);
+    const report = lintGhostProposal(parsed);
+    if (report.errors > 0) {
+      const first = report.issues.find((issue) => issue.severity === "error");
+      const suffix = first?.path ? ` @ ${first.path}` : "";
+      throw new Error(
+        `${path} failed proposal lint: ${first?.message ?? "invalid proposal"}${suffix}`,
+      );
+    }
+
+    const result = GhostProposalSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(`${path} failed proposal schema validation.`);
+    }
+
+    const proposal = result.data as GhostProposalDocument;
+    if (proposal.status === "open") proposals.push(proposal);
+  }
+
+  return proposals;
+}
+
+function parseYamlSafe(raw: string, label: string): unknown {
+  try {
+    return parseYaml(raw);
+  } catch (err) {
+    throw new Error(
+      `${label} is not valid YAML: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+async function readOptional(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+function inferPackageName(fingerprint: GhostFingerprintDocument): string {
+  if (fingerprint.summary.product) return fingerprint.summary.product;
+  const firstScope = fingerprint.topology.scopes?.[0]?.id;
+  if (firstScope) return firstScope;
+  return "ghost-package";
+}
+
+function sanitizeName(value: string): string {
+  const name = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return name || "ghost-package";
+}

--- a/packages/ghost/src/scan/context/package-review-command.ts
+++ b/packages/ghost/src/scan/context/package-review-command.ts
@@ -1,0 +1,285 @@
+import type {
+  GhostCheck,
+  GhostFingerprintExperienceContract,
+  GhostFingerprintPattern,
+  GhostFingerprintPrinciple,
+  GhostFingerprintSituation,
+} from "#ghost-core";
+import type { PackageMemory } from "./package-memory.js";
+
+export interface EmitPackageReviewInput {
+  memory: PackageMemory;
+}
+
+const REVIEW_FINDING_CATEGORIES = [
+  "fix",
+  "intentional-divergence",
+  "missing-memory",
+  "experience-gap",
+  "eval-uncertainty",
+] as const;
+
+const REVIEW_PROPOSAL_TYPES = [
+  "missing-memory",
+  "intentional-divergence",
+  "experience-gap",
+  "check-candidate",
+] as const;
+
+/**
+ * Emit a repo-local slash command from fingerprint.yml memory.
+ *
+ * The command stays intentionally light: it tells the host agent which Ghost
+ * files and CLI packets to use, then includes a compact accepted-memory index.
+ * Full canonical truth remains in .ghost/fingerprint.yml and checks.yml.
+ */
+export function emitPackageReviewCommand(
+  input: EmitPackageReviewInput,
+): string {
+  const { memory } = input;
+  const product = memory.fingerprint.summary.product ?? memory.name;
+  const activeChecks =
+    memory.checks?.checks.filter((check) => check.status === "active") ?? [];
+  const parts = [
+    packageFrontmatter(product),
+    `# ${product} Ghost review`,
+    packageModeSection(),
+    packageWorkflowSection(),
+    packageFindingPolicySection(),
+    packageMemoryIndex(memory),
+    packageChecksSection(activeChecks),
+    packageProposalSection(memory),
+    packageReviewFooter(memory),
+  ];
+  return `${parts.filter(Boolean).join("\n\n").trim()}\n`;
+}
+
+function packageFrontmatter(product: string): string {
+  return `---
+description: Ghost product-experience review for ${product} - grounded in fingerprint.yml memory
+---`;
+}
+
+function packageModeSection(): string {
+  return `## Mode
+
+If \`$ARGUMENTS\` is provided, review that file, path, or diff range. If it is empty, inspect the current working-tree or PR diff first, then choose the relevant changed surfaces.`;
+}
+
+function packageWorkflowSection(): string {
+  return `## Review Workflow
+
+1. Read \`.ghost/fingerprint.yml\` as the canonical product-experience memory.
+2. Select the relevant situation before judging UI, copy, flow, disclosure, recovery, trust, accessibility, or interaction behavior.
+3. Apply accepted principles, experience contracts, patterns, and substrate. Treat proposed or deprecated memory as non-canonical unless the user explicitly asks to explore it.
+4. Run \`ghost check\` when a diff is available. Active checks are deterministic and can block.
+5. Run \`ghost review --include-memory\` for the advisory packet when you need full diff context, open proposals, and accepted decisions.
+6. Cite the diff location, fingerprint.yml memory, any active check, and any relevant open proposal for every finding.`;
+}
+
+function packageFindingPolicySection(): string {
+  return `## Finding Policy
+
+Use these categories: ${REVIEW_FINDING_CATEGORIES.map((category) => `\`${category}\``).join(", ")}.
+
+Only findings backed by an active check should be treated as blocking. Everything else is advisory product-experience critique.
+
+If the diff reveals missing or contradictory memory, report \`missing-memory\` or \`experience-gap\` and propose one of: ${REVIEW_PROPOSAL_TYPES.map((kind) => `\`${kind}\``).join(", ")}. Do not silently rewrite \`.ghost/fingerprint.yml\`, \`.ghost/checks.yml\`, or proposal files.`;
+}
+
+function packageMemoryIndex(memory: PackageMemory): string {
+  const { fingerprint } = memory;
+  const summary = formatSummary(memory);
+  const situations = formatSituations(fingerprint.situations);
+  const principles = formatPrinciples(fingerprint.principles);
+  const contracts = formatExperienceContracts(fingerprint.experience_contracts);
+  const patterns = formatPatterns(fingerprint.patterns);
+  const substrate = formatSubstrate(memory);
+
+  return `## Fingerprint Memory Index
+
+${summary}
+
+${situations}
+
+${principles}
+
+${contracts}
+
+${patterns}
+
+${substrate}`;
+}
+
+function formatSummary(memory: PackageMemory): string {
+  const { summary, topology } = memory.fingerprint;
+  const lines = ["### Summary"];
+  lines.push(`- Product: ${summary.product ?? memory.name}`);
+  pushJoined(lines, "Audience", summary.audience);
+  pushJoined(lines, "Goals", summary.goals);
+  pushJoined(lines, "Anti-goals", summary.anti_goals);
+  pushJoined(lines, "Tradeoffs", summary.tradeoffs);
+  pushJoined(lines, "Tone", summary.tone);
+  if (topology.scopes?.length) {
+    lines.push(
+      `- Scopes: ${topology.scopes
+        .map((scope) => `\`${scope.id}\``)
+        .join(", ")}`,
+    );
+  }
+  if (topology.surface_types?.length) {
+    lines.push(
+      `- Surface types: ${topology.surface_types
+        .map((surface) => `\`${surface}\``)
+        .join(", ")}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function formatSituations(situations: GhostFingerprintSituation[]): string {
+  if (situations.length === 0) {
+    return "### Situations\n- No situations recorded yet. Treat unclear obligations as `missing-memory`.";
+  }
+  const lines = ["### Situations"];
+  for (const situation of situations.slice(0, 8)) {
+    const label = situation.title ?? situation.id;
+    const detail =
+      situation.product_obligation ??
+      situation.user_intent ??
+      situation.surface_type ??
+      "select when relevant";
+    lines.push(`- \`${situation.id}\` - ${label}: ${detail}`);
+  }
+  return lines.join("\n");
+}
+
+function formatPrinciples(principles: GhostFingerprintPrinciple[]): string {
+  const accepted = principles.filter((entry) => entry.status === "accepted");
+  if (accepted.length === 0) {
+    return "### Principles\n- No accepted principles recorded yet.";
+  }
+  const lines = ["### Principles"];
+  for (const principle of accepted.slice(0, 10)) {
+    lines.push(`- \`${principle.id}\` - ${principle.principle}`);
+    for (const guidance of principle.guidance ?? []) {
+      lines.push(`  - ${guidance}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatExperienceContracts(
+  contracts: GhostFingerprintExperienceContract[],
+): string {
+  const accepted = contracts.filter((entry) => entry.status === "accepted");
+  if (accepted.length === 0) {
+    return "### Experience Contracts\n- No accepted experience contracts recorded yet.";
+  }
+  const lines = ["### Experience Contracts"];
+  for (const contract of accepted.slice(0, 10)) {
+    lines.push(`- \`${contract.id}\` - ${contract.contract}`);
+    for (const obligation of contract.obligations ?? []) {
+      lines.push(`  - ${obligation}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatPatterns(patterns: GhostFingerprintPattern[]): string {
+  const accepted = patterns.filter((entry) => entry.status === "accepted");
+  if (accepted.length === 0) {
+    return "### Patterns\n- No accepted patterns recorded yet.";
+  }
+  const lines = ["### Patterns"];
+  for (const pattern of accepted.slice(0, 12)) {
+    lines.push(`- \`${pattern.id}\` (${pattern.kind}) - ${pattern.pattern}`);
+    for (const guidance of pattern.guidance ?? []) {
+      lines.push(`  - ${guidance}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatSubstrate(memory: PackageMemory): string {
+  const { substrate } = memory.fingerprint;
+  const lines = ["### Substrate"];
+  pushJoined(lines, "Tokens", substrate.tokens, { code: true });
+  pushJoined(lines, "Components", substrate.components, { code: true });
+  pushJoined(lines, "Accessibility", substrate.accessibility);
+  pushJoined(lines, "Responsive", substrate.responsive);
+  if (lines.length === 1) {
+    lines.push("- No substrate recorded yet.");
+  }
+  return lines.join("\n");
+}
+
+function packageChecksSection(activeChecks: GhostCheck[]): string {
+  if (activeChecks.length === 0) {
+    return `## Active Checks
+
+No active checks are recorded. Review remains advisory unless \`.ghost/checks.yml\` adds deterministic active checks.`;
+  }
+  const lines = ["## Active Checks", ""];
+  for (const check of activeChecks.slice(0, 12)) {
+    const derives = check.derives_from ? ` from \`${check.derives_from}\`` : "";
+    lines.push(
+      `- \`${check.id}\` (${check.severity})${derives}: ${check.title}`,
+    );
+    if (check.repair) lines.push(`  - Repair: ${check.repair}`);
+  }
+  if (activeChecks.length > 12) {
+    lines.push(
+      `- ${activeChecks.length - 12} more active check(s); read \`.ghost/checks.yml\` before deciding whether a finding blocks.`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function packageProposalSection(memory: PackageMemory): string {
+  const { openProposals, fingerprint } = memory;
+  const policy = fingerprint.review_policy;
+  const lines = ["## Open Memory Gaps"];
+  if (openProposals.length === 0) {
+    lines.push("- No open proposals recorded.");
+  } else {
+    for (const proposal of openProposals.slice(0, 8)) {
+      lines.push(
+        `- \`${proposal.id}\` (${proposal.kind}): ${proposal.claim} Proposed action: ${proposal.proposed_action.summary}`,
+      );
+    }
+    if (openProposals.length > 8) {
+      lines.push(
+        `- ${openProposals.length - 8} more open proposal(s); read \`.ghost/proposals/\` before judging related drift.`,
+      );
+    }
+  }
+  pushJoined(lines, "Proposal policy", policy.proposal_policy);
+  pushJoined(
+    lines,
+    "Experience-gap categories",
+    policy.experience_gap_categories,
+    { code: true },
+  );
+  pushJoined(lines, "Memory-gap policy", policy.memory_gap_policy);
+  return lines.join("\n");
+}
+
+function packageReviewFooter(memory: PackageMemory): string {
+  return `---
+
+Generated from \`.ghost/fingerprint.yml\` for ${memory.name}. Re-run \`ghost emit review-command\` after updating fingerprint.yml, checks.yml, or open proposals.`;
+}
+
+function pushJoined(
+  lines: string[],
+  label: string,
+  values: string[] | undefined,
+  options: { code?: boolean } = {},
+): void {
+  if (!values?.length) return;
+  const formatted = values.map((value) =>
+    options.code ? `\`${value}\`` : value,
+  );
+  lines.push(`- ${label}: ${formatted.join(", ")}`);
+}

--- a/packages/ghost/src/scan/context/package-writer.ts
+++ b/packages/ghost/src/scan/context/package-writer.ts
@@ -1,14 +1,8 @@
-import type { Dirent } from "node:fs";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
-import { parse as parseYaml } from "yaml";
-import {
-  type GhostFingerprintDocument,
-  type GhostProposalDocument,
-  lintGhostFingerprint,
-  lintGhostProposal,
-} from "#ghost-core";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { GhostProposalDocument } from "#ghost-core";
 import type { FingerprintPackagePaths } from "../fingerprint-package.js";
+import { loadPackageMemory, type PackageMemory } from "./package-memory.js";
 import type { WriteContextResult } from "./writer.js";
 
 export interface WritePackageContextOptions {
@@ -21,20 +15,11 @@ export interface WritePackageContextOptions {
   readme?: boolean;
 }
 
-interface PackageContext {
-  name: string;
-  fingerprint: GhostFingerprintDocument;
-  fingerprintRaw: string;
-  checks?: string;
-  intent?: string;
-  openProposals: GhostProposalDocument[];
-}
-
 export async function writePackageContextBundle(
   paths: FingerprintPackagePaths,
   options: WritePackageContextOptions,
 ): Promise<WriteContextResult> {
-  const context = await loadPackageContext(paths, options.name);
+  const context = await loadPackageMemory(paths, options.name);
   await mkdir(options.outDir, { recursive: true });
   const files: string[] = [];
 
@@ -56,8 +41,13 @@ export async function writePackageContextBundle(
     "fingerprint.yml",
     context.fingerprintRaw,
   );
-  if (context.checks) {
-    await writeContextFile(options.outDir, files, "checks.yml", context.checks);
+  if (context.checksRaw) {
+    await writeContextFile(
+      options.outDir,
+      files,
+      "checks.yml",
+      context.checksRaw,
+    );
   }
   if (context.openProposals.length > 0) {
     await writeContextFile(
@@ -82,93 +72,6 @@ export async function writePackageContextBundle(
   return { outDir: options.outDir, files };
 }
 
-async function loadPackageContext(
-  paths: FingerprintPackagePaths,
-  nameOverride?: string,
-): Promise<PackageContext> {
-  const [fingerprintRaw, checks, intent, openProposals] = await Promise.all([
-    readFile(paths.fingerprintYml, "utf-8"),
-    readOptional(paths.checks),
-    readOptional(paths.intent),
-    readOpenProposals(paths.proposals),
-  ]);
-
-  const parsed = parseYamlSafe(fingerprintRaw, "fingerprint.yml");
-  const report = lintGhostFingerprint(parsed);
-  if (report.errors > 0) {
-    const first = report.issues.find((issue) => issue.severity === "error");
-    const suffix = first?.path ? ` @ ${first.path}` : "";
-    throw new Error(
-      `fingerprint.yml failed lint with ${report.errors} error(s): ${
-        first?.message ?? "invalid fingerprint"
-      }${suffix}`,
-    );
-  }
-
-  const fingerprint = parsed as GhostFingerprintDocument;
-  return {
-    name: sanitizeName(nameOverride ?? inferPackageName(fingerprint)),
-    fingerprint,
-    fingerprintRaw,
-    checks,
-    intent,
-    openProposals,
-  };
-}
-
-async function readOpenProposals(
-  dirPath: string,
-): Promise<GhostProposalDocument[]> {
-  let entries: Dirent[];
-  try {
-    entries = await readdir(dirPath, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-
-  const proposals: GhostProposalDocument[] = [];
-  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (!entry.isFile()) continue;
-    if (entry.name.startsWith(".")) continue;
-    if (!/\.ya?ml$/i.test(entry.name)) continue;
-
-    const path = resolve(dirPath, entry.name);
-    const parsed = parseYamlSafe(await readFile(path, "utf-8"), path);
-    const report = lintGhostProposal(parsed);
-    if (report.errors > 0) {
-      const first = report.issues.find((issue) => issue.severity === "error");
-      const suffix = first?.path ? ` @ ${first.path}` : "";
-      throw new Error(
-        `${path} failed proposal lint: ${first?.message ?? "invalid proposal"}${suffix}`,
-      );
-    }
-    const proposal = parsed as GhostProposalDocument;
-    if (proposal.status === "open") proposals.push(proposal);
-  }
-
-  return proposals;
-}
-
-function parseYamlSafe(raw: string, label: string): unknown {
-  try {
-    return parseYaml(raw);
-  } catch (err) {
-    throw new Error(
-      `${label} is not valid YAML: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-}
-
-async function readOptional(path: string): Promise<string | undefined> {
-  try {
-    return await readFile(path, "utf-8");
-  } catch {
-    return undefined;
-  }
-}
-
 async function writeContextFile(
   outDir: string,
   files: string[],
@@ -180,22 +83,7 @@ async function writeContextFile(
   files.push(outPath);
 }
 
-function inferPackageName(fingerprint: GhostFingerprintDocument): string {
-  if (fingerprint.summary.product) return fingerprint.summary.product;
-  const firstScope = fingerprint.topology.scopes?.[0]?.id;
-  if (firstScope) return firstScope;
-  return "ghost-package";
-}
-
-function sanitizeName(value: string): string {
-  const name = value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
-  return name || "ghost-package";
-}
-
-function buildPackageSkillMd(context: PackageContext): string {
+function buildPackageSkillMd(context: PackageMemory): string {
   return `---
 name: ${context.name}
 description: Use this Ghost product-experience memory to preserve on-brand UI generation and review.
@@ -217,7 +105,7 @@ proposals as unresolved context, not canonical truth.
 `;
 }
 
-function buildPackagePromptMd(context: PackageContext): string {
+function buildPackagePromptMd(context: PackageMemory): string {
   const parts = [
     `You are working inside the **${context.name}** product experience as captured by Ghost.`,
   ];
@@ -228,11 +116,11 @@ function buildPackagePromptMd(context: PackageContext): string {
 ${context.fingerprintRaw.trim()}
 \`\`\``);
 
-  if (context.checks?.trim()) {
+  if (context.checksRaw?.trim()) {
     parts.push(`# Active Checks
 
 \`\`\`yaml
-${context.checks.trim()}
+${context.checksRaw.trim()}
 \`\`\``);
   }
 
@@ -275,7 +163,7 @@ function formatOpenProposals(proposals: GhostProposalDocument[]): string {
   return lines.join("\n");
 }
 
-function buildPackageReadmeMd(context: PackageContext): string {
+function buildPackageReadmeMd(context: PackageMemory): string {
   return `# ${context.name} context bundle
 
 Generated by \`ghost emit context-bundle\` from a root Ghost fingerprint
@@ -286,7 +174,7 @@ package.
 - \`SKILL.md\` - agent skill manifest.
 - \`prompt.md\` - portable prompt distilled from \`fingerprint.yml\`.
 - \`fingerprint.yml\` - canonical product-experience memory.
-${context.checks ? "- `checks.yml` - deterministic gates.\n" : ""}${context.openProposals.length > 0 ? "- `open-proposals.md` - unresolved candidate memory updates.\n" : ""}${context.intent ? "- `intent.md` - supplemental human-approved context.\n" : ""}
+${context.checksRaw ? "- `checks.yml` - deterministic gates.\n" : ""}${context.openProposals.length > 0 ? "- `open-proposals.md` - unresolved candidate memory updates.\n" : ""}${context.intent ? "- `intent.md` - supplemental human-approved context.\n" : ""}
 Regenerate this bundle when \`fingerprint.yml\`, active checks, or open
 proposals change.
 `;

--- a/packages/ghost/src/scan/index.ts
+++ b/packages/ghost/src/scan/index.ts
@@ -34,7 +34,9 @@ export {
 // --- Context (review-command + context-bundle) ---
 export type {
   ContextFormat,
+  EmitPackageReviewInput,
   EmitReviewInput,
+  PackageMemory,
   WriteContextOptions,
   WriteContextResult,
   WritePackageContextOptions,
@@ -42,7 +44,9 @@ export type {
 export {
   buildSkillMd,
   buildTokensCss,
+  emitPackageReviewCommand,
   emitReviewCommand,
+  loadPackageMemory,
   writeContextBundle,
   writePackageContextBundle,
 } from "./context/index.js";

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -352,6 +352,16 @@ describe("ghost CLI", () => {
 
     expect(reviewCommand.code).toBe(0);
     expect(reviewCommand.stdout).toContain("design-review.md");
+    const emittedReviewCommand = await readFile(
+      join(dir, ".claude", "commands", "design-review.md"),
+      "utf-8",
+    );
+    expect(emittedReviewCommand).toContain("fingerprint.yml memory");
+    expect(emittedReviewCommand).toContain("experience-gap");
+    expect(emittedReviewCommand).toContain("no-hardcoded-ui-color");
+    expect(emittedReviewCommand).not.toContain(
+      "Generated from `fingerprint.md`",
+    );
     expect(contextBundle.code).toBe(0);
     expect(contextBundle.stdout).toContain("prompt.md");
     expect(contextBundle.stdout).toContain("fingerprint.yml");

--- a/scripts/check-file-sizes.mjs
+++ b/scripts/check-file-sizes.mjs
@@ -16,9 +16,9 @@ const EXCEPTIONS = {
       "Unified CLI command registry — review/check/compare plus drift stance verbs live together for one public bin",
   },
   "packages/ghost/src/scan-commands.ts": {
-    limit: 1050,
+    limit: 1100,
     justification:
-      "Scan and fingerprint bundle command registry — one unified CLI groups init, scan, lint, verify, survey, describe, diff, and emit verbs",
+      "Scan and fingerprint bundle command registry — temporarily holds legacy markdown and fingerprint.yml package verbs until the command registry is split",
   },
   "packages/ghost/src/scan/inventory.ts": {
     limit: 1120,


### PR DESCRIPTION
🤖 Draft stack PR opened by my AI agent.

## Summary
- Adds review-command emission backed by fingerprint YAML memory.
- Updates review command packet assembly and generated CLI/docs references.
- Adds tests for the new deterministic review command path.

## Impact
Agents can ask Ghost for review-ready command context directly from canonical fingerprint memory, matching the context bundle path introduced just below this PR.

## Stack
- Branch stack position: 9 of 11
- PR stack position: 8 of 10
- Base: `codex/fingerprint-context-bundle`
- Head: `codex/fingerprint-review-command`
- Previous PR: #94

## Validation
- `/opt/homebrew/bin/pnpm build`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm check`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm test` (493 tests passed)