### PR TITLE
[codex] Add thresholded proposal guidance

### DIFF
--- a/.changeset/thresholded-proposal-guidance.md
+++ b/.changeset/thresholded-proposal-guidance.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Clarify proposal guidance so agents recommend or create durable memory candidates only after applying a proposal threshold.

--- a/apps/docs/src/content/docs/cli-reference.mdx
+++ b/apps/docs/src/content/docs/cli-reference.mdx
@@ -222,9 +222,11 @@ ghost emit context-bundle --out dist/context
 
 ### Scoped proposals - `proposal <op>`
 
-Create, list, and resolve candidate memory updates in the nearest applicable
-scoped bundle. These commands do not promote prose into `fingerprint.yml` or
-`checks.yml`; promotion remains explicit.
+Create, list, and resolve thresholded candidate memory updates in the nearest
+applicable scoped bundle. Use proposals for durable gaps: repeated,
+high-impact, explicitly human-stated, intentionally divergent, likely to recur,
+or blocking confident future review. These commands do not promote prose into
+`fingerprint.yml` or `checks.yml`; promotion remains explicit.
 
 <CliHelp tool="ghost" command="proposal" hideDescription />
 

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -125,8 +125,8 @@ outside Ghost. Ghost severities remain `critical`, `serious`, and `nit`.
 
 <DocSection title="Propose Fingerprint Updates">
 
-Use the installed `ghost` skill when work reveals memory Ghost should consider
-adding to the fingerprint:
+Use the installed `ghost` skill when work reveals durable memory Ghost should
+consider adding to the fingerprint:
 
 ```text
 Brief this work from the Ghost fingerprint
@@ -134,8 +134,10 @@ Propose this product-experience decision as a fingerprint update
 Promote this accepted proposal
 ```
 
-The recipes write proposals first. Humans promote durable context into
-`fingerprint.yml` or `checks.yml`.
+The recipes recommend proposals only when the gap is repeated, high-impact,
+explicitly human-stated, intentionally divergent, likely to recur, or blocks
+confident future review. Humans promote durable context into `fingerprint.yml`
+or `checks.yml`.
 
 For scoped product areas, use `ghost proposal create --path <path> ...` to
 write the proposal into the nearest applicable child bundle, then

--- a/packages/ghost/src/review-packet.ts
+++ b/packages/ghost/src/review-packet.ts
@@ -201,7 +201,11 @@ Review this diff as a non-blocking design-language critic. Advisory findings mus
 
 Use these finding categories: ${packet.finding_categories.join(", ")}.
 
