### PR TITLE
[codex] Document Ghost beta status

### DIFF
--- a/.changeset/beta-status-notice.md
+++ b/.changeset/beta-status-notice.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Document that Ghost is pre-1.0 beta software and may ship breaking changes during active development.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Advanced workflows can add nested fingerprint packages for product areas, custom
 comparison. Those features stay available, but the core loop is just
 `fingerprint/`, optional active checks, and Git review.
 
+## Project Status: Beta
+
+Ghost is pre-1.0 and under active development. The CLI, fingerprint schema,
+on-disk `.ghost/fingerprint/` package shape, and public JavaScript exports may
+change in breaking ways before a stable 1.0 release.
+
+Breaking changes may ship in minor versions while Ghost is pre-1.0. Patch
+versions are reserved for fixes that should not require migration. If you adopt
+Ghost today, expect some churn, pin the version you depend on, and review
+release notes before upgrading.
+
 ## Install
 
 The public npm package is **`@anarchitecture/ghost`**. It installs one CLI:

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -39,6 +39,19 @@ root-to-leaf for the file or diff being reviewed.
 
 </DocSection>
 
+<DocSection title="Project Status: Beta">
+
+Ghost is pre-1.0 and under active development. The CLI, fingerprint schema,
+on-disk `.ghost/fingerprint/` package shape, and public JavaScript exports may
+change in breaking ways before a stable 1.0 release.
+
+Breaking changes may ship in minor versions while Ghost is pre-1.0. Patch
+versions are reserved for fixes that should not require migration. If you adopt
+Ghost today, expect some churn, pin the version you depend on, and review
+release notes before upgrading.
+
+</DocSection>
+
 <DocSection title="Install Ghost">
 
 ```bash

--- a/packages/ghost/README.md
+++ b/packages/ghost/README.md
@@ -6,6 +6,17 @@ Ghost initializes root `.ghost/fingerprint/` memory, checks diffs against
 deterministic gates, emits advisory review packets, compares packages, and
 records intentional drift. It ships one CLI: `ghost`.
 
+## Project Status: Beta
+
+Ghost is pre-1.0 and under active development. The CLI, fingerprint schema,
+on-disk `.ghost/fingerprint/` package shape, and public JavaScript exports may
+change in breaking ways before a stable 1.0 release.
+
+Breaking changes may ship in minor versions while Ghost is pre-1.0. Patch
+versions are reserved for fixes that should not require migration. If you adopt
+Ghost today, expect some churn, pin the version you depend on, and review
+release notes before upgrading.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a visible beta/pre-1.0 status notice to the repo README, npm package README, and docs getting-started page.
- Clarify that the CLI, fingerprint schema, on-disk `.ghost/fingerprint/` package shape, and public JavaScript exports may break before 1.0.
- Add a patch changeset for the public package docs update.

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm test`