### PR TITLE
[codex] Validate fingerprint topology routing

### DIFF
--- a/.changeset/strong-surface-topology-lint.md
+++ b/.changeset/strong-surface-topology-lint.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Validate fingerprint scopes, surface types, and check routing targets against canonical topology memory.

--- a/.ghost/checks.yml
+++ b/.ghost/checks.yml
@@ -32,8 +32,6 @@ checks:
     applies_to:
       scopes:
         - docs-site
-      pattern_ids:
-        - component-catalogue-shell
     detector:
       type: required-regex
       pattern: 'font-display'

--- a/packages/ghost/src/ghost-core/checks/lint.ts
+++ b/packages/ghost/src/ghost-core/checks/lint.ts
@@ -73,6 +73,7 @@ function checkOne(
   const path = `checks[${index}]`;
   checkDetector(check, path, issues);
   checkGrounding(check, path, options, issues);
+  checkAppliesToTargets(check, path, options, issues);
 
   if (check.status === "disabled") return;
 
@@ -147,6 +148,48 @@ function checkOne(
   }
 }
 
+function checkAppliesToTargets(
+  check: GhostCheck,
+  path: string,
+  options: GhostChecksLintOptions,
+  issues: GhostChecksLintIssue[],
+): void {
+  if (!check.applies_to || !options.fingerprint) return;
+
+  const severity = check.status === "active" ? "error" : "warning";
+  const targets = collectFingerprintRoutingTargets(options.fingerprint);
+
+  check.applies_to.scopes?.forEach((scope, scopeIndex) => {
+    if (targets.scopes.has(scope)) return;
+    issues.push({
+      severity,
+      rule: "check-scope-unknown",
+      message: `Check references unknown fingerprint scope '${scope}'.`,
+      path: `${path}.applies_to.scopes[${scopeIndex}]`,
+    });
+  });
+
+  check.applies_to.surface_types?.forEach((surfaceType, surfaceIndex) => {
+    if (targets.surfaceTypes.has(surfaceType)) return;
+    issues.push({
+      severity,
+      rule: "check-surface-type-unknown",
+      message: `Check references unknown fingerprint surface type '${surfaceType}'.`,
+      path: `${path}.applies_to.surface_types[${surfaceIndex}]`,
+    });
+  });
+
+  check.applies_to.pattern_ids?.forEach((patternId, patternIndex) => {
+    if (targets.patterns.has(patternId)) return;
+    issues.push({
+      severity,
+      rule: "check-pattern-unknown",
+      message: `Check references unknown fingerprint pattern '${patternId}'.`,
+      path: `${path}.applies_to.pattern_ids[${patternIndex}]`,
+    });
+  });
+}
+
 function checkGrounding(
   check: GhostCheck,
   path: string,
@@ -178,6 +221,28 @@ function checkGrounding(
     message: `Check derives_from references unknown fingerprint memory '${check.derives_from}'.`,
     path: `${path}.derives_from`,
   });