-If the diff exposes missing or contradictory memory, report it as missing-memory or experience-gap and propose one of: ${packet.proposal_types.join(", ")}. Do not silently rewrite canonical memory.
+## Proposal Threshold
+
+Create or recommend a proposal only when the gap is repeated, high-impact, explicitly human-stated, intentionally divergent, likely to recur, or blocks confident future review. Do not propose for isolated implementation details, weak local context, duplicate open proposals, issues already fixable from accepted memory, vague taste concerns, or generic code quality.
+
+If the diff exposes missing or contradictory memory, report it as missing-memory or experience-gap only after applying the threshold. Include \`Memory action: none | recommend-proposal | create-proposal\` for each memory-gap finding. Default to \`recommend-proposal\`; use \`create-proposal\` only when the user explicitly asks to capture memory or when following the dedicated proposal workflow. Candidate proposal kinds: ${packet.proposal_types.join(", ")}. Do not silently rewrite canonical memory.
 
 ${formatReviewStacksSection(packet.stacks ?? null)}
 

--- a/packages/ghost/src/scan/context/package-review-command.ts
+++ b/packages/ghost/src/scan/context/package-review-command.ts
@@ -94,7 +94,11 @@ Only findings backed by an active check should be treated as blocking. Everythin
 
 Review only what Ghost memory or active checks make relevant to the product experience.
 
-If the diff reveals missing or contradictory memory, report \`missing-memory\` or \`experience-gap\` and propose one of: ${REVIEW_PROPOSAL_TYPES.map((kind) => `\`${kind}\``).join(", ")}. Do not silently rewrite \`${memoryDir}/fingerprint.yml\`, \`${memoryDir}/checks.yml\`, or proposal files.`;
+## Proposal Threshold
+
+Create or recommend a proposal only when the gap is repeated, high-impact, explicitly human-stated, intentionally divergent, likely to recur, or blocks confident future review. Do not propose for isolated implementation details, weak local context, duplicate open proposals, issues already fixable from accepted memory, vague taste concerns, or generic code quality.
+
+If the diff reveals missing or contradictory memory, report \`missing-memory\` or \`experience-gap\` only after applying the threshold. Include \`Memory action: none | recommend-proposal | create-proposal\` for each memory-gap finding. Default to \`recommend-proposal\`; use \`create-proposal\` only when the user explicitly asks to capture memory or when following the dedicated proposal workflow. Candidate proposal kinds: ${REVIEW_PROPOSAL_TYPES.map((kind) => `\`${kind}\``).join(", ")}. Do not silently rewrite \`${memoryDir}/fingerprint.yml\`, \`${memoryDir}/checks.yml\`, or proposal files.`;
 }
 
 function packageMemoryIndex(memory: PackageMemory): string {

--- a/packages/ghost/src/scan/context/package-writer.ts
+++ b/packages/ghost/src/scan/context/package-writer.ts
@@ -152,7 +152,9 @@ ${context.intent.trim()}
 - Use implementation vocabulary only when it supports the selected product memory.
 - Only active checks are blocking.
 - Treat open proposals as unresolved context that may explain gaps or intentional divergence.
-- If the task exposes missing or contradictory memory, propose a \`missing-memory\`, \`intentional-divergence\`, \`experience-gap\`, or \`check-candidate\` update instead of rewriting canonical memory silently.`);
+- Proposal Threshold: create or recommend a proposal only when the gap is repeated, high-impact, explicitly human-stated, intentionally divergent, likely to recur, or blocks confident future review.
+- Do not propose for isolated implementation details, weak local context, duplicate open proposals, issues already fixable from accepted memory, vague taste concerns, or generic code quality.
+- If the task exposes missing or contradictory memory that meets the threshold, recommend a \`missing-memory\`, \`intentional-divergence\`, \`experience-gap\`, or \`check-candidate\` update instead of rewriting canonical memory silently; create it only when the user explicitly asks to capture memory.`);
 
   return `${parts.join("\n\n")}\n`;
 }

--- a/packages/ghost/src/scan/fingerprint-package.ts
+++ b/packages/ghost/src/scan/fingerprint-package.ts
@@ -333,7 +333,8 @@ experience_contracts: []
 patterns: []
 ${implementationVocabulary}review_policy:
   proposal_policy:
-    - Agents create proposals for missing memory, intentional divergences, experience gaps, and check candidates.
+    - Agents recommend or create thresholded proposals for durable missing memory, intentional divergences, experience gaps, and check candidates.
+    - Proposal candidates should be repeated, high-impact, explicitly human-stated, intentionally divergent, likely to recur, or blocking confident future review.
     - Humans promote durable memory into fingerprint.yml and checks.yml.
   experience_gap_categories:
     - missing-memory

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -24,11 +24,11 @@ Ghost captures product identity in a repo-local fingerprint bundle:
 
 `fingerprint.yml` is the canonical product-experience memory. `config.yml`
 maps implementation roots and reference UI registries/libraries without making
-those references product intent. Checks are deterministic gates. Proposals capture
-missing memory, intentional divergence, experience gaps, and check candidates
-until a human promotes them. The host agent reads and writes the fingerprint;
-the CLI provides deterministic validation, comparison, routing, and handoff
-packets.
+those references product intent. Checks are deterministic gates. Proposals
+capture thresholded missing memory, intentional divergence, experience gaps, and
+check candidates until a human promotes them. The host agent reads and writes
+the fingerprint; the CLI provides deterministic validation, comparison,
+routing, and handoff packets.
 
 Repos may also contain nested bundles such as `apps/checkout/.ghost/`. Resolve
 the memory stack for the task path and read layers broad-to-local. Child entries

--- a/packages/ghost/src/skill-bundle/references/brief.md
+++ b/packages/ghost/src/skill-bundle/references/brief.md
@@ -33,6 +33,10 @@ Produce:
 - Open proposals or known gaps.
 - Decisions the human should make before generation.
 
-Do not invent fingerprint context. If memory is missing, say which proposal
-type should be recorded after the work: `missing-memory`,
-`intentional-divergence`, `experience-gap`, or `check-candidate`.
+Do not invent fingerprint context. If memory is missing, apply the Proposal
+Threshold before recommending memory action. A proposal candidate should be
+repeated, high-impact, explicitly human-stated, intentionally divergent, likely
+to recur, or blocking confident future review; otherwise name the gap as local
+uncertainty. If it qualifies, say which proposal type should be recorded after
+the work: `missing-memory`, `intentional-divergence`, `experience-gap`, or
+`check-candidate`.

