### PR TITLE
Reframe Ghost around product-surface composition

### DIFF
--- a/.changeset/surface-composition-framing.md
+++ b/.changeset/surface-composition-framing.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Reframe public and agent-facing copy around product-surface composition.

--- a/.ghost/fingerprint/inventory.yml
+++ b/.ghost/fingerprint/inventory.yml
@@ -62,8 +62,8 @@ building_blocks:
     - packages/ghost/src/scan/context/package-writer.ts
     - packages/ghost/src/scan/context/package-review-command.ts
   notes:
-    - Inventory is replaceable material; prose owns the judgment and composition owns how material is assembled.
-    - Correct components or tokens do not prove an experience is on-brand.
+    - Inventory is replaceable material; prose captures intent and composition captures how material is assembled.
+    - Correct components or tokens do not prove a surface is aligned.
 exemplars:
   - id: public-readme-fingerprint-model
     path: README.md

--- a/.ghost/fingerprint/prose.yml
+++ b/.ghost/fingerprint/prose.yml
@@ -5,12 +5,12 @@ summary:
     - agents generating or reviewing product UI
     - Ghost contributors
   goals:
-    - Keep product-experience fingerprints repo-local, portable, and easy for agents to read.
-    - Preserve product identity across generation, review, and remediation.
+    - Keep product-surface composition fingerprints repo-local, portable, and easy for agents to read.
+    - Preserve surface composition across generation, review, and remediation.
     - Make prose, inventory, and composition feel like the three core model layers.
     - Use Git as the staging and approval boundary for fingerprint edits.
   anti_goals:
-    - Treat raw inventory as canonical product truth.
+    - Treat raw inventory as canonical surface guidance.
     - Turn support files into peers of prose, inventory, and composition.
     - Turn Ghost into a design-system snapshot or screenshot archive.
     - Become a fingerprint lifecycle manager or proposal system.
@@ -28,7 +28,7 @@ situations:
   - id: capturing-fingerprint
     title: Capturing fingerprint layers
     user_intent: Create or update the Ghost fingerprint for a project.
-    product_obligation: Help the agent distinguish canonical prose/inventory/composition from generated cache, enforcement, and rationale memory.
+    product_obligation: Help the agent distinguish canonical prose/inventory/composition from generated cache, enforcement, and rationale history.
     principles:
       - prose.principle:fingerprint-folder-is-canonical
       - prose.principle:generated-cache-is-source-material
@@ -38,7 +38,7 @@ situations:
       - composition.pattern:core-layers-stay-prominent
   - id: reviewing-generated-ui
     title: Reviewing generated or changed UI
-    user_intent: Know whether a change preserves the product experience.
+    user_intent: Know whether a change preserves the product surface.
     product_obligation: Separate deterministic blocking checks from advisory critique.
     principles:
       - prose.principle:checks-are-enforcement
@@ -56,10 +56,10 @@ situations:
       - composition.pattern:editorial-workbench-docs
 principles:
   - id: fingerprint-folder-is-canonical
-    principle: fingerprint/ is the portable product-experience package; prose.yml, inventory.yml, and composition.yml are its core model layers.
+    principle: fingerprint/ is the portable surface-composition package; prose.yml, inventory.yml, and composition.yml are its core model layers.
     guidance:
-      - Describe the fingerprint as product-experience memory only as a high-level metaphor, not as an operational layer.
-      - Keep durable identity, hierarchy, behavior, copy, accessibility, trust, and flow in the core layer files.
+      - Describe the fingerprint as product-surface composition, not as an operational archive.
+      - Keep durable surface intent, hierarchy, behavior, copy, accessibility, trust, and flow in the core layer files.
       - Treat uncommitted or unmerged fingerprint edits as drafts handled by Git, not by a Ghost-specific lifecycle.
     evidence:
       - path: docs/fingerprint-format.md
@@ -71,12 +71,12 @@ principles:
     guidance:
       - Store generated cache under fingerprint/sources/cache/ when useful.
       - Curate durable building blocks, files, routes, libraries, assets, source links, notes, and exemplars into inventory.yml.
-      - Do not let cache or building blocks become product authority without prose and composition.
+      - Do not let cache or building blocks become surface authority without prose and composition.
     evidence:
       - path: README.md
         note: README frames generated cache as optional source material.
   - id: checks-are-enforcement
-    principle: Deterministic checks live under fingerprint/enforcement/ and should cite typed fingerprint refs when they enforce product-experience memory.
+    principle: Deterministic checks live under fingerprint/enforcement/ and should cite typed fingerprint refs when they enforce surface-composition rules.
     guidance:
       - Active checks can block; advisory findings cannot block unless check-backed.
       - Prefer typed refs such as composition.pattern:token-first-interface.
@@ -98,7 +98,7 @@ experience_contracts:
     contract: Advisory review findings must cite the diff location and the relevant fingerprint refs.
     obligations:
       - Use active checks only when a finding should block.
-      - Use missing-memory or experience-gap when the fingerprint cannot support a confident judgment.
+      - Use missing-memory or experience-gap when the fingerprint cannot support a confident finding.
     evidence:
       - path: packages/ghost/src/scan/context/package-review-command.ts
         note: Emitted review command tells agents what to cite.
@@ -107,7 +107,7 @@ experience_contracts:
     obligations:
       - Do not rewrite canonical fingerprint layers silently during generation or review.
       - Treat uncommitted or unmerged fingerprint edits as draft work.
-      - Record durable product judgment in prose.yml, inventory.yml, and composition.yml; deterministic gates belong in enforcement/checks.yml.
+      - Record durable surface-composition guidance in prose.yml, inventory.yml, and composition.yml; deterministic gates belong in enforcement/checks.yml.
     evidence:
       - path: packages/ghost/src/skill-bundle/references/capture.md
   - id: emitted-context-prefers-fingerprint-layers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # Ghost
 
-Agents can write UI. What they cannot reliably preserve is the product
-experience identity behind that UI: hierarchy, density, restraint, repetition,
-trust, flow, and the decisions that make a surface feel intentional.
+Agents can assemble UI. What they cannot reliably preserve is the product
+surface composition behind that UI: hierarchy, density, restraint, repetition,
+trust, flow, and the choices that make a surface feel intentional.
 
-Ghost keeps that product-experience memory in a repo-local `.ghost/` fingerprint package. The public npm shape
+Ghost keeps that surface composition in a repo-local `.ghost/` fingerprint package. The public npm shape
 is one package, `@anarchitecture/ghost`, with one user-facing bin, `ghost`.
 The CLI validates, computes, compares, and emits deterministic packets. The
 host agent does the interpretive BYOA work through the installed `ghost` skill.
@@ -50,7 +50,7 @@ fingerprint/
 
 The three root layer files under `fingerprint/` are the core model:
 
-- `prose.yml` for product judgment.
+- `prose.yml` for surface intent.
 - `inventory.yml` for curated material, exemplars, and source links.
 - `composition.yml` for experience patterns.
 
@@ -58,8 +58,8 @@ Supporting files live under purpose folders. `enforcement/checks.yml` is
 validation and enforcement, not generation input. `memory/intent.md` and
 `memory/decisions/` hold optional human context and rationale. Generated cache
 in `sources/cache/` is optional source material; it answers what exists, while
-core fingerprint layers answer what matters and why. `.ghost/config.yml`
-remains local adapter/routing config outside portable memory. Ordinary Git
+core fingerprint layers answer what the surface is trying to do. `.ghost/config.yml`
+remains local adapter/routing config outside portable context. Ordinary Git
 review is the approval boundary for fingerprint edits.
 
 Legacy `resources.yml`, `map.md`, `survey.json`, and `patterns.yml` may still

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Ghost
 
-**Ghost captures a portable product-experience fingerprint for AI agents.**
+**Ghost captures the composition of a product surface: the intent behind it,
+the materials it draws from, and the patterns that make it feel intentional.**
 
-Agents can write UI. What they cannot reliably preserve is the product
-experience that UI belongs to: hierarchy, density, restraint, behavior, copy,
+Agents can assemble UI. What they cannot reliably preserve is the surface
+composition behind that UI: hierarchy, density, restraint, behavior, copy,
 accessibility, trust, and flow. Traditional design systems give humans parts,
-rules, and examples. Ghost stores the upstream product judgment agents need
-around those parts in a versioned `.ghost/` bundle they can read before
-generation and validate after changes.
+rules, and examples. Ghost stores the upstream composition agents need around
+those parts in a versioned `.ghost/` bundle they can read before generation and
+validate after changes.
 
 The MVP rule is intentionally small:
 
@@ -15,10 +16,9 @@ The MVP rule is intentionally small:
 - **`fingerprint/manifest.yml`** anchors the package (`ghost.fingerprint-package/v1`).
 - **`fingerprint/prose.yml`, `fingerprint/inventory.yml`, and
   `fingerprint/composition.yml`** are the three core model files.
-- **Generation uses prose + inventory + composition.** Prose explains what
-  matters and why, inventory points to the building blocks and precedents an
-  agent can inspect or use, and composition explains how those blocks become
-  experience.
+- **Generation uses prose + inventory + composition.** `prose.yml` captures the
+  intent behind the surface. `inventory.yml` captures the materials it draws
+  from. `composition.yml` captures the patterns that make it feel intentional.
 - **`fingerprint/enforcement/checks.yml`** is optional deterministic
   enforcement grounded in fingerprint refs.
 - **Git is the approval boundary.** Uncommitted or unmerged edits are draft
@@ -35,19 +35,19 @@ Add only the sections that contain real layer content. Ghost normalizes omitted
 layer files or sections internally, so agents and checks still receive the full
 assembled `ghost.fingerprint/v1` shape they expect.
 
-Ghost captures a portable product-experience fingerprint that tools use to
-generate, validate, compare, and govern product surfaces. It is not a
-design-system generator, design-system registry, fingerprint lifecycle manager,
-proposal system, or screenshot archive.
+Ghost stores that composition as a repo-local fingerprint agents can build from,
+check against, and evolve through Git. It is not a design-system generator,
+design-system registry, fingerprint lifecycle manager, proposal system, or
+screenshot archive.
 
 Optional material can sit beside the core files:
 
 - **`.ghost/config.yml`** routes implementation roots and reference
-  registries/libraries without becoming portable product memory.
+  registries/libraries without becoming portable composition context.
 - **`.ghost/fingerprint/memory/intent.md`** records human-authored or
   human-approved product intent when useful.
-- **`.ghost/fingerprint/memory/decisions/*.yml`** records accepted/rejected product-experience
-  rationale when history matters.
+- **`.ghost/fingerprint/memory/decisions/*.yml`** records accepted/rejected
+  surface-composition rationale when history matters.
 - **`.ghost/fingerprint/sources/cache/`** holds generated cache only after you
   explicitly create it. Generated cache is optional source material: it answers
   what exists; curated `inventory.yml` is the canonical inventory layer.
