### PR TITLE
[codex] Render beta status as warning banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ comparison. Those features stay available, but the core loop is just
 
 ## Project Status: Beta
 
-Ghost is pre-1.0 and under active development. The CLI, fingerprint schema,
-on-disk `.ghost/fingerprint/` package shape, and public JavaScript exports may
-change in breaking ways before a stable 1.0 release.
-
-Breaking changes may ship in minor versions while Ghost is pre-1.0. Patch
-versions are reserved for fixes that should not require migration. If you adopt
-Ghost today, expect some churn, pin the version you depend on, and review
-release notes before upgrading.
+> [!WARNING]
+> Ghost is pre-1.0 and under active development. The CLI, fingerprint schema,
+> on-disk `.ghost/fingerprint/` package shape, and public JavaScript exports may
+> change in breaking ways before a stable 1.0 release.
+>
+> Breaking changes may ship in minor versions while Ghost is pre-1.0. Patch
+> versions are reserved for fixes that should not require migration. If you adopt
+> Ghost today, expect some churn, pin the version you depend on, and review
+> release notes before upgrading.
 
 ## Install
 

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -41,6 +41,8 @@ root-to-leaf for the file or diff being reviewed.
 
 <DocSection title="Project Status: Beta">
 
+<Callout variant="warning" title="Beta / pre-1.0">
+
 Ghost is pre-1.0 and under active development. The CLI, fingerprint schema,
 on-disk `.ghost/fingerprint/` package shape, and public JavaScript exports may
 change in breaking ways before a stable 1.0 release.
@@ -49,6 +51,8 @@ Breaking changes may ship in minor versions while Ghost is pre-1.0. Patch
 versions are reserved for fixes that should not require migration. If you adopt
 Ghost today, expect some churn, pin the version you depend on, and review
 release notes before upgrading.
+
+</Callout>
 
 </DocSection>
 

--- a/packages/ghost/README.md
+++ b/packages/ghost/README.md
@@ -8,14 +8,15 @@ records intentional drift. It ships one CLI: `ghost`.
 
 ## Project Status: Beta
 
-Ghost is pre-1.0 and under active development. The CLI, fingerprint schema,
-on-disk `.ghost/fingerprint/` package shape, and public JavaScript exports may
-change in breaking ways before a stable 1.0 release.
-
-Breaking changes may ship in minor versions while Ghost is pre-1.0. Patch
-versions are reserved for fixes that should not require migration. If you adopt
-Ghost today, expect some churn, pin the version you depend on, and review
-release notes before upgrading.
+> [!WARNING]
+> Ghost is pre-1.0 and under active development. The CLI, fingerprint schema,
+> on-disk `.ghost/fingerprint/` package shape, and public JavaScript exports may
+> change in breaking ways before a stable 1.0 release.
+>
+> Breaking changes may ship in minor versions while Ghost is pre-1.0. Patch
+> versions are reserved for fixes that should not require migration. If you adopt
+> Ghost today, expect some churn, pin the version you depend on, and review
+> release notes before upgrading.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Render the beta/pre-1.0 notice as GitHub warning callouts in both READMEs.
- Wrap the docs getting-started beta notice in the existing warning `Callout` component for a yellow banner treatment.

## Validation

- `pnpm build`
- `pnpm check`
- `pnpm test`