### PR TITLE
[codex] Fix review package decision memory

### DIFF
--- a/.changeset/review-package-decision-memory.md
+++ b/.changeset/review-package-decision-memory.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Read accepted decisions from the canonical rationale directory during single-package review.

--- a/packages/ghost/src/review-packet.ts
+++ b/packages/ghost/src/review-packet.ts
@@ -2,11 +2,7 @@ import type { Dirent } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import {
-  GHOST_DECISIONS_DIRNAME,
-  type GhostDecisionDocument,
-  lintGhostDecision,
-} from "#ghost-core";
+import { type GhostDecisionDocument, lintGhostDecision } from "#ghost-core";
 import { parseUnifiedDiff } from "./core/index.js";
 import {
   type GhostFingerprintStack,
@@ -43,9 +39,7 @@ async function buildSingleBundleReviewPacket(options: {
     config: (await readOptionalPackageConfig(paths.config)) ?? null,
   };
   if (options.includeAcceptedDecisions) {
-    packet.accepted_decisions = await readAcceptedDecisions(
-      resolve(paths.dir, GHOST_DECISIONS_DIRNAME),
-    );
+    packet.accepted_decisions = await readAcceptedDecisions(paths.decisions);
   }
   return packet;
 }
@@ -294,7 +288,7 @@ function formatAcceptedDecisionsSection(
   if (decisions.length === 0) {
     return `## Accepted Product-Experience Decisions
 
-_No accepted decisions found in .ghost/decisions._
+_No accepted decisions found in fingerprint/memory/decisions._
 `;
   }
 

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -1078,6 +1078,64 @@ libraries:
     );
   });
 
+  it("review --package includes only accepted decisions when requested", async () => {
+    await writeCheckPackage(dir);
+    await writeMemoryFiles(dir);
+    await writeFile(
+      join(dir, "change.patch"),
+      lendingPatch("let color = CashTheme.primary"),
+    );
+
+    const result = await runCli(
+      [
+        "review",
+        "--diff",
+        "change.patch",
+        "--package",
+        ".ghost",
+        "--include-memory",
+        "--format",
+        "json",
+      ],
+      dir,
+    );
+
+    expect(result.code).toBe(0);
+    const packet = JSON.parse(result.stdout);
+    expect(packet.accepted_decisions).toHaveLength(1);
+    expect(packet.accepted_decisions[0].id).toBe("checkout-reversibility");
+    expect(JSON.stringify(packet.accepted_decisions)).not.toContain(
+      "rejected-decision",
+    );
+    expect(JSON.stringify(packet.accepted_decisions)).not.toContain(
+      "saved-payment-empty-state",
+    );
+  });
+
+  it("review --package points empty decision memory to the canonical path", async () => {
+    await writeCheckPackage(dir);
+    await writeFile(
+      join(dir, "change.patch"),
+      lendingPatch("let color = CashTheme.primary"),
+    );
+
+    const result = await runCli(
+      [
+        "review",
+        "--diff",
+        "change.patch",
+        "--package",
+        ".ghost",
+        "--include-memory",
+      ],
+      dir,
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("fingerprint/memory/decisions");
+    expect(result.stdout).not.toContain(".ghost/decisions");
+  });
+
   it("check routes changed files through nested stacks by default", async () => {
     await writeNestedCheckPackage(dir);
     await writeFile(


### PR DESCRIPTION
## Summary

- Fix `ghost review --package <dir> --include-memory` so single-package review reads accepted decisions from `fingerprint/memory/decisions/`.
- Update the empty accepted-decisions markdown message to point at the canonical path.
- Add CLI regressions for `review --package` decision loading and empty-state copy.
- Add a patch changeset for `@anarchitecture/ghost`.

## Validation

- `pnpm exec vitest run packages/ghost/test/cli.test.ts -t "review --package"`
- `pnpm exec vitest run packages/ghost/test/cli.test.ts -t "accepted decisions"`
- `pnpm check`
- Pre-push hook: `pnpm build`, `pnpm check`, `pnpm test`