### PR TITLE
Simplify command discovery help

### DIFF
--- a/.changeset/quiet-command-discovery.md
+++ b/.changeset/quiet-command-discovery.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Simplify default command discovery while keeping the full command index available.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,12 @@ The public npm package is **`@anarchitecture/ghost`**. It installs one CLI:
 ```bash
 npm install -D @anarchitecture/ghost
 npx ghost --help
+npx ghost --help --all
 ```
+
+Default help is intentionally small and shows the core workflow for new
+adopters. Use `ghost --help --all` for the complete advanced and legacy command
+index; every listed command still supports `ghost <command> --help`.
 
 Install the unified BYOA skill bundle:
 

--- a/apps/docs/src/components/docs/cli-help.tsx
+++ b/apps/docs/src/components/docs/cli-help.tsx
@@ -23,6 +23,10 @@ interface CliCommand {
   name: string;
   rawName: string;
   description: string;
+  group?: string;
+  defaultHelp?: boolean;
+  compactName?: string;
+  summary?: string;
   options: CliOption[];
 }
 

--- a/apps/docs/src/content/docs/cli-reference.mdx
+++ b/apps/docs/src/content/docs/cli-reference.mdx
@@ -14,6 +14,10 @@ fingerprint readiness, validate files, emit raw inventory, compare packages,
 check diffs, emit handoff packets, and record intent. Your agent does the
 reading, writing, and reviewing.
 
+`ghost --help` intentionally shows the short core workflow for new adopters.
+Run `ghost --help --all` for the complete advanced and legacy command index;
+command-specific help remains available with `ghost <command> --help`.
+
 Canonical Ghost fingerprints start here, with optional child packages for scoped
 product areas:
 

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -55,8 +55,12 @@ result afterward; they are not generation input.
 ```bash
 npm install -D @anarchitecture/ghost
 npx ghost --help
+npx ghost --help --all
 npx ghost skill install
 ```
+
+`ghost --help` shows the core new-adopter workflow. Use `ghost --help --all`
+when you want the complete advanced and legacy command index.
 
 Once the skill is installed, ask your agent in plain English: "Set up the Ghost
 fingerprint for this repo" or "review this PR for drift". The recipe tells the

