### PR TITLE
[codex] Document collaborative fingerprint authoring

### DIFF
--- a/.changeset/collaborative-fingerprint-authoring.md
+++ b/.changeset/collaborative-fingerprint-authoring.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Document collaborative human-agent fingerprint authoring scenarios in the installed Ghost skill and public docs.

--- a/apps/docs/src/content/docs/fingerprint-authoring.mdx
+++ b/apps/docs/src/content/docs/fingerprint-authoring.mdx
@@ -1,0 +1,100 @@
+---
+title: Fingerprint Authoring
+description: Co-author Ghost fingerprints with human intent, repo evidence, agent synthesis, and Git review.
+kicker: Docs
+section: guide
+order: 20
+slug: fingerprint-authoring
+---
+
+<DocSection title="The Authoring Model">
+
+A Ghost fingerprint is not a scan dump. It is durable product-experience memory
+that a human and agent shape together.
+
+The human decides identity: what the product should feel like, who it serves,
+which situations matter, and what should not drift. Repo scans provide evidence:
+components, routes, docs, stories, copy, screenshots, tokens, examples, and UI
+library references. The agent synthesizes drafts, but ordinary Git review is
+where fingerprint edits become canonical.
+
+</DocSection>
+
+<DocSection title="Scenario Matrix">
+
+Start by classifying the authoring scenario. The scenario determines how much
+weight to give human intent, existing code, and library evidence.
+
+| Scenario | Authoring posture |
+| --- | --- |
+| Net new repo | Human-led. Capture intent, audience, posture, and early anti-goals before inventory grows. |
+| Net new repo + UI library | Human-led with library evidence. Explain how this product uses the library. |
+| Existing repo | Human + scan. Find repeated patterns and exemplars, then ask which ones are canonical. |
+| Existing repo with mixed quality | Curated scan. Separate product memory from legacy debt and accidental repetition. |
+| Design system or UI library | Grammar-led. Describe primitives, tokens, component behavior, accessibility, and composition constraints. |
+| Rebrand, redesign, or migration | Human-led transition. Capture current, target, and migration cautions. |
+| Prototype becoming product | Ratification-led. Preserve only the emergent patterns humans want to keep. |
+| Fork, white label, or tenant variant | Shared base + local divergence. Keep common identity broad and local differences scoped. |
+| Monorepo or nested surfaces | Stack-aware. Use root guidance for broad identity and nested packages for surfaces judged differently. |
+
+</DocSection>
+
+<DocSection title="Guided Workflow">
+
+1. **Interview** - ask what the product should feel like, who it serves, which
+   surfaces show it at its best, and which existing patterns are accidental or
+   legacy.
+2. **Scan** - inspect routes, components, stories, tests, docs, screenshots,
+   copy, tokens, assets, and UI library references.
+3. **Draft** - write the smallest useful `prose.yml`, `inventory.yml`, and
+   `composition.yml` entries.
+4. **Curate** - have the human keep, soften, reject, scope, or record important
+   claims before treating them as durable memory.
+5. **Validate** - run Ghost validation and use Git review as the approval
+   boundary.
+
+```bash
+ghost scan --format json
+mkdir -p .ghost/fingerprint/sources/cache
+ghost inventory . > .ghost/fingerprint/sources/cache/inventory.json
+ghost lint .ghost
+ghost verify .ghost --root .
+ghost check --base HEAD
+```
+
+Generated cache is source material only. It can support curated inventory, but
+it does not establish product judgment by itself.
+
+</DocSection>
+
+<DocSection title="Nested Packages">
+
+Nested fingerprints are opt-in. Create a local `.ghost/` only when a surface
+would be judged differently from the root product fingerprint.
+
+Use a nested package when a surface has distinct users, information density,
+trust or recovery posture, interaction rhythm, component grammar, UI library
+usage, or review criteria for the same UI decision.
+
+Keep broad product-family guidance at the root. Put local obligations in the
+nearest package that owns the surface.
+
+```bash
+ghost stack apps/checkout
+ghost lint --all
+ghost verify --all
+```
+
+</DocSection>
+
+<DocSection title="Ratification">
+
+Uncommitted or unmerged fingerprint edits are drafts. Checked-in
+`fingerprint/` core files are canonical.
+
+Use optional `fingerprint/memory/intent.md` only for human-authored or
+human-approved intent. Use `fingerprint/memory/decisions/` for rationale that
+explains why a product choice changed. Add deterministic checks sparingly, and
+only when a rule can be enforced without subjective judgment.
+
+</DocSection>

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -105,7 +105,8 @@ ghost verify --all
 
 Generated cache is optional source material. Curate durable prose, inventory,
 and composition into the core layer files, then use normal Git review for
-approval.
+approval. For a fuller human-agent workflow, read
+[Fingerprint Authoring](/docs/fingerprint-authoring).
 
 For generation, emit the upstream handoff packet:
 