+}
+
+function collectFingerprintRoutingTargets(
+  fingerprint: NonNullable<GhostChecksLintOptions["fingerprint"]>,
+): {
+  scopes: Set<string>;
+  surfaceTypes: Set<string>;
+  patterns: Set<string>;
+} {
+  const surfaceTypes = new Set(fingerprint.topology.surface_types ?? []);
+  for (const scope of fingerprint.topology.scopes ?? []) {
+    for (const surfaceType of scope.surface_types ?? []) {
+      surfaceTypes.add(surfaceType);
+    }
+  }
+  return {
+    scopes: new Set(
+      fingerprint.topology.scopes?.map((entry) => entry.id) ?? [],
+    ),
+    surfaceTypes,
+    patterns: new Set(fingerprint.patterns.map((entry) => entry.id)),
+  };
 }
 
 function parseGroundingRef(

--- a/packages/ghost/src/ghost-core/fingerprint/lint.ts
+++ b/packages/ghost/src/ghost-core/fingerprint/lint.ts
@@ -29,10 +29,16 @@ export function lintGhostFingerprint(
 
   const doc = result.data as GhostFingerprintDocument;
   checkDuplicateIds("topology.scopes", doc.topology.scopes ?? [], issues);
+  checkDuplicateStrings(
+    "topology.surface_types",
+    doc.topology.surface_types ?? [],
+    issues,
+  );
   checkDuplicateIds("situations", doc.situations, issues);
   checkDuplicateIds("principles", doc.principles, issues);
   checkDuplicateIds("experience_contracts", doc.experience_contracts, issues);
   checkDuplicateIds("patterns", doc.patterns, issues);
+  checkTopologyRefs(doc, issues);
   checkRefs(doc, issues);
 
   return finalize(issues);
@@ -56,6 +62,94 @@ function checkDuplicateIds(
     } else {
       seen.set(entry.id, index);
     }
+  });
+}
+
+function checkDuplicateStrings(
+  collectionPath: string,
+  entries: string[],
+  issues: GhostFingerprintLintIssue[],
+): void {
+  const seen = new Map<string, number>();
+  entries.forEach((entry, index) => {
+    const previous = seen.get(entry);
+    if (previous !== undefined) {
+      issues.push({
+        severity: "error",
+        rule: "duplicate-id",
+        message: `'${entry}' is duplicated (also at ${collectionPath}[${previous}])`,
+        path: `${collectionPath}[${index}]`,
+      });
+    } else {
+      seen.set(entry, index);
+    }
+  });
+}
+
+function checkTopologyRefs(
+  doc: GhostFingerprintDocument,
+  issues: GhostFingerprintLintIssue[],
+): void {
+  const topology = collectTopology(doc);
+
+  doc.topology.scopes?.forEach((scope, scopeIndex) => {
+    scope.surface_types?.forEach((surfaceType, surfaceIndex) => {
+      if (
+        topology.explicitSurfaceTypes.size === 0 ||
+        topology.explicitSurfaceTypes.has(surfaceType)
+      ) {
+        return;
+      }
+      issues.push({
+        severity: "error",
+        rule: "fingerprint-surface-type-unknown",
+        message: `Surface type '${surfaceType}' is not declared in topology.surface_types.`,
+        path: `topology.scopes[${scopeIndex}].surface_types[${surfaceIndex}]`,
+      });
+    });
+  });
+
+  doc.topology.examples?.forEach((example, exampleIndex) => {
+    checkSurfaceTypeRef(
+      example.surface_type,
+      `topology.examples[${exampleIndex}].surface_type`,
+      topology,
+      issues,
+    );
+  });
+
+  doc.situations.forEach((situation, situationIndex) => {
+    checkSurfaceTypeRef(
+      situation.surface_type,
+      `situations[${situationIndex}].surface_type`,
+      topology,
+      issues,
+    );
+  });
+
+  doc.principles.forEach((principle, index) => {
+    checkScopeRefs(
+      principle.applies_to,
+      `principles[${index}].applies_to`,
+      topology,
+      issues,
+    );
+  });
+  doc.experience_contracts.forEach((contract, index) => {
+    checkScopeRefs(
+      contract.applies_to,
+      `experience_contracts[${index}].applies_to`,
+      topology,
+      issues,
+    );
+  });
+  doc.patterns.forEach((pattern, index) => {
+    checkScopeRefs(
+      pattern.applies_to,
+      `patterns[${index}].applies_to`,
+      topology,
+      issues,
+    );
   });
 }
 
