### PR TITLE
Fix stale Changesets ignore entry

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,11 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "ghost-ui",
-    "ghost-docs",
-    "@ghost/core",
-    "ghost-scan",
-    "ghost-fleet"
-  ]
+  "ignore": ["ghost-ui", "ghost-docs", "@ghost/core", "ghost-fleet"]
 }


### PR DESCRIPTION
🤖 AI-agent-authored PR.

## Summary
- Remove the stale `ghost-scan` package from `.changeset/config.json` so `pnpm changeset version` can validate the Changesets config again.

## Verification
- `pnpm changeset status --since main`
- `pnpm --filter @anarchitecture/ghost build`
- `pnpm check`
- pre-push hook: `pnpm build`, `pnpm check`, `pnpm test`