--- a/packages/ghost/src/skill-bundle/references/capture.md
+++ b/packages/ghost/src/skill-bundle/references/capture.md
@@ -112,7 +112,16 @@ and `check` runs only active deterministic gates.
 ## Gaps
 
 If the repo does not yet contain enough product experience to capture, say so.
-For missing or contradictory memory, write a proposal with one of:
+For missing or contradictory memory, recommend or create a proposal only when
+the gap is durable enough to help a future agent. It should be repeated,
+high-impact, explicitly human-stated, intentionally divergent, likely to recur,
+or blocking confident future review.
+
+Do not create proposals for isolated implementation details, weak local context,
+duplicates of open proposals, issues already fixable from accepted memory,
+vague taste concerns, or generic code quality.
+
+Use:
 
 - `missing-memory`
 - `intentional-divergence`

--- a/packages/ghost/src/skill-bundle/references/critique.md
+++ b/packages/ghost/src/skill-bundle/references/critique.md
@@ -27,5 +27,12 @@ memory.
 Lead with actionable findings. Cite diff locations, fingerprint memory, active
 checks, open proposals, accepted decisions, and repairs where relevant.
 
+For memory-gap findings, include
+`Memory action: none | recommend-proposal | create-proposal`. Default to
+`recommend-proposal` only when the gap meets the Proposal Threshold: repeated,
+high-impact, explicitly human-stated, intentionally divergent, likely to recur,
+or blocking confident future review. Use `create-proposal` only when the user
+explicitly asks to capture memory or when following `propose.md`.
+
 Never fail a build on advisory-only context. Only active `checks.yml` gates
 block.