@@ -104,6 +198,84 @@ function checkRefs(
   });
   doc.patterns.forEach((pattern, index) => {
     checkCheckRefs(pattern.check_refs, `patterns[${index}].check_refs`, issues);
+  });
+}
+
+function collectTopology(doc: GhostFingerprintDocument): {
+  scopes: Set<string>;
+  explicitSurfaceTypes: Set<string>;
+  surfaceTypes: Set<string>;
+  situations: Set<string>;
+} {
+  const explicitSurfaceTypes = new Set(doc.topology.surface_types ?? []);
+  const surfaceTypes = new Set(explicitSurfaceTypes);
+  for (const scope of doc.topology.scopes ?? []) {
+    for (const surfaceType of scope.surface_types ?? []) {
+      surfaceTypes.add(surfaceType);
+    }
+  }
+  return {
+    scopes: new Set(doc.topology.scopes?.map((entry) => entry.id) ?? []),
+    explicitSurfaceTypes,
+    surfaceTypes,
+    situations: new Set(doc.situations.map((entry) => entry.id)),
+  };
+}
+
+function checkSurfaceTypeRef(
+  surfaceType: string | undefined,
+  path: string,
+  topology: ReturnType<typeof collectTopology>,
+  issues: GhostFingerprintLintIssue[],
+): void {
+  if (!surfaceType) return;
+  if (topology.surfaceTypes.has(surfaceType)) return;
+  issues.push({
+    severity: "error",
+    rule: "fingerprint-surface-type-unknown",
+    message: `Surface type '${surfaceType}' is not declared in topology.surface_types.`,
+    path,
+  });
+}
+
+function checkScopeRefs(
+  scope:
+    | {
+        scopes?: string[];
+        surface_types?: string[];
+        situations?: string[];
+      }
+    | undefined,
+  path: string,
+  topology: ReturnType<typeof collectTopology>,
+  issues: GhostFingerprintLintIssue[],
+): void {
+  scope?.scopes?.forEach((scopeId, index) => {
+    if (topology.scopes.has(scopeId)) return;
+    issues.push({
+      severity: "error",
+      rule: "fingerprint-scope-unknown",
+      message: `Scope '${scopeId}' is not declared in topology.scopes.`,
+      path: `${path}.scopes[${index}]`,
+    });
+  });
+  scope?.surface_types?.forEach((surfaceType, index) => {
+    if (topology.surfaceTypes.has(surfaceType)) return;
+    issues.push({
+      severity: "error",
+      rule: "fingerprint-surface-type-unknown",
+      message: `Surface type '${surfaceType}' is not declared in topology.surface_types.`,
+      path: `${path}.surface_types[${index}]`,
+    });
+  });
+  scope?.situations?.forEach((situation, index) => {
+    if (topology.situations.has(situation)) return;
+    issues.push({
+      severity: "error",
+      rule: "fingerprint-situation-unknown",
+      message: `Situation '${situation}' is not declared in situations.`,
+      path: `${path}.situations[${index}]`,
+    });
   });
 }
 

--- a/packages/ghost/test/checks-grounding.test.ts
+++ b/packages/ghost/test/checks-grounding.test.ts
@@ -31,6 +31,43 @@ describe("ghost.checks/v1 grounding", () => {
     expect(report.warnings).toBe(0);
   });
 
