### PR TITLE
feat: voice and language capture through existing fingerprint layers

### DIFF
--- a/.changeset/language-through-fingerprint-layers.md
+++ b/.changeset/language-through-fingerprint-layers.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": minor
+---
+
+Adds the voice recipe to the skill bundle and documents how voice and language map onto existing fingerprint layers without schema changes.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ optional and only used by semantic embedding helpers when a host opts in.
 | --- | --- |
 | [docs/fingerprint-format.md](./docs/fingerprint-format.md) | Portable `.ghost/fingerprint/` package format. |
 | [docs/generation-loop.md](./docs/generation-loop.md) | Brief, generate, check, review, and remediate loop. |
+| [docs/language-fingerprints.md](./docs/language-fingerprints.md) | Voice and language capture through existing fingerprint layers. |
 | [docs/host-adapters.md](./docs/host-adapters.md) | Adapter-neutral JSON, severity mapping, and custom fingerprint directories. |
 | [docs/ghost-fleet.md](./docs/ghost-fleet.md) | Current private fleet package model. |
 | [GOVERNANCE.md](./GOVERNANCE.md) | Project governance. |

--- a/docs/language-fingerprints.md
+++ b/docs/language-fingerprints.md
@@ -1,0 +1,164 @@
+# Language In The Fingerprint
+
+Voice and language are part of a product surface. Copy drifts the same way
+layout drifts: generated notifications, error messages, empty states, and
+button labels slowly stop sounding like one product.
+
+Ghost does not need a new domain, schema, or dimension set to capture this.
+Language flows through the same three core layers as every other
+surface-composition concern:
+
+- `fingerprint/prose.yml` carries voice intent.
+- `fingerprint/inventory.yml` points at copy material and external writing
+  standards.
+- `fingerprint/composition.yml` carries copy patterns.
+- `fingerprint/enforcement/checks.yml` carries the deterministic subset.
+
+This document shows the mapping. Nothing here changes the
+`ghost.fingerprint/v1` schema.
+
+## Voice Intent Lives In Prose
+
+`prose.summary.tone` already exists for tone words. Voice rules that need
+rationale become principles. Surfaces with non-negotiable wording become
+experience contracts.
+
+```yaml
+# fingerprint/prose.yml
+summary:
+  tone:
+    - plain
+    - direct
+    - warm
+principles:
+  - id: action-first-copy
+    principle: Copy leads with what the reader can do next, not with what the system did.
+    guidance:
+      - Prefer "Try again" over "The operation failed."
+      - Keep apology framing out of routine errors.
+    evidence:
+      - path: src/components/error-banner.tsx
+        note: Existing errors already lead with the recovery action.
+experience_contracts:
+  - id: exact-wording-surfaces
+    contract: Designated surfaces (legal text, consent prompts, destructive confirmations) use approved exact wording and are never paraphrased.
+    obligations:
+      - Treat the approved string as the source of truth, not a style suggestion.
+      - Route wording changes through ordinary Git review.
+    check_refs:
+      - check:no-banned-phrases
+```
+
+## Copy Material Lives In Inventory
+
+Most teams already maintain writing standards somewhere: a style guide, a
+terminology list, a banned-phrase list. The fingerprint should point at that
+source, not fork it. `inventory.sources` already supports this.
+
+```yaml
+# fingerprint/inventory.yml
+building_blocks:
+  files:
+    - src/i18n/en.json
+  notes:
+    - User-facing strings are centralized in the i18n catalog; copy edits happen there.
+sources:
+  - id: writing-standards
+    kind: url
+    ref: https://example.com/your-org/writing-standards
+    note: Org voice rules and terminology. Normativity levels map to Ghost per the table in docs/language-fingerprints.md.
+exemplars:
+  - id: refund-error-copy
+    path: src/components/refund-error.tsx
+    surface_type: error-state
+    why: Canonical error shape - states what happened, then the next step, in under two sentences.
+```
+
+External standards stay maintained in one place. The fingerprint records which
+source applies and which surfaces it governs.
+
+## Copy Patterns Live In Composition
+
+`composition.yml` already has `kind: content` for exactly this.
+
+```yaml
+# fingerprint/composition.yml
+patterns:
+  - id: error-message-shape
+    kind: content
+    pattern: Error copy states what happened, then the next step the reader can take.
+    guidance:
+      - Two sentences maximum for inline errors.
+      - Name the recovery action in the same breath as the failure.
+    anti_patterns:
+      - Passive apology framing ("we're sorry to inform you").
+      - Blaming the reader ("you entered an invalid value").
+    check_refs:
+      - check:no-banned-phrases
+    evidence:
+      - path: src/components/error-banner.tsx
+  - id: button-labels-are-verbs
+    kind: content
+    pattern: Buttons label the action the reader takes, as a verb phrase.
+    anti_patterns:
+      - Generic labels ("OK", "Submit") where a specific verb exists.
+```
+
+## The Deterministic Subset Becomes Checks
+
+Writing standards commonly carry normativity levels, in the spirit of
+RFC 2119: some rules are absolute, some are recommended, some are contextual.
+Map them onto the existing check lifecycle instead of inventing a new one:
+
+| Standard's level | Ghost expression | Effect |
+| --- | --- | --- |
+| must (legal wording, banned phrases) | `checks.yml` entry with `status: active` | `ghost check` can fail the diff |
+| should (strong recommendation) | `checks.yml` entry with `status: proposed` | Surfaces in `ghost review` as advisory |
+| may / contextual | `composition.yml` guidance only | Generation input, never a gate |
+
+Only the mechanically detectable subset belongs in `checks.yml`. The
+`forbidden-regex` and `required-regex` detectors cover banned phrases and
+required boilerplate today:
+
+```yaml
+# fingerprint/enforcement/checks.yml
+checks:
+  - id: no-banned-phrases
+    title: Banned phrases stay out of user-facing copy
+    status: active
+    severity: serious
+    derivation:
+      prose:
+        - prose.experience_contract:exact-wording-surfaces
+      composition:
+        - composition.pattern:error-message-shape
+    applies_to:
+      paths:
+        - src/i18n/**
+        - src/components/**
+    detector:
+      type: forbidden-regex
+      pattern: "we'?re sorry to inform you|per our policy"
+    repair: Lead with the recovery action; see the error-message-shape pattern and the linked writing standards.
+```
+
+Everything that needs reading comprehension - tone, register, audience fit -
+stays advisory. `ghost review` routes it to the host agent with the relevant
+prose and composition refs; it never blocks on its own.
+
+## What Ghost Deliberately Does Not Do
+
+- Ghost does not ship a voice ontology, tone scales, or scored language
+  dimensions. Voice rules are curated prose, owned by the team that writes
+  them, approved through Git review like every other fingerprint edit.
+- Ghost does not embed any organization's style guide. The fingerprint points
+  at one through `inventory.sources`.
+- Advisory copy critique never gates CI. Only active deterministic checks
+  block, exactly as with visual and structural drift.
+
+## Workflow
+
+Capturing language follows the same loop as any other layer content: inventory
+the user-facing strings, read the standards source the inventory declares,
+draft the smallest evidence-backed entries, and ask a human to curate the
+claims. The `voice` recipe in the Ghost skill bundle walks an agent through it.

