### PR TITLE
Clarify provisional Ghost memory guidance

### DIFF
--- a/.changeset/thresholded-proposal-guidance.md
+++ b/.changeset/thresholded-proposal-guidance.md
@@ -2,4 +2,4 @@
 "@anarchitecture/ghost": patch
 ---
 
-Clarify proposal guidance so agents recommend or create durable memory candidates only after applying a proposal threshold.
+Clarify proposal and silent-memory guidance so agents threshold durable memory candidates and label provisional local reasoning.

--- a/packages/ghost/src/review-packet.ts
+++ b/packages/ghost/src/review-packet.ts
@@ -201,6 +201,8 @@ Review this diff as a non-blocking design-language critic. Advisory findings mus
 
 Use these finding categories: ${packet.finding_categories.join(", ")}.
 
+When accepted fingerprint memory is silent, local evidence can still support advisory critique. Label those findings as provisional and non-Ghost-backed, and ground them in nearby product surfaces, local components, token or copy conventions, accepted decisions, or human intent. Ask the human before judging high-risk, irreversible, privacy/security/legal, or product-identity-defining choices.
+
 ## Proposal Threshold
 
 Create or recommend a proposal only when the gap is repeated, high-impact, explicitly human-stated, intentionally divergent, likely to recur, or blocks confident future review. Do not propose for isolated implementation details, weak local context, duplicate open proposals, issues already fixable from accepted memory, vague taste concerns, or generic code quality.

--- a/packages/ghost/src/scan/context/package-review-command.ts
+++ b/packages/ghost/src/scan/context/package-review-command.ts
@@ -94,6 +94,8 @@ Only findings backed by an active check should be treated as blocking. Everythin
 
 Review only what Ghost memory or active checks make relevant to the product experience.
 
+When accepted fingerprint memory is silent, local evidence can still support advisory critique. Label those findings as provisional and non-Ghost-backed, and ground them in nearby product surfaces, local components, token or copy conventions, accepted decisions, or human intent. Ask the human before judging high-risk, irreversible, privacy/security/legal, or product-identity-defining choices.
+
 ## Proposal Threshold
 
 Create or recommend a proposal only when the gap is repeated, high-impact, explicitly human-stated, intentionally divergent, likely to recur, or blocks confident future review. Do not propose for isolated implementation details, weak local context, duplicate open proposals, issues already fixable from accepted memory, vague taste concerns, or generic code quality.

--- a/packages/ghost/src/scan/context/package-writer.ts
+++ b/packages/ghost/src/scan/context/package-writer.ts
@@ -111,6 +111,12 @@ experience contracts, and patterns from \`fingerprint.yml\` before choosing
 implementation details. Use implementation vocabulary only as replaceable
 material that may help satisfy product memory. Treat proposals as unresolved
 context, not canonical truth.
+
+When accepted fingerprint memory is silent, proceed from nearby product
+surfaces, local components, token and copy conventions, accepted decisions or
+human intent, and ordinary UX judgment when safe. Label that reasoning as
+provisional and non-Ghost-backed. Ask a human before making high-risk,
+irreversible, privacy/security/legal, or product-identity-defining choices.
 `;
 }
 
@@ -152,6 +158,8 @@ ${context.intent.trim()}
 - Use implementation vocabulary only when it supports the selected product memory.
 - Only active checks are blocking.
 - Treat open proposals as unresolved context that may explain gaps or intentional divergence.
+- When accepted fingerprint memory is silent, proceed from nearby product surfaces, local components, token and copy conventions, accepted decisions or human intent, and ordinary UX judgment when safe.
+- Label silent-memory reasoning as provisional and non-Ghost-backed; ask the human before high-risk, irreversible, privacy/security/legal, or product-identity-defining choices.
 - Proposal Threshold: create or recommend a proposal only when the gap is repeated, high-impact, explicitly human-stated, intentionally divergent, likely to recur, or blocks confident future review.
 - Do not propose for isolated implementation details, weak local context, duplicate open proposals, issues already fixable from accepted memory, vague taste concerns, or generic code quality.
 - If the task exposes missing or contradictory memory that meets the threshold, recommend a \`missing-memory\`, \`intentional-divergence\`, \`experience-gap\`, or \`check-candidate\` update instead of rewriting canonical memory silently; create it only when the user explicitly asks to capture memory.`);

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -82,9 +82,19 @@ review or check format.
 - Run `ghost check` for deterministic gates and `ghost review` for advisory critique.
 - Include accepted decisions with `ghost review --include-memory` when product-experience rationale matters.
 