+  it("accepts active checks scoped to known fingerprint topology", () => {
+    const report = lintGhostChecks(
+      checksDocument({
+        applies_to: {
+          scopes: ["lending"],
+          surface_types: ["native-feature"],
+          pattern_ids: ["tokenized-ui-color"],
+        },
+      }),
+      {
+        fingerprint: fingerprintDocument({
+          topology: {
+            scopes: [
+              {
+                id: "lending",
+                paths: ["Code/Features/Lending"],
+                surface_types: ["native-feature"],
+              },
+            ],
+            surface_types: ["native-feature"],
+          },
+          patterns: [
+            {
+              id: "tokenized-ui-color",
+              status: "accepted",
+              kind: "visual",
+              pattern: "Use semantic colors.",
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(report.errors).toBe(0);
+    expect(report.warnings).toBe(0);
+  });
+
   it("reports active checks grounded in missing fingerprint.yml memory", () => {
     const doc = checksDocument({
       derives_from: "principle:missing-principle",
@@ -44,6 +81,78 @@ describe("ghost.checks/v1 grounding", () => {
     expect(report.issues[0]).toMatchObject({
       rule: "check-grounding-unknown",
       path: "checks[0].derives_from",
+    });
+  });
+
+  it("reports active checks scoped to unknown fingerprint targets", () => {
+    const report = lintGhostChecks(
+      checksDocument({
+        applies_to: {
+          scopes: ["unknown-scope"],
+          surface_types: ["unknown-surface"],
+          pattern_ids: ["unknown-pattern"],
+        },
+      }),
+      {
+        fingerprint: fingerprintDocument({
+          topology: {
+            scopes: [
+              {
+                id: "lending",
+                paths: ["Code/Features/Lending"],
+                surface_types: ["native-feature"],
+              },
+            ],
+            surface_types: ["native-feature"],
+          },
+          patterns: [
+            {
+              id: "tokenized-ui-color",
+              status: "accepted",
+              kind: "visual",
+              pattern: "Use semantic colors.",
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(report.errors).toBe(3);
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: "check-scope-unknown",
+          path: "checks[0].applies_to.scopes[0]",
+        }),
+        expect.objectContaining({
+          rule: "check-surface-type-unknown",
+          path: "checks[0].applies_to.surface_types[0]",
+        }),
+        expect.objectContaining({
+          rule: "check-pattern-unknown",
+          path: "checks[0].applies_to.pattern_ids[0]",
+        }),
+      ]),
+    );
+  });
+
+  it("downgrades proposed check target misses to warnings", () => {
+    const report = lintGhostChecks(
+      checksDocument({
+        status: "proposed",
+        applies_to: {
+          scopes: ["unknown-scope"],
+        },
+      }),
+      {
+        fingerprint: fingerprintDocument(),
+      },
+    );
+
+    expect(report.errors).toBe(0);
+    expect(report.warnings).toBe(1);
+    expect(report.issues[0]).toMatchObject({
+      rule: "check-scope-unknown",
     });
   });
 
@@ -118,7 +227,9 @@ function checksDocument(
   };
 }
 
-function fingerprintDocument(): GhostFingerprintDocument {
+function fingerprintDocument(
+  overrides: Partial<GhostFingerprintDocument> = {},
+): GhostFingerprintDocument {
   return {
     schema: GHOST_FINGERPRINT_SCHEMA,
     summary: {},
@@ -136,5 +247,6 @@ function fingerprintDocument(): GhostFingerprintDocument {
     patterns: [],
     implementation_vocabulary: {},
     review_policy: {},
+    ...overrides,
   };
 }

--- a/packages/ghost/test/fingerprint-yml-schema.test.ts
+++ b/packages/ghost/test/fingerprint-yml-schema.test.ts
@@ -80,6 +80,53 @@ describe("ghost.fingerprint/v1", () => {
     });
   });
 
+  it("reports duplicate topology surface types", () => {
+    const input = fullFingerprint();
+    input.topology.surface_types.push("dense-dashboard");
+
+    const report = lintGhostFingerprint(input);
+
+    expect(report.errors).toBe(1);
+    expect(report.issues[0]).toMatchObject({
+      rule: "duplicate-id",
+      path: "topology.surface_types[2]",
+    });
+  });
+
+  it("reports unknown topology scope and surface type references", () => {
+    const input = fullFingerprint();
+    input.situations[0].surface_type = "unknown-surface";
+    input.principles[0].applies_to = {
+      scopes: ["unknown-scope"],
+      surface_types: ["unknown-surface"],
+      situations: ["unknown-situation"],
+    };
+
+    const report = lintGhostFingerprint(input);
+
+    expect(report.errors).toBe(4);
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: "fingerprint-surface-type-unknown",
+          path: "situations[0].surface_type",
+        }),
+        expect.objectContaining({
+          rule: "fingerprint-scope-unknown",
+          path: "principles[0].applies_to.scopes[0]",
+        }),
+        expect.objectContaining({
+          rule: "fingerprint-surface-type-unknown",
+          path: "principles[0].applies_to.surface_types[0]",
+        }),
+        expect.objectContaining({
+          rule: "fingerprint-situation-unknown",
+          path: "principles[0].applies_to.situations[0]",
+        }),
+      ]),
+    );
+  });
+
   it("requires check refs to use check:*", () => {
     const input = fullFingerprint();
     input.principles[0].check_refs = ["pattern:compact-filter-toolbar"];


### PR DESCRIPTION
🤖 Draft stack PR opened by my AI agent.

## Summary
- Validates fingerprint topology routing references for scopes, surface types, and situations.
- Validates check `applies_to` routing targets against fingerprint scopes, surface types, and pattern IDs.
- Adds tests for duplicate topology surface types, unknown fingerprint references, active check failures, and proposed-check warnings.
- Adds a patch changeset for the public package validation behavior.

## Impact
Fingerprint memory and deterministic checks now fail earlier when they route through stale or misspelled topology IDs, keeping review/check packets grounded in canonical `.ghost/fingerprint.yml` memory.

## Stack
- Base: `codex/ghost-ui-reference-registry`
- Head: `codex/fingerprint-topology-routing-lint`
- Previous PR: #98

## Validation
- `pnpm test -- packages/ghost/test/checks-grounding.test.ts packages/ghost/test/fingerprint-yml-schema.test.ts` (ran full suite: 501 tests passed)
- pre-commit hook: `pnpm check`
- pre-push hook: `pnpm build`, `pnpm check`, `pnpm test` (501 tests passed)