--- a/packages/ghost/src/skill-bundle/references/patterns.md
+++ b/packages/ghost/src/skill-bundle/references/patterns.md
@@ -70,5 +70,7 @@ ghost lint .ghost
 ghost verify .ghost --root .
 ```
 
-If a pattern is speculative, record a proposal instead of adding it as accepted
-memory.
+If a pattern is speculative, do not add it as accepted memory. Recommend or
+create a proposal only when the speculation is durable enough to help future
+generation or review: repeated, high-impact, explicitly human-stated, likely to
+recur, or blocking confident review.

--- a/packages/ghost/src/skill-bundle/references/propose.md
+++ b/packages/ghost/src/skill-bundle/references/propose.md
@@ -8,6 +8,17 @@ description: Write a candidate ghost.proposal/v1 artifact from a session.
 Use this when a design review, implementation, QA finding, or PM discussion
 reveals a product-experience decision that may belong in the Ghost fingerprint.
 
+## Proposal Threshold
+
+Create a proposal only when the observation is durable enough to help a future
+agent generate or review work. Good candidates are repeated, high-impact,
+explicitly human-stated, intentionally divergent, likely to recur, or blocking
+confident future review.
+
+Do not create proposals for isolated implementation details, weak local context,
+duplicates of open proposals, issues already fixable from accepted memory,
+vague taste concerns, or generic code quality.
+
 ## Steps
 
 1. Confirm the observation is about product experience: perceived, used,
@@ -15,10 +26,12 @@ reveals a product-experience decision that may belong in the Ghost fingerprint.
 2. Resolve the memory stack for the affected path with `ghost stack <path>`.
 3. Check whether merged `fingerprint.yml`, active checks, or open proposals
    already cover it.
-4. If it is new, run `ghost proposal create --path <path> ...` so the proposal
-   lands in the nearest applicable scoped bundle.
-5. Use schema `ghost.proposal/v1`.
-6. Run `ghost lint --all` when nested bundles exist.
+4. Confirm it meets the Proposal Threshold and is not a duplicate of an open
+   proposal.
+5. If it is new and thresholded, run `ghost proposal create --path <path> ...`
+   so the proposal lands in the nearest applicable scoped bundle.
+6. Use schema `ghost.proposal/v1`.
+7. Run `ghost lint --all` when nested bundles exist.
 
 ## Proposal Shape
 

--- a/packages/ghost/src/skill-bundle/references/remediate.md
+++ b/packages/ghost/src/skill-bundle/references/remediate.md
@@ -48,9 +48,12 @@ For every finding, identify the relevant fingerprint entry:
 - Disclosure/recovery drift -> experience contract.
 - Copy/trust drift -> principle, experience contract, or review policy.
 
-If no entry applies, do not invent one inside the code patch. Report a
-`missing-memory` or `experience-gap` proposal, scoped with
-`ghost proposal create --path <path>`.
+If no entry applies, do not invent one inside the code patch. Apply the
+Proposal Threshold: recommend a `missing-memory` or `experience-gap` proposal
+only when the gap is repeated, high-impact, explicitly human-stated, likely to
+recur, or blocking confident future review. Create it with
+`ghost proposal create --path <path>` only when the user explicitly asks to
+capture memory.
 
 Then classify the repair scope:
 
@@ -94,10 +97,11 @@ unrelated cleanup, but do not under-fix the issue just to keep the diff small.
 
 Some findings have no clean code fix:
 
-- The fingerprint is silent -> propose `missing-memory`.
-- The product is intentionally changing -> propose `intentional-divergence`.
+- The fingerprint is silent -> recommend `missing-memory` when it meets the
+  Proposal Threshold.
+- The product is intentionally changing -> recommend `intentional-divergence`.
 - The generated work failed to compose despite available memory -> propose
-  `experience-gap`.
+  `experience-gap` when the gap is durable.
 - A recurring deterministic issue can be detected -> propose `check-candidate`.
 - The fix would cascade across many files -> stop and call out the separate
   implementation plan.

--- a/packages/ghost/src/skill-bundle/references/review.md
+++ b/packages/ghost/src/skill-bundle/references/review.md
@@ -80,11 +80,33 @@ Bad advisory topics:
 - enforcing a rule that is not in `checks.yml`
 - unrelated audit categories not grounded in Ghost memory
 
-### 4. Propose Durable Memory Later
+### 4. Apply The Proposal Threshold
 
-If a finding exposes missing or contradictory memory, write a proposal instead
-of silently editing canonical truth. Use `ghost proposal create --path <path>`
-so the proposal lands in the nearest applicable scoped bundle. Use:
+Do not create proposals for every ambiguity. A proposal is warranted only when
+the gap is durable enough to help a future agent generate or review work:
+
+- repeated across a surface, pattern, or workflow
+- high-impact for trust, safety, recovery, money, permissions, destructive
+  actions, or user confidence
+- explicitly stated by a human
+- intentionally divergent from accepted memory
+- likely to recur in future reviews
+- blocking confident classification as `fix`, `intentional-divergence`, or
+  `eval-uncertainty`
+
+Do not propose for isolated implementation details, weak local context,
+duplicates of open proposals, issues already fixable from accepted memory,
+vague taste concerns, or generic code quality.
+
+For memory-gap findings, include:
+
+```text
+Memory action: none | recommend-proposal | create-proposal
+```
+
+Default to `recommend-proposal`. Use `create-proposal` only when the user
+explicitly asks to capture memory or when following `propose.md`. Candidate
+proposal kinds:
 
 - `missing-memory`
 - `intentional-divergence`

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -57,7 +57,7 @@ implementation_vocabulary:
     - Current vocabulary is replaceable implementation material.
 review_policy:
   proposal_policy:
-    - Agents propose memory changes; humans promote durable truth.
+    - Agents recommend or create thresholded proposals; humans promote durable truth.
 ```
 
 ## `checks.yml`

--- a/packages/ghost/src/skill-bundle/references/survey.md
+++ b/packages/ghost/src/skill-bundle/references/survey.md
@@ -40,8 +40,9 @@ Skip it when:
 - Keep generated output under `.ghost/cache/` unless a legacy command requires
   `.ghost/survey.json`.
 - Promote only useful, durable conclusions into `fingerprint.yml`.
-- If observation is incomplete, write a proposal instead of pretending the
-  fingerprint is complete.
+- If observation is incomplete, say so. Recommend a proposal only when the gap
+  is durable enough to help future generation or review; otherwise leave it as
+  local uncertainty.
 
 ## Optional Legacy Helpers
 

--- a/packages/ghost/src/skill-bundle/references/verify.md
+++ b/packages/ghost/src/skill-bundle/references/verify.md
@@ -31,9 +31,12 @@ handoffs:
 
 5. Repair high-confidence advisory issues when they cite a diff location,
    fingerprint memory, and a concrete repair.
