### PR TITLE
[codex] Clarify Ghost prompt grounding

### DIFF
--- a/.changeset/quiet-ghost-review-scope.md
+++ b/.changeset/quiet-ghost-review-scope.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Clarify Ghost review prompts stay grounded in fingerprint memory and active checks.

--- a/packages/ghost-fleet/src/skill-bundle/references/target.md
+++ b/packages/ghost-fleet/src/skill-bundle/references/target.md
@@ -10,7 +10,7 @@ The frontmatter holds five structured pieces. Read all five before writing a sen
 
 1. `members` — id, platform, build_system, registry presence, fingerprint mtime. Confirm coverage matches what `ghost-fleet members` told you. Members in the table that aren't here mean you've got an orphan map.md or a broken fingerprint.
 
-2. `distances` — parent-only pairwise array, sorted ascending by `(a, b)`. Each entry is `{a, b, distance}` where distance is in [0, 1] roughly: the cosine-derived embedding distance between two fingerprints. Treat the numbers as *relative* — there is no universal threshold for "drifted." Look at the distribution.
+2. `distances` — parent-only pairwise array, sorted ascending by `(a, b)`. Each entry is `{a, b, distance}` where distance is in [0, 1] roughly: the cosine-derived embedding distance between two fingerprints. Treat the numbers as *relative* — there is no universal threshold for "drifted." Look at the distribution first; use any numeric bands below only as narrative calibration, never as pass/fail gates.
 
 3. `nodes` / `node_distances` — parent and scoped fingerprint nodes. Parent ids are `<member>`; scope ids are `<member>/<scope>` and carry `parent_id`. Use these when asking whether checkout-like or portal-like surfaces cluster across products.
 
@@ -26,7 +26,7 @@ Two paragraphs. Anchor each claim in a number from `distances` or a group-by tab
 
 Three questions to answer:
 
-- **Where does the fleet center?** Look at the median pairwise distance. Tight (e.g., median < 0.10) means a coherent family. Wide (median > 0.30) means several distinct languages coexist. Don't say "tight" or "wide" without naming the median.
+- **Where does the fleet center?** Look at the median pairwise distance. In many fleets, a median around or below 0.10 suggests a coherent family, while a median above roughly 0.30 suggests several distinct languages coexist. Let the fleet's own spread override those examples, and don't say "tight" or "wide" without naming the median.
 - **How is it shaped?** Is the spread uniform, or are there one or two outliers pulling the mean? Look at the max distance vs the median.
 - **What account axes drive the distances?** Cross-reference the largest distances against the group-by tables. Big distances between platforms? Between registries? Between two specific members regardless of axis?
 