@@ -118,11 +118,11 @@ Set up the Ghost fingerprint for this repo.
 Set up the Ghost fingerprint for this repo with auto-draft.
 ```
 
-Default authoring is interview-first: the agent asks what matters, scans as
-needed, drafts core layer edits, and validates them. Auto-draft is scan-first:
-the agent gathers generated cache, inspects high-signal repo evidence, writes a
-small starter draft into the core layer files, then asks you to keep, soften,
-reject, scope, record, or convert important claims.
+Default authoring is interview-first: the agent asks about the surface intent,
+scans as needed, drafts core layer edits, and validates them. Auto-draft is
+scan-first: the agent gathers generated cache, inspects high-signal repo
+evidence, writes a small starter draft into the core layer files, then asks you
+to keep, soften, reject, scope, record, or convert important claims.
 
 During setup or fingerprint edits, the agent checkpoints with commands like:
 
@@ -151,7 +151,8 @@ mkdir -p .ghost/fingerprint/sources/cache
 ghost inventory > .ghost/fingerprint/sources/cache/inventory.json
 ```
 
-Durable conclusions belong in `.ghost/fingerprint/{prose.yml,inventory.yml,composition.yml}`;
+Durable surface-composition claims belong in
+`.ghost/fingerprint/{prose.yml,inventory.yml,composition.yml}`;
 executable gates belong in `.ghost/fingerprint/enforcement/checks.yml`;
 implementation routing belongs in optional `.ghost/config.yml`.
 Auto-drafted edits to core layers are still ordinary draft work until curated
@@ -164,7 +165,8 @@ they generate or revise UI. Give it to Codex, Cursor, Claude, or another host
 agent so work starts from prose, inventory, and composition instead of relying on
 post-hoc checks. Its `prompt.md` is organized around:
 
-- **Prose** from checked-in `fingerprint/prose.yml`.
+- **Prose** from checked-in `fingerprint/prose.yml`, which captures surface
+  intent.
 - **Inventory** from curated building blocks and exemplars in
   `fingerprint/inventory.yml`, plus
   `.ghost/fingerprint/sources/cache/inventory.json` when present.
@@ -173,7 +175,7 @@ post-hoc checks. Its `prompt.md` is organized around:
   not generation input.
 
 Checks and review validate output after generation. They do not replace the
