### PR TITLE
[codex] Add fingerprint-first public exports

### DIFF
--- a/.changeset/fingerprint-first-public-exports.md
+++ b/.changeset/fingerprint-first-public-exports.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": minor
+---
+
+Add fingerprint-first public export aliases for fingerprint, governance, and comparison APIs.

--- a/packages/ghost-fleet/src/core/compute.ts
+++ b/packages/ghost-fleet/src/core/compute.ts
@@ -1,4 +1,4 @@
-import { compareFingerprints } from "@anarchitecture/ghost/core";
+import { compareFingerprints } from "@anarchitecture/ghost/compare";
 import type {
   FleetGroupingsComputed,
   FleetMember,

--- a/packages/ghost-fleet/src/core/members.ts
+++ b/packages/ghost-fleet/src/core/members.ts
@@ -11,7 +11,7 @@ import {
 import {
   FINGERPRINT_FILENAME,
   loadFingerprint,
-} from "@anarchitecture/ghost/scan";
+} from "@anarchitecture/ghost/fingerprint";
 import { parse as parseYaml } from "yaml";
 import { FLEET_MEMBERS_DIRNAME } from "./schema.js";
 import type { FleetMember, MemberSummary } from "./types.js";

--- a/packages/ghost/README.md
+++ b/packages/ghost/README.md
@@ -55,13 +55,13 @@ host opts in.
 ## Library
 
 ```ts
-import { compare, runGhostDriftCheck } from "@anarchitecture/ghost/drift";
+import { compare } from "@anarchitecture/ghost/compare";
+import { runGhostCheck } from "@anarchitecture/ghost/govern";
 import {
   initFingerprintPackage,
   lintFingerprintPackage,
   verifyFingerprintPackage,
-} from "@anarchitecture/ghost/scan";
-import { compareFingerprints } from "@anarchitecture/ghost/core";
+} from "@anarchitecture/ghost/fingerprint";
 ```
 
 ## BYOA

--- a/packages/ghost/package.json
+++ b/packages/ghost/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anarchitecture/ghost",
   "version": "0.5.0",
-  "description": "Unified Ghost CLI for repo-local product fingerprints, deterministic checks, advisory review, and drift tracking",
+  "description": "Unified Ghost CLI for portable product-experience fingerprints, deterministic checks, advisory review, and comparison",
   "license": "Apache-2.0",
   "author": "Block, Inc.",
   "repository": {
@@ -13,9 +13,9 @@
     "url": "https://github.com/block/ghost/issues"
   },
   "keywords": [
-    "design-system",
-    "drift-detection",
     "fingerprint",
+    "product-experience",
+    "design-system",
     "design-tokens",
     "shadcn",
     "design-language",
@@ -45,6 +45,18 @@
     "./core": {
       "types": "./dist/ghost-core/index.d.ts",
       "import": "./dist/ghost-core/index.js"
+    },
+    "./fingerprint": {
+      "types": "./dist/fingerprint.d.ts",
+      "import": "./dist/fingerprint.js"
+    },
+    "./govern": {
+      "types": "./dist/govern.d.ts",
+      "import": "./dist/govern.js"
+    },
+    "./compare": {
+      "types": "./dist/compare.d.ts",
+      "import": "./dist/compare.js"
     },
     "./drift": {
       "types": "./dist/core/index.d.ts",

--- a/packages/ghost/src/compare.ts
+++ b/packages/ghost/src/compare.ts
@@ -1,0 +1,18 @@
+export type {
+  CompareOptions,
+  CompareResult,
+  CompositeComparison,
+  EnrichedComparison,
+  FingerprintComparison,
+  TemporalComparison,
+} from "./core/index.js";
+export {
+  compare,
+  compareFingerprints,
+  formatComparison,
+  formatComparisonJSON,
+  formatCompositeComparison,
+  formatCompositeComparisonJSON,
+  formatTemporalComparison,
+  formatTemporalComparisonJSON,
+} from "./core/index.js";

--- a/packages/ghost/src/fingerprint.ts
+++ b/packages/ghost/src/fingerprint.ts
@@ -1,0 +1,1 @@
+export * from "./scan/index.js";

--- a/packages/ghost/src/govern.ts
+++ b/packages/ghost/src/govern.ts
@@ -1,0 +1,14 @@
+export type {
+  GhostDriftChangedFile as GhostCheckChangedFile,
+  GhostDriftChangedLine as GhostCheckChangedLine,
+  GhostDriftCheckFinding as GhostCheckFinding,
+  GhostDriftCheckOptions as GhostCheckOptions,
+  GhostDriftCheckReport as GhostCheckReport,
+  GhostDriftCheckStack as GhostCheckStack,
+  GhostDriftRoutedFile as GhostCheckRoutedFile,
+} from "./core/index.js";
+export * from "./core/index.js";
+export {
+  formatGhostDriftCheckMarkdown as formatGhostCheckMarkdown,
+  runGhostDriftCheck as runGhostCheck,
+} from "./core/index.js";

--- a/packages/ghost/src/index.ts
+++ b/packages/ghost/src/index.ts
@@ -1,4 +1,12 @@
+import * as compareApi from "./compare.js";
+import { compare as compareFunction } from "./core/index.js";
+
+/** @deprecated Use `govern`, `compare`, `@anarchitecture/ghost/govern`, or `@anarchitecture/ghost/compare`. */
 export * as drift from "./core/index.js";
 export * from "./core/index.js";
+export const compare = Object.assign(compareFunction, compareApi);
+export * as fingerprint from "./fingerprint.js";
 export * as core from "./ghost-core/index.js";
+export * as govern from "./govern.js";
+/** @deprecated Use `fingerprint` or `@anarchitecture/ghost/fingerprint`. */
 export * as scan from "./scan/index.js";

--- a/packages/ghost/test/public-exports.test.ts
+++ b/packages/ghost/test/public-exports.test.ts
@@ -1,0 +1,34 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const hasBuiltExports = existsSync(
+  resolve(REPO_ROOT, "packages/ghost/dist/fingerprint.js"),
+);
+
+describe.runIf(hasBuiltExports)("built public exports", () => {
+  it("exposes fingerprint-first package subpaths", async () => {
+    const [fingerprint, govern, compareApi] = await Promise.all([
+      import("@anarchitecture/ghost/fingerprint"),
+      import("@anarchitecture/ghost/govern"),
+      import("@anarchitecture/ghost/compare"),
+    ]);
+
+    expect(fingerprint.initFingerprintPackage).toBeTypeOf("function");
+    expect(fingerprint.lintFingerprintPackage).toBeTypeOf("function");
+    expect(fingerprint.scanStatus).toBeTypeOf("function");
+
+    expect(govern.runGhostCheck).toBeTypeOf("function");
+    expect(govern.runGhostCheck).toBe(govern.runGhostDriftCheck);
+    expect(govern.formatGhostCheckMarkdown).toBeTypeOf("function");
+    expect(govern.formatGhostCheckMarkdown).toBe(
+      govern.formatGhostDriftCheckMarkdown,
+    );
+
+    expect(compareApi.compare).toBeTypeOf("function");
+    expect(compareApi.compareFingerprints).toBeTypeOf("function");
+    expect(compareApi.formatComparison).toBeTypeOf("function");
+  });
+});


### PR DESCRIPTION
## Summary

- Add fingerprint-first public subpath exports for fingerprint, governance, and comparison APIs.
- Keep existing `scan` and `drift` subpaths as compatibility aliases while updating package projection and README examples to the new names.
- Update `ghost-fleet` consumers and add built-package smoke coverage for the new subpaths.

## Validation

- `pnpm build`
- `pnpm check`
- `pnpm test`