--- a/packages/ghost-scan/src/core/context/review-command.ts
+++ b/packages/ghost-scan/src/core/context/review-command.ts
@@ -15,8 +15,8 @@ export interface EmitReviewInput {
  * typography values. Default output path: `.claude/commands/design-review.md`.
  *
  * Scope is drift-only: off-palette hex, off-ramp spacing, non-canonical
- * radii and weights. Universal accessibility checks are out of scope —
- * those belong in Rams or a sibling a11y skill.
+ * radii and weights. Unrelated audit categories are out of scope; only
+ * fingerprint-backed obligations count as drift.
  *
  * Two emission paths:
  *   - **Checks-driven** (legacy programmatic input): when `fingerprint.checks[]`
@@ -231,7 +231,7 @@ function header(
   if (character) lines.push("", character);
   lines.push(
     "",
-    "Your job: check code for **drift** from the values below — hardcoded hexes, off-ramp spacing, typography outside the scale, radii outside the set. You are **not** checking accessibility or universal design rules; use `/rams` or a dedicated a11y skill for that.",
+    "Your job: check code for **drift** from the values below — hardcoded hexes, off-ramp spacing, typography outside the scale, radii outside the set. Keep findings grounded in this fingerprint or active checks; do not expand the review into unrelated audit categories.",
   );
   return lines.join("\n");
 }
@@ -465,7 +465,7 @@ function guidelines(): string {
 1. Read the file(s) first before making assessments
 2. Be specific with line numbers and code snippets
 3. Suggest the canonical token, not just "use a different color"
-4. Do not flag accessibility or universal-design issues here — this is drift-only
+4. Do not expand into unrelated audit categories — this is drift-only unless the fingerprint or an active check makes the issue a drift obligation
 5. If asked, offer to fix directly`;
 }
 

--- a/packages/ghost-scan/test/context/__snapshots__/review-command.test.ts.snap
+++ b/packages/ghost-scan/test/context/__snapshots__/review-command.test.ts.snap
@@ -11,7 +11,7 @@ You are a drift reviewer for the **ghost-ui** design language. This system reads
 
 A monochromatic, magazine-inspired design language that treats color as communication rather than decoration. The default palette is entirely achromatic — near-black on white — with hue reserved for semantic states and chart data. Pill-shaped interactive elements contrast with moderately rounded containers, and display typography pushes ultra-tight line-heights (0.85–0.88) with heavy negative tracking for an editorial spread aesthetic. It ships no bundled typefaces and is fully themeable at runtime through CSS custom property injection, with five non-default preset themes that prove the base architecture's range.
 
-Your job: check code for **drift** from the values below — hardcoded hexes, off-ramp spacing, typography outside the scale, radii outside the set. You are **not** checking accessibility or universal design rules; use \`/rams\` or a dedicated a11y skill for that.
+Your job: check code for **drift** from the values below — hardcoded hexes, off-ramp spacing, typography outside the scale, radii outside the set. Keep findings grounded in this fingerprint or active checks; do not expand the review into unrelated audit categories.
 
 ## Mode
 
@@ -145,7 +145,7 @@ Drift score: XX/100
 1. Read the file(s) first before making assessments
 2. Be specific with line numbers and code snippets
 3. Suggest the canonical token, not just "use a different color"
-4. Do not flag accessibility or universal-design issues here — this is drift-only
+4. Do not expand into unrelated audit categories — this is drift-only unless the fingerprint or an active check makes the issue a drift obligation
 5. If asked, offer to fix directly
 
 ---

--- a/packages/ghost/src/review-packet.ts
+++ b/packages/ghost/src/review-packet.ts
@@ -197,7 +197,7 @@ export function formatReviewPacketMarkdown(packet: ReviewPacket): string {
 
 Package: ${packet.package_dir}
 
-Review this diff as a non-blocking design-language critic. Advisory findings must be evidence-routed and must cite: ${packet.required_finding_citations.join(", ")}. Do not fail the build unless the issue is tied to an active deterministic check in checks.yml.
+Review this diff as a non-blocking design-language critic. Advisory findings must be evidence-routed and must cite: ${packet.required_finding_citations.join(", ")}. Do not fail the build unless the issue is tied to an active deterministic check in checks.yml. Keep findings grounded in fingerprint memory, human intent, open proposals, or active deterministic checks; do not expand the review into unrelated audit categories.
 
 Use these finding categories: ${packet.finding_categories.join(", ")}.
 

--- a/packages/ghost/src/scan/context/package-review-command.ts
+++ b/packages/ghost/src/scan/context/package-review-command.ts
@@ -76,7 +76,7 @@ function packageWorkflowSection(memory: PackageMemory): string {
   return `## Review Workflow
 
 1. Read \`${memoryDir}/fingerprint.yml\` as the canonical product-experience memory.
-2. Select the relevant situation before judging UI, copy, flow, disclosure, recovery, trust, accessibility, or interaction behavior.
+2. Select the relevant situation before judging UI, copy, flow, disclosure, recovery, trust, or interaction behavior. Keep findings grounded in resolved Ghost memory or active checks; do not expand the review into unrelated audit categories.
 3. Apply accepted principles, experience contracts, and patterns before choosing implementation details. Treat proposed or deprecated memory as non-canonical unless the user explicitly asks to explore it.
 4. Use implementation vocabulary only as replaceable material that may help satisfy the selected product memory.
 5. Run \`ghost check${memoryDirFlag}\` when a diff is available. Active checks are deterministic and can block.
@@ -91,6 +91,8 @@ function packageFindingPolicySection(memory: PackageMemory): string {
 Use these categories: ${REVIEW_FINDING_CATEGORIES.map((category) => `\`${category}\``).join(", ")}.
 
 Only findings backed by an active check should be treated as blocking. Everything else is advisory product-experience critique.
+
+Review only what Ghost memory or active checks make relevant to the product experience.
 
 If the diff reveals missing or contradictory memory, report \`missing-memory\` or \`experience-gap\` and propose one of: ${REVIEW_PROPOSAL_TYPES.map((kind) => `\`${kind}\``).join(", ")}. Do not silently rewrite \`${memoryDir}/fingerprint.yml\`, \`${memoryDir}/checks.yml\`, or proposal files.`;
 }