-6. If the review exposes missing or contradictory memory, record a proposal
-   with `ghost proposal create --path <path>` instead of rewriting
-   `fingerprint.yml` during verification.
+6. If the review exposes missing or contradictory memory, apply the Proposal
+   Threshold before taking memory action. Recommend a proposal candidate only
+   when the gap is repeated, high-impact, explicitly human-stated,
+   intentionally divergent, likely to recur, or blocks confident future review.
+   Create it with `ghost proposal create --path <path>` only when the user
+   explicitly asks to capture memory.
 
 Only active `checks.yml` failures block. Advisory findings guide judgment and
 may become proposals when they reveal durable memory gaps.

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -456,6 +456,10 @@ describe("ghost CLI", () => {
       "utf-8",
     );
     expect(emittedReviewCommand).toContain("fingerprint.yml memory");
+    expect(emittedReviewCommand).toContain("Proposal Threshold");
+    expect(emittedReviewCommand).toContain(
+      "Memory action: none | recommend-proposal | create-proposal",
+    );
     expect(emittedReviewCommand).toContain("experience-gap");
     expect(emittedReviewCommand).toContain("no-hardcoded-ui-color");
     expect(emittedReviewCommand).not.toContain(
@@ -471,6 +475,9 @@ describe("ghost CLI", () => {
     await expect(
       readFile(join(dir, "ghost-context", "prompt.md"), "utf-8"),
     ).resolves.toContain("Fingerprint Memory");
+    await expect(
+      readFile(join(dir, "ghost-context", "prompt.md"), "utf-8"),
+    ).resolves.toContain("Proposal Threshold");
   });
 
   it("rejects removed legacy direct markdown emit flags", () => {
@@ -510,6 +517,20 @@ describe("ghost CLI", () => {
         readFile(join(dir, "skills", "ghost", path), "utf-8"),
       ).resolves.toBeTruthy();
     }
+    await expect(
+      readFile(
+        join(dir, "skills", "ghost", "references", "propose.md"),
+        "utf-8",
+      ),
+    ).resolves.toContain("Proposal Threshold");
+    await expect(
+      readFile(
+        join(dir, "skills", "ghost", "references", "review.md"),
+        "utf-8",
+      ),
+    ).resolves.toContain(
+      "Memory action: none | recommend-proposal | create-proposal",
+    );
   });
 
   it("check fails when an active deterministic check matches added lines", async () => {
@@ -574,6 +595,10 @@ describe("ghost CLI", () => {
     expect(result.stdout).toContain("diff location");
     expect(result.stdout).toContain("fingerprint.yml memory");
     expect(result.stdout).toContain("active check when blocking");
+    expect(result.stdout).toContain("Proposal Threshold");
+    expect(result.stdout).toContain(
+      "Memory action: none | recommend-proposal | create-proposal",
+    );
     expect(result.stdout).toContain("missing-memory");
     expect(result.stdout).toContain("experience-gap");
     expect(result.stdout).toContain("repair or intentional-divergence");
@@ -839,12 +864,14 @@ libraries:
     expect(await realpath(out.dir)).toBe(
       await realpath(join(dir, "apps", "checkout", ".ghost")),
     );
-    expect(
-      await readFile(
-        join(dir, "apps", "checkout", ".ghost", "fingerprint.yml"),
-        "utf-8",
-      ),
-    ).toContain("ghost.fingerprint/v1");
+    const fingerprint = await readFile(
+      join(dir, "apps", "checkout", ".ghost", "fingerprint.yml"),
+      "utf-8",
+    );
+    expect(fingerprint).toContain("ghost.fingerprint/v1");
+    expect(fingerprint).toContain(
+      "Agents recommend or create thresholded proposals",
+    );
   });
 
   it("init --scope creates a nested bundle under a custom memory directory", async () => {


### PR DESCRIPTION
🤖

## Summary
- Add Proposal Threshold guidance to Ghost review prompts, context bundles, and installed skill recipes.
- Require memory-gap findings to include `Memory action: none | recommend-proposal | create-proposal`.
- Update initialized fingerprint policy, docs, tests, and add a patch changeset.

## Validation
- `pnpm exec vitest run packages/ghost/test/cli.test.ts`
- `pnpm test`
- pre-commit hook: `pnpm check` + format checks
- pre-push hook: `pnpm build`, `pnpm check`, `pnpm test`