--- a/docs/language-fingerprints.md
+++ b/docs/language-fingerprints.md
@@ -33,6 +33,13 @@ summary:
 principles:
   - id: action-first-copy
     principle: Copy leads with what the reader can do next, not with what the system did.
+    applies_to:
+      paths:
+        - src/i18n/**
+        - src/components/**
+      surface_types:
+        - error-state
+        - empty-state
     guidance:
       - Prefer "Try again" over "The operation failed."
       - Keep apology framing out of routine errors.
@@ -42,12 +49,24 @@ principles:
 experience_contracts:
   - id: exact-wording-surfaces
     contract: Designated surfaces (legal text, consent prompts, destructive confirmations) use approved exact wording and are never paraphrased.
+    applies_to:
+      surface_types:
+        - legal-text
+        - consent-prompt
+        - destructive-confirmation
     obligations:
       - Treat the approved string as the source of truth, not a style suggestion.
       - Route wording changes through ordinary Git review.
     check_refs:
       - check:no-banned-phrases
 ```
+
+Scope every voice entry with `applies_to`. Selective context assembly uses
+`applies_to` paths, scopes, and surface types to decide which fingerprint
+entries reach an agent for a given piece of work. Scoped voice entries are
+selected when copy work touches their surfaces and stay out of the way when
+it does not; unscoped entries only surface through ref edges or the global
+fallback.
 
 ## Copy Material Lives In Inventory
 
@@ -87,6 +106,9 @@ patterns:
   - id: error-message-shape
     kind: content
     pattern: Error copy states what happened, then the next step the reader can take.
+    applies_to:
+      surface_types:
+        - error-state
     guidance:
       - Two sentences maximum for inline errors.
       - Name the recovery action in the same breath as the failure.

--- a/install/manifest.json
+++ b/install/manifest.json
@@ -18,6 +18,7 @@
     "references/remediate.md",
     "references/review.md",
     "references/schema.md",
-    "references/verify.md"
+    "references/verify.md",
+    "references/voice.md"
   ]
 }

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -88,6 +88,7 @@ or check format.
 - Collaborative authoring scenarios: follow [references/authoring-scenarios.md](references/authoring-scenarios.md).
 - Fingerprint capture: follow [references/capture.md](references/capture.md).
 - Author fingerprint patterns: follow [references/patterns.md](references/patterns.md).
+- Capture voice and language: follow [references/voice.md](references/voice.md).
 - Recall surface-composition context: follow [references/recall.md](references/recall.md).
 - Shape a pre-generation brief: follow [references/brief.md](references/brief.md).
 - Critique generated or changed work: follow [references/critique.md](references/critique.md).

--- a/packages/ghost/src/skill-bundle/references/voice.md
+++ b/packages/ghost/src/skill-bundle/references/voice.md
@@ -1,0 +1,41 @@
+---
+name: voice
+description: Capture voice and language guidance into existing Ghost fingerprint layers.
+---
+
+# Recipe: Capture Voice And Language
+
+Language maps onto the existing layers; do not invent new schema. See
+`docs/language-fingerprints.md` in the Ghost repo for the full mapping.
+
+1. Inventory the user-facing strings: i18n catalogs, error components,
+   notifications, empty states, onboarding copy. Record durable locations in
+   `inventory.building_blocks` and strong examples as `inventory.exemplars`.
+2. Check `inventory.sources` for a declared writing-standards source. Read it
+   when present. If the team maintains standards elsewhere, propose adding a
+   `sources` entry pointing at them instead of copying their content in.
+3. Draft the smallest evidence-backed entries:
+   - Tone words into `prose.summary.tone`.
+   - Voice rules with rationale into `prose.principles`.
+   - Surfaces with non-negotiable exact wording into
+     `prose.experience_contracts`.
+   - Copy shapes into `composition.patterns` with `kind: content`, including
+     `anti_patterns` observed in the repo.
+4. Promote only the mechanically detectable subset into
+   `fingerprint/enforcement/checks.yml`:
+   - Absolute rules (banned phrases, required boilerplate) become
+     `forbidden-regex` or `required-regex` checks with `status: active`.
+   - Recommendations become `status: proposed` so `ghost review` surfaces
+     them without blocking.
+   - Contextual guidance stays in composition only.
+   - Give each check a `derivation` ref back to the prose or composition
+     entry it enforces.
+5. Validate with `ghost lint` and `ghost verify --root <target>`, then hand
+   the draft to the human to curate. Fingerprint edits stay ordinary
+   uncommitted draft work until Git review accepts them.
+
+When reviewing copy changes, cite the diff location and the relevant
+`prose.principle`, `prose.experience_contract`, or `composition.pattern` refs.
+Tone and register findings are advisory unless an active check backs them.
+When voice layers are silent, proceed from nearby copy in the repo and label
+that reasoning as provisional and non-Ghost-backed.

--- a/packages/ghost/src/skill-bundle/references/voice.md
+++ b/packages/ghost/src/skill-bundle/references/voice.md
@@ -21,6 +21,10 @@ Language maps onto the existing layers; do not invent new schema. See
      `prose.experience_contracts`.
    - Copy shapes into `composition.patterns` with `kind: content`, including
      `anti_patterns` observed in the repo.
+   - Scope each entry with `applies_to` (paths, scopes, surface types) so
+     selective context assembly surfaces it for copy work on those surfaces
+     and omits it elsewhere. Unscoped entries reach agents only through ref
+     edges or the global fallback.
 4. Promote only the mechanically detectable subset into
    `fingerprint/enforcement/checks.yml`:
    - Absolute rules (banned phrases, required boilerplate) become


### PR DESCRIPTION
## Summary

Documents how voice and language flow through Ghost's existing fingerprint model — **no new domain, no schema change, no new dimensions**. Supersedes #49.

### Why not a new domain

#49 proposed communication voice as a parallel dimension set (tone/structure/register/boundaries with 0–1 scalars and a 20-dim embedding). That design predates the fingerprint-package model and has aged out on three axes:

1. **Targets a removed package.** Files land in `packages/ghost-drift/`, which was folded into `packages/ghost`. The frontmatter/body partition rules and `ghost-drift` verbs it builds on are legacy.
2. **The current model already absorbed the concern.** `prose.summary.tone` exists, `composition.yml` has `kind: content` patterns, and `enforcement/checks.yml` ships `forbidden-regex`/`required-regex` detectors — which is what the proposed `boundaries` block reinvents.
3. **Scored voice scalars are a human call, not a measurement.** Curated prose rules with evidence, owned through Git review, fit Ghost's model; an embedded voice ontology does not. Ghost stays the deterministic calculator and never ships anyone's style guide.

### What this adds

- **`docs/language-fingerprints.md`** — the mapping: voice intent → `prose.yml` (tone words, principles, experience contracts for exact-wording surfaces); copy material and external writing standards → `inventory.yml` (`sources` entries point at maintained standards instead of forking them); copy shapes → `composition.yml` `kind: content` patterns; the mechanically detectable subset → `enforcement/checks.yml`.
- **Normativity-level mapping** (RFC 2119 spirit): a standard's *must* → `status: active` check (blocks); *should* → `status: proposed` (advisory in `ghost review`); *may/contextual* → composition guidance only, never a gate.
- **`references/voice.md`** — skill recipe: inventory user-facing strings → read the declared standards source → draft smallest evidence-backed entries → promote only the deterministic subset to checks → human curates, Git approves.
- Registered in `SKILL.md`, `install/manifest.json`, README resources, plus a `minor` changeset.

All examples are org-agnostic per the repo's own `oss-language-is-portable` principle: any project with a style guide wires it in via `inventory.sources`; organization-specific voice content lives in each adopting repo's own fingerprint, not in Ghost.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test` — 338/338 passing (install-manifest test covers `voice.md`)
- [x] `pnpm check` guards pass (terminology, file-size, install-bundle, CLI manifest in sync)
- [x] No runtime code changes; docs + skill bundle + manifest only