--- a/apps/docs/src/generated/cli-manifest.json
+++ b/apps/docs/src/generated/cli-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-04T15:42:44.164Z",
+  "generatedAt": "2026-06-04T20:36:11.697Z",
   "tools": [
     {
       "tool": "ghost",
@@ -9,6 +9,10 @@
           "name": "lint",
           "rawName": "lint [file]",
           "description": "Validate a root Ghost fingerprint package, fingerprint.yml, checks.yml, or legacy markdown — defaults to .ghost",
+          "group": "core",
+          "defaultHelp": true,
+          "compactName": "lint",
+          "summary": "Validate a fingerprint package or artifact.",
           "options": [
             {
               "rawName": "--format <fmt>",
@@ -41,6 +45,10 @@
           "name": "init",
           "rawName": "init [dir]",
           "description": "Create a root .ghost fingerprint package (fingerprint.yml and checks.yml)",
+          "group": "core",
+          "defaultHelp": true,
+          "compactName": "init",
+          "summary": "Create .ghost/fingerprint.yml and checks.yml.",
           "options": [
             {
               "rawName": "--scope <path>",
@@ -97,6 +105,10 @@
           "name": "verify",
           "rawName": "verify [dir]",
           "description": "Verify a root Ghost fingerprint package: prose/composition evidence, inventory exemplars, and checks are grounded.",
+          "group": "core",
+          "defaultHelp": true,
+          "compactName": "verify",
+          "summary": "Verify evidence, exemplar paths, and typed refs.",
           "options": [
             {
               "rawName": "--root <dir>",
@@ -137,6 +149,10 @@
           "name": "scan",
           "rawName": "scan [dir]",
           "description": "Report fingerprint layer readiness: produced artifacts, useful prose/inventory/composition, and the next BYOA step.",
+          "group": "core",
+          "defaultHelp": true,
+          "compactName": "scan",
+          "summary": "Report fingerprint layer readiness.",
           "options": [
             {
               "rawName": "--include-scopes",
@@ -177,6 +193,10 @@
           "name": "stack",
           "rawName": "stack [paths...]",
           "description": "Inspect the nested Ghost fingerprint stack for one or more repo paths.",
+          "group": "advanced",
+          "defaultHelp": false,
+          "compactName": "stack",
+          "summary": "Inspect a nested fingerprint stack for repo paths.",
           "options": [
             {
               "rawName": "--memory-dir <relative-dir>",
@@ -201,6 +221,10 @@
           "name": "inventory",
           "rawName": "inventory [path]",
           "description": "Emit deterministic raw signals about a frontend repo as JSON for optional cache/source material: package manifests, language histogram, candidate config files, registry presence, top-level tree, and git remote.",
+          "group": "advanced",
+          "defaultHelp": false,
+          "compactName": "inventory",
+          "summary": "Emit raw repo signals for optional cache material.",
           "options": []
         },
         {
@@ -208,6 +232,10 @@
           "name": "describe",
           "rawName": "describe [fingerprint]",
           "description": "Print a section map of intent.md or a direct fingerprint markdown file (line ranges + token estimates).",
+          "group": "advanced",
+          "defaultHelp": false,
+          "compactName": "describe",
+          "summary": "Print intent or direct markdown section ranges.",
           "options": [
             {
               "rawName": "--format <fmt>",
@@ -224,6 +252,10 @@
           "name": "diff",
           "rawName": "diff <a> <b>",
           "description": "Legacy direct markdown diff between two fingerprint.md files — what decisions, palette roles, and tokens changed (text-level, NOT embedding distance; for that, use `ghost compare`).",
+          "group": "legacy",
+          "defaultHelp": false,
+          "compactName": "diff",
+          "summary": "Diff two legacy direct markdown fingerprints.",
           "options": [
             {
               "rawName": "--format <fmt>",
@@ -240,6 +272,10 @@
           "name": "survey",
           "rawName": "survey <op> [...surveys]",
           "description": "Legacy/cache helpers for ghost.survey/v1 files. Ops: merge, fix-ids, summarize, catalog, patterns.",
+          "group": "legacy",
+          "defaultHelp": false,
+          "compactName": "survey",
+          "summary": "Run legacy/cache survey helpers.",
           "options": [
             {
               "rawName": "-o, --out <path>",
@@ -280,6 +316,10 @@
           "name": "emit",
           "rawName": "emit <kind>",
           "description": "Emit a derived artifact from the fingerprint package (review command or context-bundle generation packet)",
+          "group": "core",
+          "defaultHelp": true,
+          "compactName": "emit",
+          "summary": "Emit review-command or context-bundle artifacts.",
           "options": [
             {
               "rawName": "--path <path>",
@@ -352,6 +392,10 @@
           "name": "compare",
           "rawName": "compare [...fingerprints]",
           "description": "Compare two or more fingerprints or root .ghost bundles. N=2 returns a pairwise delta; N≥3 returns a composite fingerprint.",
+          "group": "compare",
+          "defaultHelp": false,
+          "compactName": "compare",
+          "summary": "Compare packages or direct fingerprints.",
           "options": [
             {
               "rawName": "--semantic",
@@ -416,6 +460,10 @@
           "name": "ack",
           "rawName": "ack",
           "description": "Acknowledge current drift — record intentional stance toward the tracked fingerprint",
+          "group": "compare",
+          "defaultHelp": false,
+          "compactName": "ack",
+          "summary": "Record stance toward tracked drift.",
           "options": [
             {
               "rawName": "-c, --config <path>",
@@ -464,6 +512,10 @@
           "name": "track",
           "rawName": "track <fingerprint>",
           "description": "Track another fingerprint as this repo's reference",
+          "group": "compare",
+          "defaultHelp": false,
+          "compactName": "track",
+          "summary": "Shift the tracked reference fingerprint.",
           "options": [
             {
               "rawName": "-d, --dimension <name>",
@@ -488,6 +540,10 @@
           "name": "diverge",
           "rawName": "diverge <dimension>",
           "description": "Declare intentional divergence on a dimension",
+          "group": "compare",
+          "defaultHelp": false,
+          "compactName": "diverge",
+          "summary": "Declare intentional divergence on a dimension.",
           "options": [
             {
               "rawName": "-c, --config <path>",
@@ -520,6 +576,10 @@
           "name": "skill",
           "rawName": "skill <action>",
           "description": "Install the unified Ghost skill bundle.",
+          "group": "core",
+          "defaultHelp": true,
+          "compactName": "skill install",
+          "summary": "Install the Ghost skill bundle.",
           "options": [
             {
               "rawName": "--dest <path>",
@@ -552,6 +612,10 @@
           "name": "check",
           "rawName": "check",
           "description": "Run active ghost.checks/v1 gates from the resolved fingerprint stack against a git diff.",
+          "group": "core",
+          "defaultHelp": true,
+          "compactName": "check",
+          "summary": "Run active deterministic gates against a diff.",
           "options": [
             {
               "rawName": "--base <ref>",
@@ -600,6 +664,10 @@
           "name": "review",
           "rawName": "review",
           "description": "Emit an evidence-routed advisory review prompt from the fingerprint package and a git diff.",
+          "group": "core",
+          "defaultHelp": true,
+          "compactName": "review",
+          "summary": "Emit an advisory packet from fingerprint layers and a diff.",
           "options": [
             {
               "rawName": "--base <ref>",

--- a/packages/ghost/README.md
+++ b/packages/ghost/README.md
@@ -11,25 +11,28 @@ records intentional drift. It ships one CLI: `ghost`.
 ```bash
 npm install -D @anarchitecture/ghost
 npx ghost --help
+npx ghost --help --all
 ```
+
+`ghost --help` shows the core workflow. `ghost --help --all` shows the full
+advanced and legacy command index.
 
 ## Use
 
 ```bash
 ghost init --with-intent
 ghost scan --format json
-ghost inventory
 ghost lint .ghost
 ghost verify .ghost --root .
 ghost check --base main
 ghost review --base main --include-memory
-ghost compare a/.ghost b/.ghost
-ghost ack
-ghost diverge typography --reason "Product deliberately uses an editorial scale"
 ghost emit review-command
 ghost emit context-bundle
 ghost skill install
 ```
+
+Advanced commands such as `inventory`, `compare`, `ack`, and `diverge` remain
+available and appear in the full help index.
 
 Zero config for every verb. No API key is required. `OPENAI_API_KEY` /
 `VOYAGE_API_KEY` are optional and only used by semantic embedding helpers when a

--- a/packages/ghost/src/cli.ts
+++ b/packages/ghost/src/cli.ts
@@ -5,6 +5,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { cac } from "cac";
+import { formatGhostHelp } from "./command-discovery.js";
 import { loadComparableFingerprint } from "./comparable-fingerprint.js";
 import {
   compare,
@@ -34,6 +35,8 @@ import { registerScanCommands } from "./scan-commands.js";
 import { registerSkillCommand } from "./skill-command.js";
 
 const execFileAsync = promisify(execFile);
+
+export { getCommandDiscoveryMetadata } from "./command-discovery.js";
 
 export function buildCli(): ReturnType<typeof cac> {
   const cli = cac("ghost");
@@ -267,7 +270,7 @@ export function buildCli(): ReturnType<typeof cac> {
       }
     });
 
-  cli.help();
+  cli.help((sections) => formatGhostHelp(cli, sections));
   cli.version(readPackageVersion());
 
   return cli;

--- a/packages/ghost/src/command-discovery.ts
+++ b/packages/ghost/src/command-discovery.ts
@@ -1,0 +1,299 @@
+import type { CAC, Command } from "cac";
+
+type HelpSection = {
+  title?: string;
+  body: string;
+};
+
+export type CommandDiscoveryGroup = "core" | "advanced" | "compare" | "legacy";
+
+export type CommandDiscoveryMetadata = {
+  name: string;
+  group: CommandDiscoveryGroup;
+  defaultHelp: boolean;
+  compactName: string;
+  summary: string;
+  order: number;
+};
+
+const GROUPS: ReadonlyArray<{
+  group: CommandDiscoveryGroup;
+  title: string;
+}> = [
+  { group: "core", title: "Core workflow" },
+  { group: "advanced", title: "Advanced/package inspection" },
+  { group: "compare", title: "Compare/stance" },
+  { group: "legacy", title: "Legacy/cache" },
+];
+
+const COMMAND_DISCOVERY = [
+  {
+    name: "init",
+    group: "core",
+    defaultHelp: true,
+    compactName: "init",
+    summary: "Create .ghost/fingerprint.yml and checks.yml.",
+  },
+  {
+    name: "scan",
+    group: "core",
+    defaultHelp: true,
+    compactName: "scan",
+    summary: "Report fingerprint layer readiness.",
+  },
+  {
+    name: "lint",
+    group: "core",
+    defaultHelp: true,
+    compactName: "lint",
+    summary: "Validate a fingerprint package or artifact.",
+  },
+  {
+    name: "verify",
+    group: "core",
+    defaultHelp: true,
+    compactName: "verify",
+    summary: "Verify evidence, exemplar paths, and typed refs.",
+  },
+  {
+    name: "check",
+    group: "core",
+    defaultHelp: true,
+    compactName: "check",
+    summary: "Run active deterministic gates against a diff.",
+  },
+  {
+    name: "review",
+    group: "core",
+    defaultHelp: true,
+    compactName: "review",
+    summary: "Emit an advisory packet from fingerprint layers and a diff.",
+  },
+  {
+    name: "emit",
+    group: "core",
+    defaultHelp: true,
+    compactName: "emit",
+    summary: "Emit review-command or context-bundle artifacts.",
+  },
+  {
+    name: "skill",
+    group: "core",
+    defaultHelp: true,
+    compactName: "skill install",
+    summary: "Install the Ghost skill bundle.",
+  },
+  {
+    name: "stack",
+    group: "advanced",
+    defaultHelp: false,
+    compactName: "stack",
+    summary: "Inspect a nested fingerprint stack for repo paths.",
+  },
+  {
+    name: "inventory",
+    group: "advanced",
+    defaultHelp: false,
+    compactName: "inventory",
+    summary: "Emit raw repo signals for optional cache material.",
+  },
+  {
+    name: "describe",
+    group: "advanced",
+    defaultHelp: false,
+    compactName: "describe",
+    summary: "Print intent or direct markdown section ranges.",
+  },
+  {
+    name: "compare",
+    group: "compare",
+    defaultHelp: false,
+    compactName: "compare",
+    summary: "Compare packages or direct fingerprints.",
+  },
+  {
+    name: "ack",
+    group: "compare",
+    defaultHelp: false,
+    compactName: "ack",
+    summary: "Record stance toward tracked drift.",
+  },
+  {
+    name: "track",
+    group: "compare",
+    defaultHelp: false,
+    compactName: "track",
+    summary: "Shift the tracked reference fingerprint.",
+  },
+  {
+    name: "diverge",
+    group: "compare",
+    defaultHelp: false,
+    compactName: "diverge",
+    summary: "Declare intentional divergence on a dimension.",
+  },
+  {
+    name: "diff",
+    group: "legacy",
+    defaultHelp: false,
+    compactName: "diff",
+    summary: "Diff two legacy direct markdown fingerprints.",
+  },
+  {
+    name: "survey",
+    group: "legacy",
+    defaultHelp: false,
+    compactName: "survey",
+    summary: "Run legacy/cache survey helpers.",
+  },
+] satisfies ReadonlyArray<Omit<CommandDiscoveryMetadata, "order">>;
+
+const COMMAND_METADATA: ReadonlyArray<CommandDiscoveryMetadata> =
+  COMMAND_DISCOVERY.map((entry, index) => ({
+    ...entry,
+    order: index,
+  }));
+
+const METADATA_BY_NAME = new Map(
+  COMMAND_METADATA.map((entry) => [entry.name, entry]),
+);
+
+export function getCommandDiscoveryMetadata(): CommandDiscoveryMetadata[] {
+  return COMMAND_METADATA.map((entry) => ({ ...entry }));
+}
+
+export function getCommandDiscoveryForCommand(
+  name: string,
+): CommandDiscoveryMetadata | undefined {
+  const entry = METADATA_BY_NAME.get(name);
+  return entry ? { ...entry } : undefined;
+}
+
+export function formatGhostHelp(
+  cli: CAC,
+  sections: HelpSection[],
+): HelpSection[] {
+  if (cli.matchedCommand) return sections;
+
+  const baseSections = pickBaseSections(sections);
+  const showAll = Boolean(
+    (cli.options as Record<string, unknown> | undefined)?.all,
+  );
+  const commandSections = showAll
+    ? formatAllCommandSections(cli.commands)
+    : formatDefaultCommandSections(cli.commands);
+
+  return [
+    baseSections.header,
+    baseSections.usage,
+    ...commandSections,
+    ...(showAll ? [formatCommandHelpSection(cli.commands, cli.name)] : []),
+    ...(showAll ? [] : [formatMoreSection()]),
+    baseSections.options,
+  ].filter(isSection);
+}
+
+function pickBaseSections(sections: HelpSection[]): {
+  header?: HelpSection;
+  usage?: HelpSection;
+  options?: HelpSection;
+} {
+  return {
+    header: sections.find((section) => !section.title),
+    usage: sections.find((section) => section.title === "Usage"),
+    options: sections.find((section) => section.title === "Options"),
+  };
+}
+
+function formatDefaultCommandSections(commands: Command[]): HelpSection[] {
+  return [
+    {
+      title: "Core workflow",
+      body: formatCommandRows(
+        commands.filter((command) => metadataFor(command)?.defaultHelp),
+        "compact",
+      ),
+    },
+  ];
+}
+
+function formatAllCommandSections(commands: Command[]): HelpSection[] {
+  const grouped = GROUPS.map(({ group, title }) => ({
+    title,
+    body: formatCommandRows(
+      commands.filter((command) => metadataFor(command)?.group === group),
+      "raw",
+    ),
+  })).filter((section) => section.body.length > 0);
+
+  const uncategorized = commands.filter((command) => !metadataFor(command));
+  if (uncategorized.length > 0) {
+    grouped.push({
+      title: "Other",
+      body: formatCommandRows(uncategorized, "raw"),
+    });
+  }
+
+  return grouped;
+}
+
+function formatCommandRows(
+  commands: Command[],
+  mode: "compact" | "raw",
+): string {
+  const sorted = [...commands].sort(compareCommands);
+  const rows = sorted.map((command) => {
+    const metadata = metadataFor(command);
+    const displayName =
+      mode === "compact"
+        ? (metadata?.compactName ?? command.name)
+        : command.rawName;
+    const summary = metadata?.summary ?? command.description;
+    return { displayName, summary };
+  });
+  const width = Math.max(...rows.map((row) => row.displayName.length), 0);
+  return rows
+    .map((row) => `  ${padRight(row.displayName, width)}  ${row.summary}`)
+    .join("\n");
+}
+
+function formatCommandHelpSection(
+  commands: Command[],
+  cliName: string,
+): HelpSection {
+  const sorted = [...commands].sort(compareCommands);
+  return {
+    title: "For command-specific help",
+    body: sorted
+      .map((command) => `  $ ${cliName} ${command.name} --help`)
+      .join("\n"),
+  };
+}
+
+function formatMoreSection(): HelpSection {
+  return {
+    title: "More",
+    body: [
+      "  $ ghost --help --all      Show all advanced and legacy commands",
+      "  $ ghost <command> --help  Show command-specific options",
+    ].join("\n"),
+  };
+}
+
+function compareCommands(a: Command, b: Command): number {
+  const aOrder = metadataFor(a)?.order ?? Number.MAX_SAFE_INTEGER;
+  const bOrder = metadataFor(b)?.order ?? Number.MAX_SAFE_INTEGER;
+  return aOrder - bOrder || a.name.localeCompare(b.name);
+}
+
+function metadataFor(command: Command): CommandDiscoveryMetadata | undefined {
+  return METADATA_BY_NAME.get(command.name);
+}
+
+function padRight(value: string, width: number): string {
+  return value + " ".repeat(Math.max(0, width - value.length));
+}
+
+function isSection(section: HelpSection | undefined): section is HelpSection {
+  return Boolean(section);
+}

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -123,13 +123,80 @@ describe("ghost CLI", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  it("prints top-level help for the unified ghost bin", async () => {
+  it("prints compact top-level help for new adopters", async () => {
     const result = await runCli(["--help"], dir, { allowNoExit: true });
 
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("ghost");
-    expect(result.stdout).toContain("skill");
+    expect(result.stdout).toContain("Core workflow");
+    for (const command of [
+      "init",
+      "scan",
+      "lint",
+      "verify",
+      "check",
+      "review",
+      "emit",
+      "skill install",
+    ]) {
+      expect(result.stdout).toContain(command);
+    }
+    expect(result.stdout).toContain("ghost --help --all");
+    expect(result.stdout).not.toContain("survey <op>");
+    expect(result.stdout).not.toContain("diff <a> <b>");
+    expect(result.stdout).not.toMatch(/\n {2}ack\s/);
+    expect(result.stdout).not.toContain("track <fingerprint>");
+    expect(result.stdout).not.toContain("diverge <dimension>");
     expect(result.stdout).not.toContain("proposal <op>");
+  });
+
+  it("prints the complete grouped command index with --help --all", async () => {
+    const result = await runCli(["--help", "--all"], dir, {
+      allowNoExit: true,
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Core workflow");
+    expect(result.stdout).toContain("Advanced/package inspection");
+    expect(result.stdout).toContain("Compare/stance");
+    expect(result.stdout).toContain("Legacy/cache");
+    for (const command of [
+      "lint [file]",
+      "init [dir]",
+      "verify [dir]",
+      "scan [dir]",
+      "stack [paths...]",
+      "inventory [path]",
+      "describe [fingerprint]",
+      "diff <a> <b>",
+      "survey <op> [...surveys]",
+      "emit <kind>",
+      "compare [...fingerprints]",
+      "ack",
+      "track <fingerprint>",
+      "diverge <dimension>",
+      "skill <action>",
+      "check",
+      "review",
+    ]) {
+      expect(result.stdout).toContain(command);
+    }
+  });
+
+  it("keeps command-specific --all help local to lint and verify", async () => {
+    const lint = await runCli(["lint", "--help"], dir, { allowNoExit: true });
+    const verify = await runCli(["verify", "--help"], dir, {
+      allowNoExit: true,
+    });
+
+    expect(lint.code).toBe(0);
+    expect(lint.stdout).toContain("--all");
+    expect(lint.stdout).toContain("Validate every nested fingerprint package");
+    expect(lint.stdout).not.toContain("Core workflow");
+    expect(verify.code).toBe(0);
+    expect(verify.stdout).toContain("--all");
+    expect(verify.stdout).toContain("Verify every nested fingerprint package");
+    expect(verify.stdout).not.toContain("Core workflow");
   });
 
   it("compares explicitly supplied fingerprint files", async () => {

--- a/scripts/dump-cli-help.mjs
+++ b/scripts/dump-cli-help.mjs
@@ -35,23 +35,44 @@ for (const tool of TOOLS) {
     );
     process.exit(1);
   }
-  const { buildCli } = await import(pathToFileURL(cliDist).href);
+  const cliModule = await import(pathToFileURL(cliDist).href);
+  const { buildCli } = cliModule;
   const cli = buildCli();
+  const discoveryMetadata =
+    tool.name === "ghost" &&
+    typeof cliModule.getCommandDiscoveryMetadata === "function"
+      ? new Map(
+          cliModule
+            .getCommandDiscoveryMetadata()
+            .map((entry) => [entry.name, entry]),
+        )
+      : new Map();
 
-  const commands = cli.commands.map((cmd) => ({
-    tool: tool.name,
-    name: cmd.name,
-    rawName: cmd.rawName,
-    description: cmd.description,
-    options: cmd.options.map((o) => ({
-      rawName: o.rawName,
-      name: o.name,
-      description: o.description,
-      default: o.config?.default ?? null,
-      takesValue: /<[^>]+>/.test(o.rawName),
-      negated: Boolean(o.negated),
-    })),
-  }));
+  const commands = cli.commands.map((cmd) => {
+    const discovery = discoveryMetadata.get(cmd.name);
+    return {
+      tool: tool.name,
+      name: cmd.name,
+      rawName: cmd.rawName,
+      description: cmd.description,
+      ...(discovery
+        ? {
+            group: discovery.group,
+            defaultHelp: discovery.defaultHelp,
+            compactName: discovery.compactName,
+            summary: discovery.summary,
+          }
+        : {}),
+      options: cmd.options.map((o) => ({
+        rawName: o.rawName,
+        name: o.name,
+        description: o.description,
+        default: o.config?.default ?? null,
+        takesValue: /<[^>]+>/.test(o.rawName),
+        negated: Boolean(o.negated),
+      })),
+    };
+  });
 
   const globalOptions = cli.globalCommand.options.map((o) => ({
     rawName: o.rawName,


### PR DESCRIPTION
## Summary
- Add Ghost-owned command discovery metadata and compact top-level help.
- Keep all commands callable while exposing the full grouped index via ghost --help --all.
- Extend the generated CLI manifest with optional discovery metadata and update docs.

## Tests
- pnpm build
- pnpm check
- pnpm test