+## When Memory Is Silent
+
+Silent fingerprint memory does not require stopping by default. When accepted
+memory does not cover the task, proceed from nearby product surfaces, local
+components, token and copy conventions, accepted decisions or human intent, and
+ordinary UX judgment when safe. Label that reasoning as provisional and
+non-Ghost-backed. Ask a human before making high-risk, irreversible,
+privacy/security/legal, or product-identity-defining choices.
+
 ## Never
 
 - Never treat advisory composition judgment as a CI gate.
-- Never invent product-experience memory absent from `fingerprint.yml`.
+- Never claim provisional judgment, local convention, or general UX reasoning as
+  Ghost-backed memory.
 - Never treat `intent.md` as authoritative unless human-authored or human-approved.
 - Never treat proposals or rejected decisions as canonical inputs.

--- a/packages/ghost/src/skill-bundle/references/brief.md
+++ b/packages/ghost/src/skill-bundle/references/brief.md
@@ -33,10 +33,17 @@ Produce:
 - Open proposals or known gaps.
 - Decisions the human should make before generation.
 
-Do not invent fingerprint context. If memory is missing, apply the Proposal
-Threshold before recommending memory action. A proposal candidate should be
-repeated, high-impact, explicitly human-stated, intentionally divergent, likely
-to recur, or blocking confident future review; otherwise name the gap as local
-uncertainty. If it qualifies, say which proposal type should be recorded after
-the work: `missing-memory`, `intentional-divergence`, `experience-gap`, or
-`check-candidate`.
+When accepted fingerprint memory is silent, do not stop by default. Continue
+from nearby product surfaces, local components, token and copy conventions,
+accepted decisions or human intent, and ordinary UX judgment when safe. Label
+that guidance as provisional and non-Ghost-backed, and ask the human only for
+high-risk, irreversible, privacy/security/legal, or product-identity-defining
+choices.
+
+Do not claim provisional guidance as fingerprint context. If memory is missing,
+apply the Proposal Threshold before recommending memory action. A proposal
+candidate should be repeated, high-impact, explicitly human-stated,
+intentionally divergent, likely to recur, or blocking confident future review;
+otherwise name the gap as local uncertainty. If it qualifies, say which proposal
+type should be recorded after the work: `missing-memory`,
+`intentional-divergence`, `experience-gap`, or `check-candidate`.

--- a/packages/ghost/src/skill-bundle/references/capture.md
+++ b/packages/ghost/src/skill-bundle/references/capture.md
@@ -117,6 +117,11 @@ the gap is durable enough to help a future agent. It should be repeated,
 high-impact, explicitly human-stated, intentionally divergent, likely to recur,
 or blocking confident future review.
 
+When accepted fingerprint memory is silent, that silence does not block useful
+work by itself. Continue from nearby product surfaces, local components, token
+and copy conventions, accepted decisions or human intent, and ordinary UX
+judgment when safe. Label that reasoning as provisional and non-Ghost-backed.
+
 Do not create proposals for isolated implementation details, weak local context,
 duplicates of open proposals, issues already fixable from accepted memory,
 vague taste concerns, or generic code quality.

--- a/packages/ghost/src/skill-bundle/references/critique.md
+++ b/packages/ghost/src/skill-bundle/references/critique.md
@@ -27,6 +27,12 @@ memory.
 Lead with actionable findings. Cite diff locations, fingerprint memory, active
 checks, open proposals, accepted decisions, and repairs where relevant.
 
+When accepted fingerprint memory is silent, you may use nearby product surfaces,
+local components, token and copy conventions, accepted decisions or human intent,
+and ordinary UX judgment for provisional critique. Label that reasoning as
+non-Ghost-backed, and ask the human before judging high-risk, irreversible,
+privacy/security/legal, or product-identity-defining choices.
+
 For memory-gap findings, include
 `Memory action: none | recommend-proposal | create-proposal`. Default to
 `recommend-proposal` only when the gap meets the Proposal Threshold: repeated,