--- a/install/manifest.json
+++ b/install/manifest.json
@@ -8,6 +8,7 @@
   },
   "files": [
     "SKILL.md",
+    "references/authoring-scenarios.md",
     "references/brief.md",
     "references/capture.md",
     "references/compare.md",

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -83,6 +83,7 @@ or check format.
 
 ## Workflows
 
+- Collaborative authoring scenarios: follow [references/authoring-scenarios.md](references/authoring-scenarios.md).
 - Fingerprint capture: follow [references/capture.md](references/capture.md).
 - Author fingerprint patterns: follow [references/patterns.md](references/patterns.md).
 - Recall product-experience context: follow [references/recall.md](references/recall.md).

--- a/packages/ghost/src/skill-bundle/references/authoring-scenarios.md
+++ b/packages/ghost/src/skill-bundle/references/authoring-scenarios.md
@@ -1,0 +1,148 @@
+---
+name: authoring-scenarios
+description: Choose the right human-agent workflow for authoring Ghost fingerprints.
+handoffs:
+  - label: Inspect fingerprint readiness
+    command: ghost scan --format json
+    prompt: Classify this repo's fingerprint authoring scenario and summarize missing layers.
+  - label: Inspect nested stacks
+    command: ghost stack <path>
+    prompt: Decide whether this path needs local fingerprint guidance or can inherit the root package.
+---
+
+# Recipe: Collaborative Fingerprint Authoring
+
+**Goal:** help a human and agent co-author durable product-experience memory
+without turning raw repo scans into product truth.
+
+Human intent decides identity. Code, docs, examples, screenshots, stories, and
+UI libraries provide evidence. Agent synthesis is draft work until the human
+curates it and ordinary Git review accepts it.
+
+## 1. Classify The Scenario
+
+Choose the nearest scenario before writing fingerprint layers:
+
+| Scenario | Default authoring posture |
+| --- | --- |
+| Net new repo | Human-led. Capture intent, audience, product posture, and early anti-goals before adding much inventory. |
+| Net new repo + UI library | Human-led with library evidence. Record how this product uses the library, not just that the library exists. |
+| Existing repo | Human + scan. Use repo scans to find repeated patterns and exemplars; ask which ones are canonical. |
+| Existing repo with mixed quality | Curated scan. Separate canonical examples from drift, legacy debt, and accidental repetition. |
+| Design system or UI library | Grammar-led. Describe primitives, component behavior, token posture, accessibility, and composition constraints. |
+| Rebrand, redesign, or migration | Human-led transition. Capture current, target, and migration cautions; use decisions for rationale. |
+| Prototype becoming product | Ratification-led. Preserve only the emergent patterns a human wants to keep. |
+| Fork, white label, or tenant variant | Shared base + local divergence. Keep common identity broad and local differences scoped. |
+| Monorepo or nested surfaces | Stack-aware. Use root guidance for product-family identity and nested packages for surfaces judged differently. |
+
+If more than one scenario applies, start with the broad repo scenario, then run
+the nested decision test for individual products, apps, or feature areas.
+
+## 2. Interview The Human
+
+Ask only high-leverage questions that change the fingerprint:
+
+- What should this product feel like, and what should it never become?
+- Who is the audience, and what are they trying to get done?
+- Which screens, flows, stories, or examples show the product at its best?
+- Which current patterns are legacy, accidental, experimental, or low quality?
+- Where do trust, density, pacing, accessibility, recovery, or disclosure matter most?
+- Are there surfaces where the same UI decision should be judged differently?
+
+Use human-authored or human-approved answers in `prose.yml` and optional
+`fingerprint/memory/intent.md`. Do not treat unapproved notes as canonical.
+
+## 3. Scan For Evidence
+
+Read the product, not just the component library. Inspect routes, components,
+stories, tests, docs, screenshots, examples, copy, tokens, assets, and UI
+library references that reveal identity, hierarchy, behavior, accessibility,
+trust, and flow.
+
+Optional cache:
+
+```bash
+mkdir -p .ghost/fingerprint/sources/cache
+ghost inventory . > .ghost/fingerprint/sources/cache/inventory.json
+```
+
+Treat generated cache as scratch evidence. It can support curated entries in
+`inventory.yml`, but it does not establish product judgment by itself.
+
+## 4. Draft The Core Layers
+
+Write the smallest useful durable content:
+
+- `prose.yml`: product summary, audience, situations, principles, contracts,
+  anti-goals, and tradeoffs.
+- `inventory.yml`: topology, building blocks, source links, and curated
+  exemplars the agent can inspect or use.
+- `composition.yml`: patterns, layouts, structures, flows, states, content,
+  behavior, and visual arrangements.
+
+Label uncertain reasoning in the working notes as provisional. Prefer a few
+high-confidence claims with evidence over a broad catalog.
+
+## 5. Curate With The Human
+
+Before treating draft content as durable memory, ask the human to classify
+important claims:
+
+- keep as canonical
+- soften into guidance
+- reject as accidental or legacy
+- move to generated cache or scratch notes
+- scope to a nested package
+- record as a decision
+- convert into a deterministic check
+
+Only add checks when the rule can be enforced deterministically. Subjective
+composition judgment belongs in `composition.yml` or advisory review, not in a
+blocking gate.
+
+## 6. Decide Nested Packages
+
+Create or update a local `.ghost/` only when a surface would be judged
+differently from the root package.
+
+Use a nested package when the local surface has distinct:
+
+- users or jobs-to-be-done
+- density or information architecture
+- trust, safety, privacy, or recovery posture
+- interaction rhythm or workflow length
+- component grammar or UI library usage
+- review criteria for the same UI decision
+
+Keep broad product-family guidance at the root. Put local obligations in the
+nearest package that owns the surface. Validate nested repos with stack-aware
+commands:
+
+```bash
+ghost stack <path>
+ghost lint --all
+ghost verify --all
+```
+
+## 7. Validate And Ratify
+
+Validate before calling layers complete:
+
+```bash
+ghost lint .ghost
+ghost verify .ghost --root <target>
+ghost check --base HEAD
+```
+
+Use ordinary Git review as the approval boundary. Uncommitted or unmerged
+fingerprint edits are drafts; checked-in `fingerprint/` core files are the
+canonical package.
+
+## Never
+
+- Never copy raw inventory into canonical layers without curation.
+- Never claim scan frequency is product authority.
+- Never make `fingerprint/memory/intent.md` authoritative unless human-authored
+  or human-approved.
+- Never create nested packages just to mirror directory structure.
+- Never turn advisory composition judgment into a deterministic gate.

--- a/packages/ghost/src/skill-bundle/references/capture.md
+++ b/packages/ghost/src/skill-bundle/references/capture.md
@@ -37,7 +37,27 @@ generation; they are not generation input.
 
 ## Steps
 
-### 1. Initialize
+### 1. Classify The Authoring Scenario
+
+Before initialization or edits, decide which authoring posture fits this repo.
+Follow [authoring-scenarios.md](authoring-scenarios.md) when the user is setting
+up or substantially revising a fingerprint.
+
+Common starting points:
+
+- Net new repos are mostly human-led because the repo has little evidence.
+- Net new repos with a UI library combine human intent with library scans.
+- Existing repos combine human judgment with code, docs, route, story, and
+  exemplar scans.
+- Existing repos with mixed quality require curation before repeated patterns
+  become canonical.
+- Monorepos and product suites need a nested-package decision pass before local
+  surfaces inherit or add guidance.
+
+Human intent decides product identity. Scans provide evidence. Agent synthesis
+is draft work until a human curates it and ordinary Git review accepts it.
+
+### 2. Initialize
 
 ```bash
 ghost init
@@ -48,7 +68,7 @@ Use `--with-intent` only when you have human-authored or human-approved context
 to preserve. Use `--with-config --reference <path-or-registry>` when local
 routing or a reference UI registry/library should be recorded in `.ghost/config.yml`.
 
-### 2. Orient
+### 3. Orient
 
 Read the product, not just the component library. Look for surfaces, docs,
 tests, stories, routes, screenshots, or examples that reveal identity,
@@ -64,7 +84,7 @@ ghost inventory . > .ghost/fingerprint/sources/cache/inventory.json
 Treat generated cache as scratch material. Do not copy raw inventory into
 `inventory.yml` without judgment.
 
-### 3. Write Core Layers
+### 4. Write Core Layers
 
 Edit the smallest useful durable layer content:
 
@@ -74,8 +94,10 @@ Edit the smallest useful durable layer content:
   behavior, and visual arrangements.
 
 Prefer a few high-confidence entries over a comprehensive but noisy catalog.
+Ask the human to keep, soften, reject, scope, or record important claims before
+treating draft content as durable fingerprint guidance.
 
-### 4. Add Checks Sparingly
+### 5. Add Checks Sparingly
 
 `fingerprint/enforcement/checks.yml` is the executable appendix. Add only
 deterministic checks with typed derivation refs:
@@ -90,7 +112,7 @@ Ref-backed checks are preferred. Missing or unresolved derivation refs lint as
 warnings. Inventory can support a check, but inventory-only grounding is not
 product judgment by itself.
 
-### 5. Validate
+### 6. Validate
 
 ```bash
 ghost lint .ghost


### PR DESCRIPTION
## Summary

- Add a collaborative authoring scenarios recipe to the installed Ghost skill bundle.
- Update the capture recipe so fingerprint setup starts with scenario classification and human curation.
- Add public docs for human-agent fingerprint authoring and link them from Getting Started.
- Include the new skill recipe in the install manifest and add a patch changeset.

## Validation

- `pnpm test -- packages/ghost/test/cli.test.ts packages/ghost/test/skill-bundle-manifest.test.ts`
- `pnpm check:docs`
- `pnpm check:install-bundle`
- `pnpm check`
- pre-commit hook: `pnpm check`
- pre-push hook: `pnpm build`, `pnpm check`, `pnpm test`