-prose, inventory, and composition inputs that help agents produce the right thing.
+prose, inventory, and composition inputs that help agents compose the surface.
 After implementation, run Ghost review/check against the same fingerprint layers when the
 repo workflow supports it.
 

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -29,8 +29,8 @@ export default function Home() {
           </p>
           <div className="space-y-5 text-muted-foreground leading-relaxed">
             <p className="thesis-item">
-              Agents can write UI. What they cannot reliably preserve is the
-              product-experience world that UI belongs to.
+              Agents can assemble UI. What they cannot reliably preserve is the
+              surface composition that UI belongs to.
             </p>
             <p className="thesis-item">
               For years, design systems solved a human assembly problem. They
@@ -40,23 +40,25 @@ export default function Home() {
             <p className="thesis-item">
               That layer still matters, but agents change the scarce layer.
               Models can copy local patterns and recombine components. They do
-              not consistently preserve the decisions that make a product feel
-              intentional: hierarchy, density, restraint, behavior, copy,
-              accessibility, trust, and flow.
+              not consistently preserve the composition that makes a product
+              surface feel intentional: hierarchy, density, restraint, behavior,
+              copy, accessibility, trust, and flow.
             </p>
             <p className="thesis-item">
-              Ghost is a repo-local product-experience world model for agents.
+              Ghost captures the composition of a product surface: the intent
+              behind it, the materials it draws from, and the patterns that make
+              it feel intentional.
             </p>
             <p className="thesis-item">
-              It turns upstream product judgment into checked-in fingerprint
-              layers: what matters, why it matters, which situations change the
-              obligation, which patterns hold the experience together, and which
-              examples show the product at its best.
+              It stores that composition as checked-in fingerprint layers: which
+              intent shapes the surface, which materials agents can draw from,
+              which situations change the obligation, which patterns hold the
+              surface together, and which examples show it at its best.
             </p>
             <p className="thesis-item">
               Components, tokens, libraries, and generated cache become
               implementation material. Ghost does not replace them. It gives
-              agents the product model that tells them when and how those
+              agents the surface context that tells them when and how those
               materials belong.
             </p>
             <p className="thesis-item">Ghost keeps that model compact:</p>
@@ -87,10 +89,11 @@ export default function Home() {
               </li>
             </ul>
             <p className="thesis-item">
-              The split is deliberate. Fingerprint prose answers what matters
-              and why. Cache answers what exists. Exemplars show concrete
-              surfaces worth inspecting before generation or review. Checks
-              validate output; they are not generation input.
+              The split is deliberate. <code>prose.yml</code> captures the
+              intent behind the surface. <code>inventory.yml</code> captures the
+              materials it draws from. <code>composition.yml</code> captures the
+              patterns that make it feel intentional. Cache answers what exists.
+              Checks validate output; they are not generation input.
             </p>
             <p className="thesis-item">A typical loop becomes:</p>
             <ol className="thesis-item list-decimal space-y-2 pl-6">
@@ -112,10 +115,10 @@ export default function Home() {
               review packets, comparison, and upstream handoff packets.
             </p>
             <p className="thesis-item">
-              This is critical because product judgment that cannot be recalled
-              or evaluated cannot be delegated. A product experience that only
-              its original author can judge is not transferable: to agents, to
-              new engineers, or to forks of the product.
+              This is critical because surface composition that cannot be
+              recalled or evaluated cannot be delegated. A product surface that
+              only its original author can assess is not transferable: to
+              agents, to new engineers, or to forks of the product.
             </p>
             <p className="thesis-item">
               Drift becomes measurable within this system. When generated or
@@ -124,7 +127,7 @@ export default function Home() {
             </p>
             <ul className="thesis-item list-disc space-y-2 pl-6">
               <li>incorrect generation: agent failure</li>
-              <li>missing memory: under-specified product judgment</li>
+              <li>missing-memory: under-specified surface context</li>
               <li>intentional product evolution</li>
             </ul>
             <p className="thesis-item">
@@ -139,20 +142,21 @@ export default function Home() {
             </p>
             <p className="thesis-item">
               This leads to a practical governance model. Each repository owns
-              its product experience fingerprint. Advanced workflows can add
-              nested packages for product areas, custom fingerprint directories
-              for host wrappers, comparison across systems, and declared drift
+              its product-surface fingerprint. Advanced workflows can add nested
+              packages for product areas, custom fingerprint directories for
+              host wrappers, comparison across systems, and declared drift
               stances.
             </p>
             <p className="thesis-item">
               Across an organization, the collection of Ghost packages forms a
-              higher-order map: a distributed model of product experience as it
-              is actually practiced, not as it is only described.
+              higher-order map: a distributed model of product-surface
+              composition as it is actually practiced, not as it is only
+              described.
             </p>
             <p className="thesis-item">
-              Design systems were libraries for humans. Ghost is memory for
-              agents: every surface can carry the product model it extends, and
-              every deviation can carry evidence.
+              Design systems were libraries for humans. Ghost is composition
+              context for agents: every surface can carry the fingerprint it
+              extends, and every deviation can carry evidence.
             </p>
           </div>
         </section>

--- a/apps/docs/src/app/tools/drift/page.tsx
+++ b/apps/docs/src/app/tools/drift/page.tsx
@@ -17,7 +17,7 @@ const cards: {
     name: "Ghost loop",
     href: "/docs/getting-started#the-simple-model",
     description:
-      "See how memory, checks, review, comparison, and intent fit together.",
+      "See how context, checks, review, comparison, and intent fit together.",
     icon: <Orbit className="size-8" strokeWidth={1.5} />,
   },
   {

--- a/apps/docs/src/content/docs/cli-reference.mdx
+++ b/apps/docs/src/content/docs/cli-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Commands around the portable fingerprint lifecycle. Your agent handles the judgment work.
+description: Commands around the portable fingerprint lifecycle. Your agent handles the composition work.
 kicker: Docs
 section: guide
 order: 30

--- a/apps/docs/src/content/docs/fingerprint-authoring.mdx
+++ b/apps/docs/src/content/docs/fingerprint-authoring.mdx
@@ -9,14 +9,14 @@ slug: fingerprint-authoring
 
 <DocSection title="The Authoring Model">
 
-A Ghost fingerprint is not a scan dump. It is durable product-experience memory
-that a human and agent shape together.
+A Ghost fingerprint is not a scan dump. It is durable product-surface
+composition that a human and agent shape together.
 
-The human decides identity: what the product should feel like, who it serves,
-which situations matter, and what should not drift. Repo scans provide evidence:
-components, routes, docs, stories, copy, screenshots, tokens, examples, and UI
-library references. The agent synthesizes drafts, but ordinary Git review is
-where fingerprint edits become canonical.
+The human names the intent: what the product surface should feel like, who it
+serves, which situations matter, and what should not drift. Repo scans provide
+evidence: components, routes, docs, stories, copy, screenshots, tokens,
+examples, and UI library references. The agent synthesizes drafts, but ordinary
+Git review is where fingerprint edits become canonical.
 
 </DocSection>
 
@@ -30,12 +30,12 @@ weight to give human intent, existing code, and library evidence.
 | Net new repo | Human-led. Capture intent, audience, posture, and early anti-goals before inventory grows. |
 | Net new repo + UI library | Human-led with library evidence. Explain how this product uses the library. |
 | Existing repo | Human + scan. Find repeated patterns and exemplars, then ask which ones are canonical. |
-| Existing repo with mixed quality | Curated scan. Separate product memory from legacy debt and accidental repetition. |
+| Existing repo with mixed quality | Curated scan. Separate durable surface composition from legacy debt and accidental repetition. |
 | Design system or UI library | Grammar-led. Describe primitives, tokens, component behavior, accessibility, and composition constraints. |
 | Rebrand, redesign, or migration | Human-led transition. Capture current, target, and migration cautions. |
 | Prototype becoming product | Ratification-led. Preserve only the emergent patterns humans want to keep. |
-| Fork, white label, or tenant variant | Shared base + local divergence. Keep common identity broad and local differences scoped. |
-| Monorepo or nested surfaces | Stack-aware. Use root guidance for broad identity and nested packages for surfaces judged differently. |
+| Fork, white label, or tenant variant | Shared base + local divergence. Keep common surface composition broad and local differences scoped. |
+| Monorepo or nested surfaces | Stack-aware. Use root guidance for broad composition and nested packages for surfaces assessed differently. |
 
 </DocSection>
 
@@ -64,7 +64,7 @@ Set up the Ghost fingerprint for this repo with auto-draft.
 3. **Draft** - write the smallest useful `prose.yml`, `inventory.yml`, and
    `composition.yml` entries.
 4. **Curate** - have the human keep, soften, reject, scope, or record important
-   claims before treating them as durable memory.
+   claims before treating them as durable surface context.
 5. **Validate** - run Ghost validation and use Git review as the approval
    boundary.
 
@@ -78,15 +78,15 @@ ghost check --base HEAD
 ```
 
 Generated cache is source material only. It can support curated inventory, but
-it does not establish product judgment by itself. Scan frequency and raw cache
-may seed a draft, but they do not decide what the product means.
+it does not establish surface-composition guidance by itself. Scan frequency and
+raw cache may seed a draft, but they do not decide what the surface should do.
 
 </DocSection>
 
 <DocSection title="Nested Packages">
 
 Nested fingerprints are opt-in. Create a local `.ghost/` only when a surface
-would be judged differently from the root product fingerprint.
+should be assessed differently from the root product fingerprint.
 
 Use a nested package when a surface has distinct users, information density,
 trust or recovery posture, interaction rhythm, component grammar, UI library
@@ -111,6 +111,6 @@ Uncommitted or unmerged fingerprint edits are drafts. Checked-in
 Use optional `fingerprint/memory/intent.md` only for human-authored or
 human-approved intent. Use `fingerprint/memory/decisions/` for rationale that
 explains why a product choice changed. Add deterministic checks sparingly, and
-only when a rule can be enforced without subjective judgment.
+only when a rule can be enforced deterministically.
 
 </DocSection>

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Install Ghost, author a portable product-experience fingerprint, and use it to generate, validate, compare, and govern product surfaces.
+description: Install Ghost, author a product-surface composition fingerprint, and use it to generate, validate, compare, and govern product surfaces.
 kicker: Docs
 section: guide
 order: 10
@@ -9,9 +9,10 @@ slug: getting-started
 
 <DocSection title="The Simple Model">
 
-Ghost keeps a project's portable product-experience fingerprint in the repo,
-where your agent can use it. The public package is `@anarchitecture/ghost`,
-and it installs one CLI: `ghost`.
+Ghost captures the composition of a product surface: the intent behind it, the
+materials it draws from, and the patterns that make it feel intentional. It
+stores that composition as a repo-local fingerprint your agent can use. The
+public package is `@anarchitecture/ghost`, and it installs one CLI: `ghost`.
 
 The canonical portable fingerprint is a folder:
 
@@ -86,14 +87,15 @@ The default workflow is interview-first. Auto-draft is an opt-in skill workflow
 where the agent scans first, writes a small starter draft into the core layer
 files, and then asks you to curate the claims. It is not a Ghost CLI command.
 
-The fingerprint records durable product-experience guidance:
+The fingerprint records durable surface-composition guidance:
 
-1. **Prose** - what product this is, who it serves, which situations matter,
-   and which principles or contracts govern the experience.
-2. **Inventory** - topology, building blocks, files, routes, assets, libraries,
-   exemplars, and source links agents may inspect or use.
-3. **Composition** - patterns, rules, layouts, structures, flows, states,
-   content, behavior, and visual arrangements.
+1. **Prose** - the intent behind the surface: what product this is, who it
+   serves, which situations matter, and which principles or contracts apply.
+2. **Inventory** - the materials it draws from: topology, building blocks,
+   files, routes, assets, libraries, exemplars, and source links agents may
+   inspect or use.
+3. **Composition** - the patterns that make it feel intentional: rules, layouts,
+   structures, flows, states, content, behavior, and visual arrangements.
 
 ```bash
 ghost init --with-intent
@@ -150,12 +152,12 @@ outside Ghost. Ghost severities remain `critical`, `serious`, and `nit`.
 
 <DocSection title="Update Fingerprint Layers">
 
-Use the installed `ghost` skill when work reveals durable product-experience
-judgment Ghost should add to the fingerprint:
+Use the installed `ghost` skill when work reveals durable surface-composition
+guidance Ghost should add to the fingerprint:
 
 ```text
 Brief this work from the Ghost fingerprint
-Update the fingerprint with this product-experience decision
+Update the fingerprint with this surface-composition decision
 ```
 
 Fingerprint edits are ordinary edits to the split fingerprint package and

--- a/docs/fingerprint-blueprint.md
+++ b/docs/fingerprint-blueprint.md
@@ -1,6 +1,6 @@
 # Ghost Fingerprint Blueprint
 
-A Ghost fingerprint is checked-in product-experience memory for a repo: a
+A Ghost fingerprint is checked-in product-surface composition for a repo: a
 portable contract humans can approve and agents can act from. It is the
 material a host agent reads before generating UI and the deterministic
 grounding Ghost uses after changes for lint, verify, check, review, compare,
@@ -8,8 +8,8 @@ and context-bundle flows.
 
 The fingerprint is not a single prompt, screenshot archive, or generated design
 system dump. It is a small portable package of curated YAML and optional human
-context. Its job is to preserve product judgment: hierarchy, density,
-restraint, trust, flow, accessibility, copy, repetition, and the decisions that
+context. Its job is to preserve surface composition: hierarchy, density,
+restraint, trust, flow, accessibility, copy, repetition, and the choices that
 make a surface feel intentional.
 
 ## The Portable Package
@@ -18,10 +18,10 @@ The canonical package lives at `.ghost/fingerprint/`:
 
 ```text
 .ghost/
-  config.yml                    # optional local routing; not portable memory
+  config.yml                    # optional local routing; not portable context
   fingerprint/
     manifest.yml                # package anchor
-    prose.yml                   # core: product judgment
+    prose.yml                   # core: surface intent
     inventory.yml               # core: curated material and source links
     composition.yml             # core: experience patterns
 
@@ -37,12 +37,12 @@ The canonical package lives at `.ghost/fingerprint/`:
 ```
 
 The portable boundary is `.ghost/fingerprint/`. That folder can move with the
-product memory to another host or repo. `.ghost/config.yml` stays outside the
+surface-composition context to another host or repo. `.ghost/config.yml` stays outside the
 package because it stores local adapter details such as implementation roots,
 reference registries, or host routing.
 
 Git is the approval boundary. Uncommitted edits are draft work; checked-in core
-layer files are the approved Ghost memory.
+layer files are the approved Ghost fingerprint.
 
 ## Package Anchor
 
@@ -64,9 +64,9 @@ agent needs before writing product UI:
 
 | File | Question | Role |
 | --- | --- | --- |
-| `prose.yml` | What matters, why, and for whom? | Product judgment. |
+| `prose.yml` | What intent shapes the surface, and for whom? | Surface intent. |
 | `inventory.yml` | What materials can an agent inspect or reuse? | Curated implementation material and source links. |
-| `composition.yml` | How do materials become a recognizable experience? | Patterns, flows, rules, states, and arrangements. |
+| `composition.yml` | Which patterns make the surface feel intentional? | Patterns, flows, rules, states, and arrangements. |
 
 The layer files are raw YAML. Ghost assembles them internally into a
 `ghost.fingerprint/v1` document:
@@ -84,8 +84,9 @@ consistent assembled shape.
 
 ## `prose.yml`
 
-`prose.yml` carries product judgment. It should be human-readable, sparse, and
-durable enough that a reviewer can see what has actually been approved.
+`prose.yml` captures the intent behind the surface. It should be
+human-readable, sparse, and durable enough that a reviewer can see what has
+actually been approved.
 
 ```yaml
 summary:
@@ -154,9 +155,9 @@ experience_contracts:
       - check:review-packet-citations
 ```
 
-Use prose for statements that require judgment: audience needs, product
-obligations, acceptable tradeoffs, what the experience refuses to become, and
-contracts that should shape agent behavior. Do not put generated source material,
+Use prose for statements about audience needs, product obligations, acceptable
+tradeoffs, what the surface refuses to become, and contracts that should shape
+agent behavior. Do not put generated source material,
 large file lists, or deterministic detector configuration here.
 
 ## `inventory.yml`
@@ -224,12 +225,12 @@ Supported `sources[].kind` values are `cache`, `registry`, `file`, `url`, and
 generated material canonical by themselves.
 
 Inventory-only evidence can support a check or review finding, but it does not
-establish product judgment alone. Durable judgment belongs in `prose.yml` or
-`composition.yml`.
+establish surface-composition guidance alone. Durable guidance belongs in
+`prose.yml` or `composition.yml`.
 
 ## `composition.yml`
 
-`composition.yml` describes how product material turns into experience. A
+`composition.yml` captures the patterns that make a surface feel intentional. A
 pattern is reusable guidance about structure, layout, flow, state, behavior,
 visual language, or content.
 
@@ -257,10 +258,9 @@ patterns:
 Pattern `kind` can be `rule`, `layout`, `structure`, `flow`, `state`,
 `visual`, `behavior`, or `content`.
 
-Use composition for repeatable experience logic: common arrangements, state
+Use composition for repeatable surface logic: common arrangements, state
 behavior, content sequencing, responsive expectations, density choices, and
-interaction flow. Keep one-off facts in inventory and broad value judgments in
-prose.
+interaction flow. Keep one-off facts in inventory and broad intent in prose.
 
 ## Typed References
 
@@ -333,8 +333,8 @@ Detector `type` can be:
 
 Ref-backed checks are preferred. Missing derivation refs lint as warnings, not
 errors, so teams can draft gates while curation catches up. Promote only rules
-that can be detected deterministically; subjective taste stays in prose or
-composition until there is a reliable detector.
+that can be detected deterministically; taste stays in prose or composition
+until there is a reliable detector.
 
 ## Memory
 
@@ -343,7 +343,7 @@ context. Use it for constraints, audience notes, strategic intent, exceptions,
 and tradeoffs that should not be inferred from code alone.
 
 `fingerprint/memory/decisions/*.yml` stores accepted, rejected, or superseded
-product-experience rationale:
+surface-composition rationale:
 
 ```yaml
 schema: ghost.decision/v1
@@ -367,7 +367,7 @@ or superseded decisions are history, not canonical instructions.
 ## Generated Sources
 
 `fingerprint/sources/cache/` is optional generated source material. Cache answers
-what exists; the core layers answer what matters.
+what exists; the core layers answer what the surface is trying to do.
 
 Use cache when observed repo facts are useful:
 
@@ -403,7 +403,7 @@ broad-to-local:
 - intent files concatenate with layer headings;
 - decisions merge by `id`, with child entries winning.
 
-Use nested packages when an area has a genuinely different product memory, not
+Use nested packages when an area has genuinely different surface composition, not
 just because it has different files.
 
 ## Readiness
@@ -439,7 +439,7 @@ ghost inventory > .ghost/fingerprint/sources/cache/inventory.json
 Curate the core layers:
 
 ```text
-fingerprint/prose.yml          product judgment
+fingerprint/prose.yml          surface intent
 fingerprint/inventory.yml      curated material and exemplars
 fingerprint/composition.yml    reusable experience patterns
 ```
@@ -463,7 +463,7 @@ ghost emit review-command
 
 ## Authoring Rules
 
-- Write durable product meaning in `prose.yml`.
+- Write durable surface intent in `prose.yml`.
 - Write curated repo material and exemplars in `inventory.yml`.
 - Write repeatable experience patterns in `composition.yml`.
 - Write deterministic gates in `enforcement/checks.yml`.
@@ -477,11 +477,11 @@ Do not:
 
 - describe root-level `fingerprint.md` or direct `fingerprint.yml` as the new
   canonical package input;
-- treat cache output as canonical product judgment;
+- treat cache output as canonical surface guidance;
 - promote subjective taste directly into a check without a deterministic
   detector;
 - put structural gate configuration in prose;
-- use `.ghost/config.yml` as portable product memory.
+- use `.ghost/config.yml` as portable surface context.
 
 ## Legacy Material
 

--- a/docs/fingerprint-format.md
+++ b/docs/fingerprint-format.md
@@ -1,15 +1,15 @@
 # The Portable Fingerprint Package Format
 
-A Ghost fingerprint is the checked-in, repo-local product-experience contract
+A Ghost fingerprint is the checked-in, repo-local surface-composition contract
 that humans can approve and agents can act from. The canonical portable package
 lives under `.ghost/fingerprint/`:
 
 ```text
 .ghost/
-  config.yml                    # optional local routing; not portable memory
+  config.yml                    # optional local routing; not portable context
   fingerprint/
     manifest.yml                # ghost.fingerprint-package/v1 package anchor
-    prose.yml                   # core: product judgment
+    prose.yml                   # core: surface intent
     inventory.yml               # core: curated material and source links
     composition.yml             # core: experience patterns
 
@@ -27,7 +27,7 @@ lives under `.ghost/fingerprint/`:
 Git is the staging and approval boundary: uncommitted or unmerged edits are
 draft work, and checked-in `fingerprint/` core files are canonical for Ghost.
 `.ghost/config.yml` stays outside the portable package because it routes local
-implementation roots and reference libraries rather than product memory.
+implementation roots and reference libraries rather than surface context.
 
 `manifest.yml` is intentionally small:
 
@@ -42,7 +42,7 @@ by checks, review packets, context bundles, compare, and stack merges.
 
 ## Core Layers
 
-`prose.yml` explains what matters and why:
+`prose.yml` captures the intent behind the surface:
 
 ```yaml
 summary:
@@ -52,7 +52,7 @@ summary:
     - Preserve task-first documentation and product trust.
 principles:
   - id: prose-before-cache
-    principle: Prose explains what matters and why; generated cache only explains what exists.
+    principle: Prose captures the intent behind the surface; generated cache only explains what exists.
 experience_contracts:
   - id: review-cites-memory
     contract: Advisory review findings must cite the diff and relevant fingerprint refs.
@@ -89,7 +89,7 @@ Supported `inventory.sources[].kind` values are `cache`, `registry`, `file`,
 `url`, and `package`. Source links are provenance and orientation; they do not
 make generated source material canonical by themselves.
 
-`composition.yml` explains how product material becomes experience:
+`composition.yml` captures the patterns that make a surface feel intentional:
 
 ```yaml
 patterns:
@@ -142,7 +142,7 @@ checks:
 
 Ref-backed checks are preferred. Missing or unresolved derivation refs lint as
 warnings, not errors. Inventory refs can support checks, but inventory-only
-grounding does not establish product judgment alone. Composition patterns can
+grounding does not establish surface-composition guidance alone. Composition patterns can
 cite related checks via `check_refs`.
 
 ## Memory And Sources
@@ -152,7 +152,7 @@ intent: constraints, tradeoffs, audience notes, and known exceptions that
 should not be inferred from code alone.
 
 `fingerprint/memory/decisions/*.yml` stores accepted or rejected
-product-experience rationale using `ghost.decision/v1`. `ghost review
+surface-composition rationale using `ghost.decision/v1`. `ghost review
 --include-memory` reads accepted decisions.
 
 `fingerprint/sources/cache/` is refreshable generated material. It can help an

--- a/docs/generation-loop.md
+++ b/docs/generation-loop.md
@@ -1,8 +1,8 @@
 # Fingerprint Generation Loop
 
 Ghost gives UI generators and product-development agents a local, auditable
-product-experience fingerprint. Generation starts from checked-in core layers;
-checks and review govern the result afterward.
+product-surface composition fingerprint. Generation starts from checked-in core
+layers; checks and review govern the result afterward.
 
 ```text
 fingerprint/prose.yml + fingerprint/inventory.yml + fingerprint/composition.yml
@@ -17,7 +17,7 @@ HTML / JSX / app code
 ghost check + ghost review
         |
         v
-deterministic gates + advisory product-experience findings
+deterministic gates + advisory surface-composition findings
 ```
 
 ## Before Generation
@@ -42,9 +42,10 @@ mkdir -p .ghost/fingerprint/sources/cache
 ghost inventory > .ghost/fingerprint/sources/cache/inventory.json
 ```
 
-Cache answers what exists now and does not count toward scan readiness. Prose
-answers what matters and why. Curated inventory points to building blocks and
-exemplars. Composition explains how those blocks become experience.
+Cache answers what exists now and does not count toward scan readiness.
+`prose.yml` captures the intent behind the surface. Curated inventory points to
+building blocks and exemplars. `composition.yml` captures the patterns that make
+the surface feel intentional.
 
 ## Govern
 
@@ -66,7 +67,7 @@ ghost review --base main --include-memory
 Advisory review packets include the current diff, the split fingerprint core
 layers, relevant inventory exemplars, active checks, optional accepted
 decisions, and finding categories for fixes, intentional divergence, missing
-memory, experience gaps, and eval uncertainty.
+missing grounding, experience gaps, and eval uncertainty.
 
 Review findings should cite the diff location, relevant fingerprint refs,
 relevant exemplars when useful, and any active check when blocking.
@@ -79,7 +80,7 @@ smallest useful response:
 - Fix the generated or changed code.
 - Explain why a divergence is intentional.
 - Update the split fingerprint package or optional rationale files when the
-  user asks to change Ghost memory.
+  user asks to change the Ghost fingerprint.
 
 ## CI
 
@@ -92,7 +93,7 @@ ghost check --base main
 ghost review --base main --format markdown
 ```
 
-Advanced wrappers that store memory outside `.ghost` can pass
+Advanced wrappers that store fingerprint packages outside `.ghost` can pass
 `--memory-dir <relative-dir>` to stack-aware commands. `--package <dir>` remains
 exact single-bundle mode and bypasses stack discovery.
 

--- a/docs/ideas/fingerprint-first-architecture.md
+++ b/docs/ideas/fingerprint-first-architecture.md
@@ -9,7 +9,7 @@ status: settled
 Ghost is fingerprint-first.
 
 The durable Ghost artifact is the checked-in fingerprint package: a portable
-product-experience contract that humans can approve and agents can act from.
+surface-composition contract that humans can approve and agents can act from.
 Everything else in Ghost is tooling for that contract or tooling around it.
 Drift remains important, but it is one governance workflow over the fingerprint,
 not the center of the architecture.
@@ -17,17 +17,18 @@ not the center of the architecture.
 This settles the mental model for follow-on work. Existing docs already describe
 `.ghost/fingerprint/` as the portable package and generation context. Older
 idea docs that center `ghost-drift`, package decomposition, or drift comparison
-should be read through this updated hierarchy: the fingerprint owns product
-memory; tools consume, validate, compare, generate from, or govern that memory.
+should be read through this updated hierarchy: the fingerprint owns surface
+context; tools consume, validate, compare, generate from, or govern that
+context.
 
 ## Decisions
 
 - The fingerprint package is the durable artifact. `.ghost/fingerprint/`
   remains the portable boundary, anchored by `fingerprint/manifest.yml`.
 - Core generation input is `prose.yml`, `inventory.yml`, and
-  `composition.yml`. Prose explains what matters and why, inventory points to
-  curated material and exemplars, and composition explains how those materials
-  become experience.
+  `composition.yml`. `prose.yml` captures the intent behind the surface,
+  `inventory.yml` points to curated material and exemplars, and
+  `composition.yml` captures the patterns that make it feel intentional.
 - Supporting material stays subordinate to the core layers:
   `enforcement/checks.yml` validates deterministic obligations,
   `memory/intent.md` and `memory/decisions/` preserve optional human-approved
@@ -38,11 +39,11 @@ memory; tools consume, validate, compare, generate from, or govern that memory.
   whether a change remains faithful to the fingerprint, how intentional
   divergence is recorded, and how references shift over time.
 - Git remains the approval boundary. Uncommitted or unmerged fingerprint edits
-  are draft work; checked-in fingerprint files are canonical Ghost memory.
+  are draft work; checked-in fingerprint files are canonical Ghost context.
 
 ## Rationale
 
-Agents need product-experience memory before they generate, not only after a
+Agents need surface-composition context before they generate, not only after a
 diff exists. Post-hoc drift review can catch violations, but it cannot be the
 only way Ghost participates in the work. The highest-leverage artifact is the
 structured input that lets a host agent build, revise, or explain a product
@@ -52,12 +53,12 @@ and flow.
 That makes the fingerprint more like an upstream contract than a static
 guideline or a downstream inspection report. Review, linting, comparison,
 generation packets, authoring tools, marketing workflows, and vibe-coding
-workflows can all use the same checked-in product memory. Their outputs differ,
+workflows can all use the same checked-in surface context. Their outputs differ,
 but their source of truth is the fingerprint.
 
 This also keeps Ghost adapter-neutral. Codex, Claude, Cursor, Goose, CI
 wrappers, docs tools, and design-system integrations can bring their own
-display, policy, and execution format. Ghost owns the portable memory, stable
+display, policy, and execution format. Ghost owns the portable context, stable
 packets, deterministic validation, and stack resolution.
 
 ## Lifecycle taxonomy
@@ -69,7 +70,7 @@ fingerprint lifecycle:
 | --- | --- | --- |
 | Capture | `init`, `inventory`, `scan` | Create the package, gather optional source material, and report layer readiness. |
 | Validate | `lint`, `verify` | Check schema shape, refs, evidence, exemplars, and deterministic package quality. |
-| Generate / apply | `emit context-bundle`, host agents, future generation consumers | Give agents the upstream product-experience contract before they build or revise. |
+| Generate / apply | `emit context-bundle`, host agents, future generation consumers | Give agents the upstream surface-composition contract before they build or revise. |
 | Govern | `check`, `review`, `ack`, `track`, `diverge` | Validate changed surfaces, produce advisory findings, and record stance toward divergence. |
 | Compare | `compare`, fleet-style analysis | Understand distance, cohorts, reference relationships, and change across packages. |
 
@@ -78,10 +79,10 @@ or create public API guarantees. It gives follow-on work a shared hierarchy.
 
 ## Consequences
 
-- Positioning should lead with the portable product-experience fingerprint, not
-  drift detection. A good default sentence is: Ghost captures a portable
-  product-experience fingerprint that tools use to generate, validate, compare,
-  and govern product surfaces.
+- Positioning should lead with the portable surface-composition fingerprint, not
+  drift detection. A good default sentence is: Ghost captures the composition of
+  a product surface: the intent behind it, the materials it draws from, and the
+  patterns that make it feel intentional.
 - Docs IA should make the lifecycle visible. Drift/review docs remain useful,
   but they should live under governance rather than define the product.
 - CLI help should group commands by fingerprint lifecycle where practical.
@@ -94,7 +95,7 @@ or create public API guarantees. It gives follow-on work a shared hierarchy.
   inventory evidence. Those ideas are follow-on design work, not new schema in
   this memo.
 - Dogfooding should update Ghost's own fingerprint and examples to express this
-  identity. The repo should be able to describe itself as fingerprint-first
+  framing. The repo should be able to describe itself as fingerprint-first
   before it asks other repos to do the same.
 
 ## Follow-on tracks

--- a/docs/ideas/fingerprint-yml-reset-plans.md
+++ b/docs/ideas/fingerprint-yml-reset-plans.md
@@ -5,10 +5,10 @@ in [docs/fingerprint-format.md](../fingerprint-format.md).
 
 The current model is intentionally three-layered:
 
-- `prose` explains what matters and why.
+- `prose` captures the intent behind the surface.
 - `inventory` points to building blocks and exemplars the agent can inspect or
   use.
-- `composition` explains how those blocks become experience through patterns,
+- `composition` captures how those blocks become intentional surfaces through patterns,
   rules, layouts, structures, flows, states, content, behavior, and visual
   arrangements.
 

--- a/docs/ideas/ghost-fleet.md
+++ b/docs/ideas/ghost-fleet.md
@@ -35,7 +35,7 @@ A read-only **elevation view** over a directory of (map.md, fingerprint.md) memb
 | `ghost fleet` (skill) | LLM-driven recipe: synthesize the fleet-shape narrative for fleet.md | `packages/ghost-fleet/src/skill-bundle/` |
 | `ghost fleet view` (CLI) | Deterministic composite, group-by, tracks-graph, output artifacts | CLI |
 
-The math is deterministic — composite distances, clustering, group-by. The narrative ("Cash family clusters tight; Tidal pulls away on warmth and density; Afterpay sits in its own region") is judgement and lives in the skill. Same split as map/fingerprint.
+The math is deterministic — composite distances, clustering, group-by. The narrative ("Cash family clusters tight; Tidal pulls away on warmth and density; Afterpay sits in its own region") is interpretation and lives in the skill. Same split as map/fingerprint.
 
 ## CLI surface
 

--- a/docs/ideas/ghost-map.md
+++ b/docs/ideas/ghost-map.md
@@ -6,7 +6,7 @@ status: exploring
 
 > Fingerprint-first context: map is optional topology/source-material support.
 > It helps agents find the right product surfaces, but the fingerprint remains
-> the portable product-experience contract.
+> the portable surface-composition contract.
 
 ## Why it's interesting
 
@@ -20,7 +20,7 @@ This is one of five decentralized tools (`map`, `fingerprint`, `drift`, `fleet`,
 
 A **navigation card**, not an extraction. It answers *where* and *what kind*, never *how it feels*.
 
-- Not a profile (no design-language judgement — that's fingerprint).
+- Not a profile (no design-language interpretation — that's fingerprint).
 - Not exhaustive (six feature areas beat thirty if six are the ones a sampling agent should actually visit).
 - Not aspirational (records what the repo is, not what it should be).
 - Language-agnostic by design (web, iOS, Android, Flutter, desktop, mixed).
@@ -112,7 +112,7 @@ The skill itself isn't invoked from the Ghost CLI — it's installed into the ho
 
 ## Inventory output (sketch)
 
-The deterministic step the recipe leans on. JSON, machine-shape, no judgement.
+The deterministic step the recipe leans on. JSON, machine-shape, no interpretation.
 
 ```json
 {

--- a/docs/ideas/ghost-scan.md
+++ b/docs/ideas/ghost-scan.md
@@ -7,7 +7,7 @@ status: exploring
 > Historical design note: the separate `packages/ghost-scan` package described
 > here was removed. The public Ghost CLI and current fingerprint capture
 > workflow live in `packages/ghost` and canonical `.ghost/fingerprint/`
-> memory. Read this through the fingerprint-first architecture: the artifact is
+> context. Read this through the fingerprint-first architecture: the artifact is
 > the portable package, while scan/fingerprint verbs are authoring and
 > validation tools around it.
 

--- a/docs/ideas/ghost-ui.md
+++ b/docs/ideas/ghost-ui.md
@@ -6,7 +6,7 @@ status: exploring
 
 > Fingerprint-first context: ghost-ui is reference inventory and evidence for
 > fingerprints. It can improve generation and governance, but it is not the
-> portable product-experience contract itself.
+> portable surface-composition contract itself.
 
 ## Why it's interesting
 

--- a/docs/ideas/guided-migration.md
+++ b/docs/ideas/guided-migration.md
@@ -12,7 +12,7 @@ An agentic loop where repo A consciously migrates toward repo B's visual directi
 
 ## The observation
 
-Embedding distance is a *tier selector*, not a progress bar. Closing 0.6 → 0.3 is usually easier than 0.3 → 0.05: the first half removes obviously wrong answers (different font family, different base unit, different radii language); the second half means reconciling deliberate choices that both sides consider correct. The last 0.05 is where local identity lives and often shouldn't go to zero at all.
+Embedding distance is a *tier selector*, not a progress bar. Closing 0.6 → 0.3 is usually easier than 0.3 → 0.05: the first half removes obviously wrong answers (different font family, different base unit, different radii language); the second half means reconciling deliberate choices that both sides consider correct. The last 0.05 is where local surface character lives and often shouldn't go to zero at all.
 
 ## Distance tiers
 
@@ -38,7 +38,7 @@ A `migrate.md` skill recipe alongside profile / review / verify / generate / dis
 4. Re-profile → `ack` → repeat.
 5. Stop when `d ≤ floor + ε`, or agent hits a dim the user marks `diverging`.
 
-No CLI primitive is missing. All the judgement work lives in the recipe.
+No CLI primitive is missing. All the interpretation work lives in the recipe.
 
 ## Open questions
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Ghost — install the unified product-experience memory skill bundle.
+# Ghost — install the unified surface-composition skill bundle.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/block/ghost/main/install/install.sh | sh
@@ -192,8 +192,8 @@ printf '\nInstalled %d files to %s\n' "$count" "$GHOST_DEST"
 printf '\n'
 printf 'Next:\n'
 printf '  cd <your-repo>\n'
-printf '  Tell your agent: "Set up Ghost memory for this repo"\n'
+printf '  Tell your agent: "Set up the Ghost fingerprint for this repo"\n'
 printf '\n'
-printf 'The agent will use .ghost/fingerprint/ as checked-in product-experience memory,\n'
+printf 'The agent will use .ghost/fingerprint/ as checked-in surface-composition context,\n'
 printf 'generate from prose.yml, inventory.yml, and composition.yml, keep optional\n'
 printf 'deterministic gates in enforcement/checks.yml, and run ghost lint/verify/check/review.\n'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghost",
   "private": true,
-  "description": "Product-experience world model tooling for AI agents",
+  "description": "Product-surface composition tooling for AI agents",
   "license": "Apache-2.0",
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/packages/ghost-core/src/checks/lint.ts
+++ b/packages/ghost-core/src/checks/lint.ts
@@ -225,7 +225,7 @@ function checkGrounding(
       severity: check.status === "active" ? "error" : "warning",
       rule: "check-grounding-inventory-only",
       message:
-        "Inventory refs can support a check, but active checks must derive from prose or composition memory.",
+        "Inventory refs can support a check, but active checks must derive from prose or composition refs.",
       path: `${path}.derivation`,
     });
   }

--- a/packages/ghost-core/test/memory.test.ts
+++ b/packages/ghost-core/test/memory.test.ts
@@ -23,7 +23,7 @@ const VALID_DECISION = {
   decided_at: "2026-05-17T00:00:00.000Z",
 };
 
-describe("Ghost product-experience memory schemas", () => {
+describe("Ghost decision rationale schemas", () => {
   it("accepts a valid ghost.decision/v1 document", () => {
     const report = core.lintGhostDecision(VALID_DECISION);
 

--- a/packages/ghost-ui/README.md
+++ b/packages/ghost-ui/README.md
@@ -15,7 +15,7 @@ This workspace carries a repo-local Ghost reference bundle in `.ghost/`.
 component families, registry shape, and reference-registry boundaries. It does
 not define product-specific flows, copy, trust obligations, or business intent
 for consuming apps. New products should reference this bundle and the generated
-`public/r/registry.json`, then fill their own product experience memory
+`public/r/registry.json`, then fill their own surface-composition fingerprint
 separately.
 
 Agents should read this README, `.ghost/fingerprint.yml`,
@@ -38,7 +38,7 @@ That distinction helps generators pick relevant references instead of treating e
 - **Components** — 49 UI primitives (Radix-based) + 48 AI elements (chat, streaming, agent UI) + theme + hooks.
 - **Tokens** — `src/styles/` CSS custom properties consumed by the registry and components.
 - **Registry** — `public/r/registry.json`, generated shadcn-compatible catalogue for consumption. Source entries live in `registry.json`; rebuilt by `just build-registry`.
-- **Ghost reference memory** — `.ghost/fingerprint.yml` + `.ghost/checks.yml`, used as reference-registry context by consuming products.
+- **Ghost reference context** — `.ghost/fingerprint.yml` + `.ghost/checks.yml`, used as reference-registry context by consuming products.
 - **Agent context** — `.shadcn/skills.md`, generated from the registry and component sources for AI assistants.
 
 ## Use

--- a/packages/ghost/README.md
+++ b/packages/ghost/README.md
@@ -1,12 +1,14 @@
 # @anarchitecture/ghost
 
-**Unified Ghost CLI for portable product-experience fingerprints.**
+**Unified Ghost CLI for product-surface composition fingerprints.**
 
-Ghost captures a portable product-experience fingerprint that tools use to
-generate, validate, compare, and govern product surfaces. It initializes root
-`.ghost/fingerprint/` packages, validates deterministic gates, emits handoff
-and review packets, compares packages, and records intentional divergence. It
-ships one CLI: `ghost`.
+Ghost captures the composition of a product surface: the intent behind it, the
+materials it draws from, and the patterns that make it feel intentional. It
+stores that composition as a repo-local fingerprint agents can build from,
+check against, and evolve through Git. It initializes root `.ghost/fingerprint/`
+packages, validates deterministic gates, emits handoff and review packets,
+compares packages, and records intentional divergence. It ships one CLI:
+`ghost`.
 
 ## Project Status: Beta
 
@@ -69,9 +71,9 @@ import {
 Ghost is bring-your-own-agent. The CLI performs deterministic work: inventory,
 lint, verify, compare, check, and handoff packet generation. The installed
 `ghost` skill teaches your host agent how to capture canonical
-`.ghost/fingerprint/` memory, brief and generate work from it, review changes
-against it, verify generated UI, remediate issues, and suggest memory edits
-when the user asks.
+`.ghost/fingerprint/` surface-composition context, brief and generate work from
+it, review changes against it, verify generated UI, remediate issues, and
+suggest fingerprint edits when the user asks.
 
 ```bash
 ghost skill install

--- a/packages/ghost/package.json
+++ b/packages/ghost/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anarchitecture/ghost",
   "version": "0.7.0",
-  "description": "Unified Ghost CLI for portable product-experience fingerprints, deterministic checks, advisory review, and comparison",
+  "description": "Unified Ghost CLI for product-surface composition fingerprints, deterministic checks, advisory review, and comparison",
   "license": "Apache-2.0",
   "author": "Block, Inc.",
   "repository": {
@@ -14,7 +14,8 @@
   },
   "keywords": [
     "fingerprint",
-    "product-experience",
+    "product-surface",
+    "surface-composition",
     "design-system",
     "design-tokens",
     "shadcn",

--- a/packages/ghost/src/ghost-core/checks/lint.ts
+++ b/packages/ghost/src/ghost-core/checks/lint.ts
@@ -214,7 +214,7 @@ function checkGrounding(
       severity: "warning",
       rule: "check-grounding-missing",
       message:
-        "Checks should declare derivation refs when they enforce product-experience memory.",
+        "Checks should declare derivation refs when they enforce surface-composition rules.",
       path: `${path}.derivation`,
     });
     return;
@@ -225,7 +225,7 @@ function checkGrounding(
       severity: "warning",
       rule: "check-grounding-inventory-only",
       message:
-        "Inventory refs can support a check, but prose or composition refs are preferred for product-experience enforcement.",
+        "Inventory refs can support a check, but prose or composition refs are preferred for surface-composition enforcement.",
       path: `${path}.derivation`,
     });
   }

--- a/packages/ghost/src/review-packet.ts
+++ b/packages/ghost/src/review-packet.ts
@@ -174,7 +174,7 @@ Review this diff as a non-blocking design-language critic. Advisory findings mus
 
 Use these finding categories: ${packet.finding_categories.join(", ")}.
 
-When fingerprint layers are silent, local evidence can still support advisory critique. Label those findings as provisional and non-Ghost-backed, and ground them in nearby product surfaces, local components, token or copy conventions, or optional rationale files when present. Ask the human before judging high-risk, irreversible, privacy/security/legal, or product-identity-defining choices.
+When fingerprint layers are silent, local evidence can still support advisory critique. Label those findings as provisional and non-Ghost-backed, and ground them in nearby product surfaces, local components, token or copy conventions, or optional rationale files when present. Ask the human before assessing high-risk, irreversible, privacy/security/legal, or product-surface-defining choices.
 
 If the diff exposes missing fingerprint grounding or layer coverage, report it as missing-memory or experience-gap. Do not silently rewrite the Ghost package during review; fingerprint and check edits are ordinary Git-reviewed edits.
 
@@ -286,13 +286,13 @@ function formatAcceptedDecisionsSection(
 ): string {
   if (!decisions) return "";
   if (decisions.length === 0) {
-    return `## Accepted Product-Experience Decisions
+    return `## Accepted Surface-Composition Decisions
 
 _No accepted decisions found in fingerprint/memory/decisions._
 `;
   }
 
-  const lines = ["## Accepted Product-Experience Decisions", ""];
+  const lines = ["## Accepted Surface-Composition Decisions", ""];
   for (const decision of decisions) {
     lines.push(`### ${decision.title}`);
     lines.push("");

--- a/packages/ghost/src/scan-commands.ts
+++ b/packages/ghost/src/scan-commands.ts
@@ -931,7 +931,7 @@ function surveyPatternReviewExpectations(survey: Survey): string[] {
   }
 
   return [
-    "Identify the surface type before judging composition.",
+    "Identify the surface type before assessing composition.",
     "Cite matching composition_patterns[].evidence and survey.ui_surfaces evidence for advisory findings.",
     "Treat fingerprint/memory/intent.md as human authority when present.",
   ];

--- a/packages/ghost/src/scan/constants.ts
+++ b/packages/ghost/src/scan/constants.ts
@@ -7,7 +7,7 @@ export const RESOURCES_FILENAME = "resources.yml";
 /** Canonical filename for operational composition grammar. */
 export const PATTERNS_FILENAME = "patterns.yml";
 
-/** Canonical product experience memory artifact. */
+/** Canonical product-surface composition artifact. */
 export const FINGERPRINT_YML_FILENAME = "fingerprint.yml";
 
 /** Portable fingerprint bundle directory under the package root. */
@@ -44,7 +44,7 @@ export const SCOPE_SURVEYS_DIRNAME = "modules";
 /** Canonical filename for human-promoted deterministic gates. */
 export const CHECKS_FILENAME = "checks.yml";
 
-/** Optional directory containing accepted/rejected product-experience decisions. */
+/** Optional directory containing accepted/rejected surface-composition decisions. */
 export const DECISIONS_DIRNAME = "decisions";
 
 /** Optional directory containing generated, non-canonical caches. */

--- a/packages/ghost/src/scan/context/package-review-command.ts
+++ b/packages/ghost/src/scan/context/package-review-command.ts
@@ -53,7 +53,7 @@ export function emitPackageReviewCommand(
 
 function packageFrontmatter(product: string): string {
   return `---
-description: Ghost product-experience review for ${product} - grounded in fingerprint core layers
+description: Ghost surface-composition review for ${product} - grounded in fingerprint core layers
 ---`;
 }
 
@@ -69,7 +69,7 @@ function packageWorkflowSection(context: PackageContext): string {
   return `## Review Workflow
 
 1. Read \`${fingerprintDir}/fingerprint/prose.yml\`, \`${fingerprintDir}/fingerprint/inventory.yml\`, and \`${fingerprintDir}/fingerprint/composition.yml\` as the canonical core layers.
-2. Select the relevant situation before judging UI, copy, flow, disclosure, recovery, trust, or interaction behavior. Keep findings grounded in the resolved fingerprint stack or active checks; do not expand the review into unrelated audit categories.
+2. Select the relevant situation before assessing UI, copy, flow, disclosure, recovery, trust, or interaction behavior. Keep findings grounded in the resolved fingerprint stack or active checks; do not expand the review into unrelated audit categories.
 3. Apply prose principles, experience contracts, and composition patterns before choosing implementation details.
 4. Inspect relevant inventory exemplars as concrete anchors for what good looks like.
 5. Use inventory building blocks only as replaceable material that may help satisfy the selected prose and composition.
@@ -83,11 +83,11 @@ function packageFindingPolicySection(): string {
 
 Use these categories: ${REVIEW_FINDING_CATEGORIES.map((category) => `\`${category}\``).join(", ")}.
 
-Only findings backed by an active check should be treated as blocking. Everything else is advisory product-experience critique.
+Only findings backed by an active check should be treated as blocking. Everything else is advisory surface-composition critique.
 
-Review only what fingerprint layers or active checks make relevant to the product experience.
+Review only what fingerprint layers or active checks make relevant to the product surface.
 
-When fingerprint layers are silent, local evidence can still support advisory critique. Label those findings as provisional and non-Ghost-backed, and ground them in nearby product surfaces, local components, token or copy conventions, or optional rationale files when present. Ask the human before judging high-risk, irreversible, privacy/security/legal, or product-identity-defining choices.
+When fingerprint layers are silent, local evidence can still support advisory critique. Label those findings as provisional and non-Ghost-backed, and ground them in nearby product surfaces, local components, token or copy conventions, or optional rationale files when present. Ask the human before assessing high-risk, irreversible, privacy/security/legal, or product-surface-defining choices.
 
 If the diff reveals missing fingerprint grounding or layer coverage, report \`missing-memory\` or \`experience-gap\` as a review finding. Do not silently rewrite the Ghost package during review; fingerprint edits are ordinary edits that go through normal Git review.`;
 }
@@ -213,7 +213,7 @@ function formatBuildingBlocks(context: PackageContext): string {
   const { building_blocks: blocks } = context.fingerprint.inventory;
   const lines = ["### Inventory Building Blocks"];
   lines.push(
-    "- Use these as replaceable implementation material, not product-experience authority.",
+    "- Use these as replaceable implementation material, not surface-composition authority.",
   );
   pushJoined(lines, "Tokens", blocks.tokens, { code: true });
   pushJoined(lines, "Components", blocks.components, { code: true });

--- a/packages/ghost/src/scan/context/package-writer.ts
+++ b/packages/ghost/src/scan/context/package-writer.ts
@@ -114,14 +114,14 @@ async function writeContextFile(
 function buildPackageSkillMd(context: PackageContext): string {
   return `---
 name: ${context.name}
-description: Use this Ghost product-experience world model to preserve coherent UI generation and review.
+description: Use this Ghost surface-composition fingerprint to preserve coherent UI generation and review.
 user-invocable: true
 ---
 
 This skill grounds work in the **${context.name}** Ghost fingerprint.
 
 Treat this bundle as the upstream handoff for agentic UI work. Use it before
-generation so the output extends the product-experience world model, then
+generation so the output extends the same product-surface composition, then
 validate the resulting diff with Ghost checks or review when available.
 
 Read the files in this order:
@@ -139,9 +139,9 @@ findings advisory.
 
 When fingerprint layers are silent, proceed from nearby product surfaces, local
 components, token and copy conventions, optional rationale files when present,
-and ordinary UX judgment when safe. Label that reasoning as provisional and
+and ordinary UX reasoning when safe. Label that reasoning as provisional and
 non-Ghost-backed. Ask a human before making high-risk, irreversible,
-privacy/security/legal, or product-identity-defining choices. Fingerprint edits
+privacy/security/legal, or product-surface-defining choices. Fingerprint edits
 are ordinary Git-reviewed edits to \`fingerprint/\` files and optional local
 \`config.yml\` when present.
 `;
@@ -149,18 +149,18 @@ are ordinary Git-reviewed edits to \`fingerprint/\` files and optional local
 
 function buildPackagePromptMd(context: PackageContext): string {
   const parts = [
-    `You are working inside the **${context.name}** product experience as captured by Ghost.`,
+    `You are working inside the **${context.name}** product-surface composition as captured by Ghost.`,
   ];
 
   parts.push(`# Agent Handoff
 
-This packet is upstream input for agentic UI work, not post-hoc commentary. Use it before writing or revising product surfaces so the output extends the same product-experience world model instead of merely passing local checks.
+This packet is upstream input for agentic UI work, not post-hoc commentary. Use it before writing or revising product surfaces so the output extends the same surface composition instead of merely passing local checks.
 
 After generating, validate the diff with Ghost checks or review when available, and keep Ghost package edits as ordinary Git-reviewed edits to the source \`.ghost\` package.`);
 
   parts.push(`# Prose
 
-Canonical product meaning lives in \`fingerprint/prose.yml\`. Use situations, principles, and experience contracts as the source of product judgment.
+Surface intent lives in \`fingerprint/prose.yml\`. Use situations, principles, and experience contracts as the source of intent for the work.
 
 \`\`\`yaml
 ${stringifyYaml(context.fingerprint.prose, { lineWidth: 0 }).trim()}
@@ -221,8 +221,8 @@ ${context.intent.trim()}
 - Use inventory building blocks only when they support the selected prose and composition.
 - Treat checks as validation; only active checks are blocking.
 - After generating, run or request Ghost review/check when available so output is validated against the same fingerprint layers.
-- When fingerprint layers are silent, proceed from nearby product surfaces, local components, token and copy conventions, optional rationale files when present, and ordinary UX judgment when safe.
-- Label silent-layer reasoning as provisional and non-Ghost-backed; ask the human before high-risk, irreversible, privacy/security/legal, or product-identity-defining choices.
+- When fingerprint layers are silent, proceed from nearby product surfaces, local components, token and copy conventions, optional rationale files when present, and ordinary UX reasoning when safe.
+- Label silent-layer reasoning as provisional and non-Ghost-backed; ask the human before high-risk, irreversible, privacy/security/legal, or product-surface-defining choices.
 - Treat fingerprint edits as ordinary Git-reviewed edits to \`fingerprint/\` files and optional local \`config.yml\` when present.`);
 
   return `${parts.join("\n\n")}\n`;
@@ -243,7 +243,7 @@ Ghost checks or review when available.
 - \`SKILL.md\` - agent skill manifest.
 - \`prompt.md\` - portable generation packet: prose, inventory, composition, and checks.
 - \`fingerprint/manifest.yml\` - portable fingerprint package anchor.
-- \`fingerprint/prose.yml\` - canonical product judgment.
+- \`fingerprint/prose.yml\` - surface intent.
 - \`fingerprint/inventory.yml\` - canonical curated material and source links.
 - \`fingerprint/composition.yml\` - canonical experience patterns.
 ${context.checksRaw ? "- `fingerprint/enforcement/checks.yml` - deterministic gates.\n" : ""}${context.intent ? "- `fingerprint/memory/intent.md` - supplemental human-authored context.\n" : ""}
@@ -345,7 +345,7 @@ function formatBuildingBlocks(context: PackageContext): string {
   const { building_blocks: blocks } = context.fingerprint.inventory;
   const lines = [
     "## Building Blocks",
-    "- Use these as available material, not product-experience authority.",
+    "- Use these as available material, not surface-composition authority.",
   ];
   pushJoined(lines, "Tokens", blocks.tokens, { code: true });
   pushJoined(lines, "Components", blocks.components, { code: true });

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: ghost
-description: Author, validate, and review repo-local Ghost fingerprints. Use when the user wants to set up a product fingerprint, update .ghost, brief work from product-experience context, review drift, verify generated UI, or compare fingerprint packages.
+description: Author, validate, and review repo-local Ghost fingerprints. Use when the user wants to set up a product-surface fingerprint, update .ghost, brief work from surface-composition context, review drift, verify generated UI, or compare fingerprint packages.
 license: Apache-2.0
 metadata:
   homepage: https://github.com/block/ghost
   cli: ghost
 ---
 
-# Ghost - Product Fingerprints
+# Ghost - Product-Surface Fingerprints
 
-Ghost captures product identity in a repo-local fingerprint package:
+Ghost captures the composition of a product surface: the intent behind it, the
+materials it draws from, and the patterns that make it feel intentional.
 
 ```text
 .ghost/
@@ -33,10 +34,11 @@ design-system registry, or screenshot archive.
 
 Generation uses **prose + inventory + composition**:
 
-- `fingerprint/prose.yml` explains what matters and why.
+- `fingerprint/prose.yml` captures the intent behind the surface.
 - `inventory` points to building blocks and precedents the agent can inspect
   or use, including exemplars.
-- `fingerprint/composition.yml` explains how those blocks become experience.
+- `fingerprint/composition.yml` captures the patterns that make the surface feel
+  intentional.
 
 Checks and review validate output; they are not generation input.
 
@@ -86,7 +88,7 @@ or check format.
 - Collaborative authoring scenarios: follow [references/authoring-scenarios.md](references/authoring-scenarios.md).
 - Fingerprint capture: follow [references/capture.md](references/capture.md).
 - Author fingerprint patterns: follow [references/patterns.md](references/patterns.md).
-- Recall product-experience context: follow [references/recall.md](references/recall.md).
+- Recall surface-composition context: follow [references/recall.md](references/recall.md).
 - Shape a pre-generation brief: follow [references/brief.md](references/brief.md).
 - Critique generated or changed work: follow [references/critique.md](references/critique.md).
 - Review drift: follow [references/review.md](references/review.md).
@@ -119,15 +121,15 @@ evidence-backed core layer entries, then ask the human to curate the claims.
 Silent fingerprint layers do not require stopping by default. When the fingerprint does
 not cover the task, proceed from nearby product surfaces, local components,
 token and copy conventions, optional rationale files when present, and ordinary
-UX judgment when safe. Label that reasoning as provisional and
+UX reasoning when safe. Label that reasoning as provisional and
 non-Ghost-backed.
 Ask a human before making high-risk, irreversible, privacy/security/legal, or
-product-identity-defining choices.
+product-surface-defining choices.
 
 ## Never
 
-- Never treat advisory composition judgment as a CI gate.
-- Never claim provisional judgment, local convention, or general UX reasoning as
+- Never treat advisory composition critique as a CI gate.
+- Never claim provisional reasoning, local convention, or general UX reasoning as
   Ghost-backed.
 - Never treat `fingerprint/memory/intent.md` as authoritative unless human-authored or human-approved.
 - Never treat rejected decisions as canonical inputs.

--- a/packages/ghost/src/skill-bundle/references/authoring-scenarios.md
+++ b/packages/ghost/src/skill-bundle/references/authoring-scenarios.md
@@ -12,12 +12,12 @@ handoffs:
 
 # Recipe: Collaborative Fingerprint Authoring
 
-**Goal:** help a human and agent co-author durable product-experience memory
+**Goal:** help a human and agent co-author durable product-surface composition
 without turning raw repo scans into product truth.
 
-Human intent decides identity. Code, docs, examples, screenshots, stories, and
-UI libraries provide evidence. Agent synthesis is draft work until the human
-curates it and ordinary Git review accepts it.
+Human intent anchors surface composition. Code, docs, examples, screenshots,
+stories, and UI libraries provide evidence. Agent synthesis is draft work until
+the human curates it and ordinary Git review accepts it.
 
 `auto-draft` is an optional skill mode for reducing blank-page cost. It scans
 first and writes starter core layer edits, but those edits are still draft work
@@ -36,8 +36,8 @@ Choose the nearest scenario before writing fingerprint layers:
 | Design system or UI library | Grammar-led. Describe primitives, component behavior, token posture, accessibility, and composition constraints. |
 | Rebrand, redesign, or migration | Human-led transition. Capture current, target, and migration cautions; use decisions for rationale. |
 | Prototype becoming product | Ratification-led. Preserve only the emergent patterns a human wants to keep. |
-| Fork, white label, or tenant variant | Shared base + local divergence. Keep common identity broad and local differences scoped. |
-| Monorepo or nested surfaces | Stack-aware. Use root guidance for product-family identity and nested packages for surfaces judged differently. |
+| Fork, white label, or tenant variant | Shared base + local divergence. Keep common surface composition broad and local differences scoped. |
+| Monorepo or nested surfaces | Stack-aware. Use root guidance for product-family composition and nested packages for surfaces assessed differently. |
 
 If more than one scenario applies, start with the broad repo scenario, then run
 the nested decision test for individual products, apps, or feature areas.
@@ -56,7 +56,7 @@ Ask only high-leverage questions that change the fingerprint:
 - Which screens, flows, stories, or examples show the product at its best?
 - Which current patterns are legacy, accidental, experimental, or low quality?
 - Where do trust, density, pacing, accessibility, recovery, or disclosure matter most?
-- Are there surfaces where the same UI decision should be judged differently?
+- Are there surfaces where the same UI decision should be assessed differently?
 
 Use human-authored or human-approved answers in `prose.yml` and optional
 `fingerprint/memory/intent.md`. Do not treat unapproved notes as canonical.
@@ -68,8 +68,8 @@ use it to curate claims instead of asking every question up front.
 
 Read the product, not just the component library. Inspect routes, components,
 stories, tests, docs, screenshots, examples, copy, tokens, assets, and UI
-library references that reveal identity, hierarchy, behavior, accessibility,
-trust, and flow.
+library references that reveal hierarchy, behavior, accessibility, trust, and
+flow.
 
 Optional cache:
 
@@ -79,11 +79,12 @@ ghost inventory . > .ghost/fingerprint/sources/cache/inventory.json
 ```
 
 Treat generated cache as scratch evidence. It can support curated entries in
-`inventory.yml`, but it does not establish product judgment by itself.
+`inventory.yml`, but it does not establish surface-composition guidance by
+itself.
 
 In auto-draft mode, always create or refresh this cache before drafting, then
 inspect the high-signal files it points to. Scan facts may seed `inventory.yml`;
-scan frequency and raw cache do not establish product judgment.
+scan frequency and raw cache do not establish surface-composition guidance.
 
 ## 4. Draft The Core Layers
 
@@ -105,7 +106,7 @@ exemplars where possible, and leave ambiguous product meaning for curation.
 
 ## 5. Curate With The Human
 
-Before treating draft content as durable memory, ask the human to classify
+Before treating draft content as durable surface context, ask the human to classify
 important claims:
 
 - keep as canonical
@@ -117,12 +118,12 @@ important claims:
 - convert into a deterministic check
 
 Only add checks when the rule can be enforced deterministically. Subjective
-composition judgment belongs in `composition.yml` or advisory review, not in a
+composition critique belongs in `composition.yml` or advisory review, not in a
 blocking gate.
 
 ## 6. Decide Nested Packages
 
-Create or update a local `.ghost/` only when a surface would be judged
+Create or update a local `.ghost/` only when a surface should be assessed
 differently from the root package.
 
 Use a nested package when the local surface has distinct:
@@ -165,4 +166,4 @@ canonical package.
 - Never make `fingerprint/memory/intent.md` authoritative unless human-authored
   or human-approved.
 - Never create nested packages just to mirror directory structure.
-- Never turn advisory composition judgment into a deterministic gate.
+- Never turn advisory composition critique into a deterministic gate.

--- a/packages/ghost/src/skill-bundle/references/capture.md
+++ b/packages/ghost/src/skill-bundle/references/capture.md
@@ -12,7 +12,7 @@ handoffs:
 
 # Recipe: Author Ghost Fingerprint
 
-**Goal:** record durable product-experience memory in `.ghost/fingerprint/`.
+**Goal:** record durable product-surface composition in `.ghost/fingerprint/`.
 If a change is uncommitted or unmerged, it is draft work. If it is checked in,
 Ghost treats the fingerprint package as canonical.
 
@@ -30,9 +30,9 @@ Ghost treats the fingerprint package as canonical.
     sources/cache/
 ```
 
-`prose.yml` answers what matters and why. `inventory.yml` records curated
-materials, exemplars, and source links. `composition.yml` records how those
-materials become recognizable experience. Checks validate output after
+`prose.yml` captures the intent behind the surface. `inventory.yml` records
+curated materials, exemplars, and source links. `composition.yml` records the
+patterns that make the surface feel intentional. Checks validate output after
 generation; they are not generation input.
 
 ## Steps
@@ -47,15 +47,16 @@ Common starting points:
 
 - Net new repos are mostly human-led because the repo has little evidence.
 - Net new repos with a UI library combine human intent with library scans.
-- Existing repos combine human judgment with code, docs, route, story, and
+- Existing repos combine human intent with code, docs, route, story, and
   exemplar scans.
 - Existing repos with mixed quality require curation before repeated patterns
   become canonical.
 - Monorepos and product suites need a nested-package decision pass before local
   surfaces inherit or add guidance.
 
-Human intent decides product identity. Scans provide evidence. Agent synthesis
-is draft work until a human curates it and ordinary Git review accepts it.
+Human intent anchors surface composition. Scans provide evidence. Agent
+synthesis is draft work until a human curates it and ordinary Git review
+accepts it.
 
 If the user asks for `auto-draft`, keep this same boundary: the mode may create
 starter edits, but it does not make scan output canonical.
@@ -103,8 +104,8 @@ less and ask more. Do not fill core layers with speculative product claims.
 ### 4. Orient
 
 Read the product, not just the component library. Look for surfaces, docs,
-tests, stories, routes, screenshots, or examples that reveal identity,
-hierarchy, behavior, copy, accessibility, and trust.
+tests, stories, routes, screenshots, or examples that reveal hierarchy,
+behavior, copy, accessibility, trust, and flow.
 
 Optional helper:
 
@@ -114,7 +115,7 @@ ghost inventory . > .ghost/fingerprint/sources/cache/inventory.json
 ```
 
 Treat generated cache as scratch material. Do not copy raw inventory into
-`inventory.yml` without judgment.
+`inventory.yml` without curation.
 
 ### 5. Write Core Layers
 
@@ -142,7 +143,7 @@ derivation:
 
 Ref-backed checks are preferred. Missing or unresolved derivation refs lint as
 warnings. Inventory can support a check, but inventory-only grounding is not
-product judgment by itself.
+surface-composition guidance by itself.
 
 ### 7. Validate
 
@@ -160,5 +161,5 @@ packages exist.
 - Never describe any file outside `.ghost/fingerprint/` as canonical package input.
 - Never treat generated cache as canonical inventory.
 - Never treat auto-draft as a CLI feature or a replacement for human curation.
-- Never invent product-experience obligations absent from evidence or human direction.
-- Never promote subjective judgment directly into checks; make it deterministic or keep it advisory.
+- Never invent surface-composition obligations absent from evidence or human direction.
+- Never promote subjective taste directly into checks; make it deterministic or keep it advisory.

--- a/packages/ghost/src/skill-bundle/references/compare.md
+++ b/packages/ghost/src/skill-bundle/references/compare.md
@@ -43,4 +43,4 @@ Use for: comparing a collection of fingerprints at the same elevation: which are
 - **> 0.5**: the two fingerprints represent meaningfully different systems. Either one has diverged intentionally, or they were never the same.
 
 If the user asks "why did it change", inspect the compared fingerprint layers
-and summarize the product-experience differences directly.
+and summarize the surface-composition differences directly.

--- a/packages/ghost/src/skill-bundle/references/critique.md
+++ b/packages/ghost/src/skill-bundle/references/critique.md
@@ -16,7 +16,7 @@ When fingerprint layers are silent, you may use nearby product surfaces, local
 components, token and copy conventions, accepted decisions, or human intent when
 present. Label that reasoning as provisional and non-Ghost-backed.
 
-Do not make advisory taste judgment sound blocking unless an active check backs
+Do not make advisory taste critique sound blocking unless an active check backs
 it. If fingerprint grounding or layer coverage is missing or contradictory,
 name that as `missing-memory` or `experience-gap`; edit the Ghost package only
 when the user asks you to.

--- a/packages/ghost/src/skill-bundle/references/patterns.md
+++ b/packages/ghost/src/skill-bundle/references/patterns.md
@@ -1,6 +1,6 @@
 ---
 name: patterns
-description: Author product-experience patterns inside .ghost/fingerprint/composition.yml.
+description: Author surface-composition patterns inside .ghost/fingerprint/composition.yml.
 handoffs:
   - label: Verify fingerprint package
     command: ghost verify .ghost --root .
@@ -11,7 +11,7 @@ handoffs:
 
 **Goal:** write useful `patterns[]` entries in `.ghost/fingerprint/composition.yml`.
 
-Patterns are durable product-experience memory. They may describe rules,
+Patterns are durable surface-composition guidance. They may describe rules,
 layouts, structures, flows, states, content, behavior, or visual arrangements.
 They are not a raw inventory of everything the repo does.
 
@@ -63,7 +63,7 @@ Allowed `kind` values:
 - Cite paths, locators, or notes as evidence.
 - Put obligations that affect failure, disclosure, recovery, or trust in
   `prose.experience_contracts`, not only `composition.patterns`.
-- Put broad product judgment in `prose.principles`.
+- Put broad surface intent in `prose.principles`.
 - Add `check_refs` only when a deterministic check exists in `fingerprint/enforcement/checks.yml`.
 
 ## Validate

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -7,7 +7,7 @@ Canonical package:
   config.yml                    optional local routing
   fingerprint/
     manifest.yml                ghost.fingerprint-package/v1
-    prose.yml                   core product judgment
+    prose.yml                   core surface intent
     inventory.yml               core material and source links
     composition.yml             core patterns
     enforcement/checks.yml      optional ghost.checks/v1 gates
@@ -43,4 +43,4 @@ Use these typed refs:
 
 `fingerprint/enforcement/checks.yml` remains deterministic only. Ref-backed
 checks are preferred; missing or unresolved derivation refs lint as warnings.
-Inventory refs can support a check but do not establish product judgment alone.
+Inventory refs can support a check but do not establish surface guidance alone.

--- a/packages/ghost/src/skill-bundle/references/verify.md
+++ b/packages/ghost/src/skill-bundle/references/verify.md
@@ -17,7 +17,7 @@ description: Verify generated UI or fingerprint edits against Ghost.
 Report:
 
 - Active-check failures and repairs.
-- Advisory product-experience drift with citations.
+- Advisory surface-composition drift with citations.
 - Missing or unreachable evidence and exemplar paths.
 - Provisional local reasoning where fingerprint layers are silent.
 - Any fingerprint edits the user requested.

--- a/packages/ghost/test/checks-grounding.test.ts
+++ b/packages/ghost/test/checks-grounding.test.ts
@@ -24,7 +24,7 @@ describe("ghost.checks/v1 grounding", () => {
     });
   });
 
-  it("accepts active checks grounded in prose memory", () => {
+  it("accepts active checks grounded in prose refs", () => {
     const report = lintGhostChecks(checksDocument(), {
       fingerprint: fingerprintDocument(),
     });
@@ -45,7 +45,7 @@ describe("ghost.checks/v1 grounding", () => {
     });
   });
 
-  it("accepts active checks grounded in composition memory", () => {
+  it("accepts active checks grounded in composition refs", () => {
     const report = lintGhostChecks(
       checksDocument({
         derivation: {

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -900,7 +900,7 @@ checks:
     await expect(
       readFile(join(dir, "skills", "ghost", "SKILL.md"), "utf-8"),
     ).resolves.toContain(
-      "Never claim provisional judgment, local convention, or general UX reasoning",
+      "Never claim provisional reasoning, local convention, or general UX reasoning",
     );
     await expect(
       readFile(

--- a/scripts/check-terminology.mjs
+++ b/scripts/check-terminology.mjs
@@ -4,12 +4,17 @@ import { join, relative } from "node:path";
 const ROOTS = [
   "README.md",
   "CLAUDE.md",
+  "package.json",
   "docs",
   "apps",
+  "install",
+  "packages/ghost/README.md",
+  "packages/ghost/package.json",
   "packages/ghost/src",
   "packages/ghost/test",
   "packages/ghost-core/src",
   "packages/ghost-core/test",
+  "packages/ghost-ui/README.md",
   ".ghost",
   ".changeset",
 ];
@@ -49,6 +54,19 @@ const FORBIDDEN_PHRASES = [
   "custom memory directories",
   "inventory cache",
   "generated inventory",
+  "product-experience",
+  "product experience",
+  "product judgment",
+  "product identity",
+  "experience identity",
+  "product memory",
+  "experience memory",
+  "world model",
+  "memory for agents",
+  "judgment",
+  "judgement",
+  "judging",
+  "judged",
 ];
 
 const DISALLOWED_VERSION_MARKER = `${"v"}${"2"}`;
@@ -67,10 +85,12 @@ const ALLOWED_MEMORY_TERMS = [
   "--memory-dir",
   "--include-memory",
   "missing-memory",
-  "product-experience memory",
-  "memory for agents",
   "muscle memory",
   "in-memory",
+  "fingerprint/memory/intent.md",
+  "fingerprint/memory/decisions",
+  "memory/intent.md",
+  "memory/decisions",
 ];
 
 const forbiddenPatterns = FORBIDDEN_PHRASES.map((phrase) => ({


### PR DESCRIPTION
## Summary
- Reframe public and agent-facing Ghost copy around product-surface composition.
- Update emitted context/review packet language, installed skill docs, package metadata, installer copy, and Ghost’s dogfood fingerprint.
- Tighten terminology checks and add a patch changeset.

## Validation
- `pnpm test`
- `pnpm check`
- `node packages/ghost/dist/bin.js scan --format json`
- `node packages/ghost/dist/bin.js lint .ghost`
- `node packages/ghost/dist/bin.js verify .ghost --root .`
- Pre-push hook reran `pnpm build`, `pnpm check`, and `pnpm test` successfully.