--- a/packages/ghost/src/skill-bundle/references/remediate.md
+++ b/packages/ghost/src/skill-bundle/references/remediate.md
@@ -62,7 +62,8 @@ Then classify the repair scope:
 - **Structural**: layout, hierarchy, flow, action placement, component anatomy,
   state model, disclosure, recovery, or trust behavior must change.
 - **Unresolved**: the fingerprint is silent or contradictory, or the product is
-  intentionally changing.
+  intentionally changing. Silent memory does not block a safe local repair, but
+  local-evidence reasoning must be labeled provisional and non-Ghost-backed.
 
 Do not choose a local token or class patch when the cited memory is about
 hierarchy, disclosure, recovery, trust, flow, or task structure. In those cases,

--- a/packages/ghost/src/skill-bundle/references/review.md
+++ b/packages/ghost/src/skill-bundle/references/review.md
@@ -80,6 +80,13 @@ Bad advisory topics:
 - enforcing a rule that is not in `checks.yml`
 - unrelated audit categories not grounded in Ghost memory
 
+When accepted fingerprint memory is silent, local evidence can still support
+advisory critique. Label those findings as provisional and non-Ghost-backed, and
+ground them in nearby product surfaces, local components, token or copy
+conventions, accepted decisions, or human intent. Ask the human before judging
+high-risk, irreversible, privacy/security/legal, or product-identity-defining
+choices.
+
 ### 4. Apply The Proposal Threshold
 
 Do not create proposals for every ambiguity. A proposal is warranted only when

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -456,6 +456,7 @@ describe("ghost CLI", () => {
       "utf-8",
     );
     expect(emittedReviewCommand).toContain("fingerprint.yml memory");
+    expect(emittedReviewCommand).toContain("provisional and non-Ghost-backed");
     expect(emittedReviewCommand).toContain("Proposal Threshold");
     expect(emittedReviewCommand).toContain(
       "Memory action: none | recommend-proposal | create-proposal",
@@ -478,6 +479,12 @@ describe("ghost CLI", () => {
     await expect(
       readFile(join(dir, "ghost-context", "prompt.md"), "utf-8"),
     ).resolves.toContain("Proposal Threshold");
+    await expect(
+      readFile(join(dir, "ghost-context", "prompt.md"), "utf-8"),
+    ).resolves.toContain("Label silent-memory reasoning as provisional");
+    await expect(
+      readFile(join(dir, "ghost-context", "SKILL.md"), "utf-8"),
+    ).resolves.toContain("provisional and non-Ghost-backed");
   });
 
   it("rejects removed legacy direct markdown emit flags", () => {
@@ -517,6 +524,14 @@ describe("ghost CLI", () => {
         readFile(join(dir, "skills", "ghost", path), "utf-8"),
       ).resolves.toBeTruthy();
     }
+    await expect(
+      readFile(join(dir, "skills", "ghost", "SKILL.md"), "utf-8"),
+    ).resolves.toContain("When Memory Is Silent");
+    await expect(
+      readFile(join(dir, "skills", "ghost", "SKILL.md"), "utf-8"),
+    ).resolves.toContain(
+      "Never claim provisional judgment, local convention, or general UX reasoning",
+    );
     await expect(
       readFile(
         join(dir, "skills", "ghost", "references", "propose.md"),
@@ -596,6 +611,7 @@ describe("ghost CLI", () => {
     expect(result.stdout).toContain("fingerprint.yml memory");
     expect(result.stdout).toContain("active check when blocking");
     expect(result.stdout).toContain("Proposal Threshold");
+    expect(result.stdout).toContain("provisional and non-Ghost-backed");
     expect(result.stdout).toContain(
       "Memory action: none | recommend-proposal | create-proposal",
     );


### PR DESCRIPTION
🤖 AI-agent-authored PR.

## Summary
- Add guidance for when accepted Ghost fingerprint memory is silent: proceed from local evidence when safe, but label that reasoning provisional and non-Ghost-backed.
- Carry the guidance through installed skill docs, context bundle prompts, review commands, and advisory review packets.
- Extend CLI tests to lock the emitted prompt surfaces and update the changeset copy.

## Verification
- `pnpm exec biome check packages/ghost/src/review-packet.ts packages/ghost/src/scan/context/package-review-command.ts packages/ghost/src/scan/context/package-writer.ts packages/ghost/test/cli.test.ts`
- `pnpm exec vitest run packages/ghost/test`
- pre-push hook: `pnpm build`, `pnpm check`, `pnpm test`