--- a/packages/ghost/src/scan/context/review-command.ts
+++ b/packages/ghost/src/scan/context/review-command.ts
@@ -15,8 +15,8 @@ export interface EmitReviewInput {
  * typography values. Default output path: `.claude/commands/design-review.md`.
  *
  * Scope is drift-only: off-palette hex, off-ramp spacing, non-canonical
- * radii and weights. Universal accessibility checks are out of scope —
- * those belong in Rams or a sibling a11y skill.
+ * radii and weights. Unrelated audit categories are out of scope; only
+ * fingerprint-backed obligations count as drift.
  *
  * Two emission paths:
  *   - **Checks-driven** (legacy programmatic input): when `fingerprint.checks[]`
@@ -231,7 +231,7 @@ function header(
   if (character) lines.push("", character);
   lines.push(
     "",
-    "Your job: check code for **drift** from the values below — hardcoded hexes, off-ramp spacing, typography outside the scale, radii outside the set. You are **not** checking accessibility or universal design rules; use `/rams` or a dedicated a11y skill for that.",
+    "Your job: check code for **drift** from the values below — hardcoded hexes, off-ramp spacing, typography outside the scale, radii outside the set. Keep findings grounded in this fingerprint or active checks; do not expand the review into unrelated audit categories.",
   );
   return lines.join("\n");
 }
@@ -465,7 +465,7 @@ function guidelines(): string {
 1. Read the file(s) first before making assessments
 2. Be specific with line numbers and code snippets
 3. Suggest the canonical token, not just "use a different color"
-4. Do not flag accessibility or universal-design issues here — this is drift-only
+4. Do not expand into unrelated audit categories — this is drift-only unless the fingerprint or an active check makes the issue a drift obligation
 5. If asked, offer to fix directly`;
 }
 

--- a/packages/ghost/src/skill-bundle/references/critique.md
+++ b/packages/ghost/src/skill-bundle/references/critique.md
@@ -15,7 +15,7 @@ memory.
 2. Run `ghost review --include-memory` for advisory critique.
 3. Read the review packet, accepted decisions, and open proposals.
 4. Separate findings by role:
-   - design: hierarchy, flow, density, tone, accessibility
+   - design: hierarchy, flow, density, tone, and Ghost-backed obligations
    - engineering: implementation choices that preserve experience
    - pm: product promise, tradeoffs, trust, disclosure
    - qa: experience commitments and edge states

--- a/packages/ghost/src/skill-bundle/references/review.md
+++ b/packages/ghost/src/skill-bundle/references/review.md
@@ -70,13 +70,15 @@ Good advisory topics:
 - generic composition
 - awkward action placement
 - copy or trust-contract mismatch
-- accessibility or responsive obligation drift
+- obligations grounded in fingerprint memory, human intent, open proposals, or
+  active checks
 
 Bad advisory topics:
 
 - vague taste objections with no diff location
 - restating fingerprint prose without applying it to the change
 - enforcing a rule that is not in `checks.yml`
+- unrelated audit categories not grounded in Ghost memory
 
 ### 4. Propose Durable Memory Later
 


### PR DESCRIPTION
🤖 This draft PR keeps Ghost review and fleet reasoning prompts grounded in repo-local evidence instead of inviting unrelated audit categories or universal distance thresholds.

## What changed

- Updated generated advisory review packet wording to keep findings tied to fingerprint memory, human intent, open proposals, or active checks.
- Updated generated review-command wording for both the unified `ghost` package and the legacy `ghost-scan` copy.
- Tightened the installed skill recipe language for review and critique so it describes Ghost-backed obligations without naming unrelated review domains.
- Clarified `ghost-fleet` distance guidance so numeric bands are narrative calibration, not pass/fail gates.
- Added a patch changeset for `@anarchitecture/ghost`.

## Why

The previous review prompts could read as if Ghost review should broaden into unrelated audit work, and the fleet recipe mixed relative-distance guidance with example thresholds that could be over-literalized. This keeps Ghost review and fleet synthesis grounded in the fingerprint, active checks, and the fleet’s own distribution.

## Validation

- `pnpm test packages/ghost-scan/test/context/review-command.test.ts packages/ghost/test/cli.test.ts`
- pre-commit hook: `pnpm check`, format check
- pre-push hook: `pnpm build`, `pnpm check`, `pnpm test`