### PR TITLE
[codex] Add navigable Ghost context entrypoints

### DIFF
--- a/.changeset/navigable-context-entrypoint.md
+++ b/.changeset/navigable-context-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Emit compact, path-aware Ghost context entrypoints for generation and review.

--- a/apps/docs/src/content/docs/cli-reference.mdx
+++ b/apps/docs/src/content/docs/cli-reference.mdx
@@ -121,7 +121,7 @@ ghost verify --all --memory-dir .design/memory
 
 ### Generate handoff packets - `emit`
 
-Emit `review-command` or the `context-bundle` generation packet from split
+Emit `review-command` or the `context-bundle` compact entrypoint from split
 fingerprint layers. Use `context-bundle` before generation and
 `review-command` when a host wants a reusable review prompt.
 

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -116,7 +116,7 @@ approval. For a fuller human-agent workflow, read
 
 <DocSection title="Generate From Ghost">
 
-Before generating or revising UI, emit the upstream handoff packet:
+Before generating or revising UI, emit the upstream compact entrypoint:
 
 ```bash
 ghost emit context-bundle

--- a/apps/docs/src/generated/cli-manifest.json
+++ b/apps/docs/src/generated/cli-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-05T03:15:06.380Z",
+  "generatedAt": "2026-06-10T17:47:36.455Z",
   "tools": [
     {
       "tool": "ghost",
@@ -315,7 +315,7 @@
           "tool": "ghost",
           "name": "emit",
           "rawName": "emit <kind>",
-          "description": "Emit a derived artifact from the fingerprint package (review command or context-bundle generation packet)",
+          "description": "Emit a derived artifact from the fingerprint package (review command or compact context entrypoint)",
           "group": "core",
           "defaultHelp": true,
           "compactName": "emit",
@@ -372,7 +372,7 @@
             {
               "rawName": "--prompt-only",
               "name": "promptOnly",
-              "description": "Emit only prompt.md (context-bundle generation packet)",
+              "description": "Emit only prompt.md (context-bundle compact entrypoint)",
               "default": null,
               "takesValue": false,
               "negated": false

--- a/packages/ghost/src/review-packet.ts
+++ b/packages/ghost/src/review-packet.ts
@@ -4,11 +4,14 @@ import { resolve } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { type GhostDecisionDocument, lintGhostDecision } from "#ghost-core";
 import { parseUnifiedDiff } from "./core/index.js";
+import { buildContextEntrypoint } from "./scan/context/entrypoint.js";
+import { formatContextEntrypointMarkdown } from "./scan/context/entrypoint-markdown.js";
 import {
+  fingerprintStackToPackageContext,
   type GhostFingerprintStack,
   type GhostPackageConfig,
   groupFingerprintStacksForPaths,
-  loadFingerprintPackage,
+  loadPackageContext,
   readOptionalPackageConfig,
   resolveFingerprintPackage,
 } from "./scan/index.js";
@@ -30,12 +33,28 @@ async function buildSingleBundleReviewPacket(options: {
   includeAcceptedDecisions: boolean;
 }): Promise<ReviewPacket> {
   const paths = resolveFingerprintPackage(options.packageDir, process.cwd());
-  const loaded = await loadFingerprintPackage(paths);
+  const changedFiles = parseUnifiedDiff(options.diffText).map(
+    (file) => file.path,
+  );
+  const context = await loadPackageContext(paths);
+  context.targetPaths = changedFiles;
   const packet: ReviewPacket = {
     ...baseReviewPacket(paths.dir, options.diffText),
-    fingerprint: loaded.fingerprint,
+    fingerprint: context.fingerprint,
+    context_markdown: formatReviewContextMarkdown([
+      {
+        title: paths.dir,
+        markdown: formatContextEntrypointMarkdown(
+          buildContextEntrypoint(context, { targetPaths: changedFiles }),
+          {
+            heading: "### Selected Fingerprint Context",
+            includeIntro: false,
+          },
+        ),
+      },
+    ]),
     intent: (await readOptional(paths.intent)) ?? null,
-    checks: (await readOptional(paths.checks)) ?? null,
+    checks: context.checksRaw ?? null,
     config: (await readOptionalPackageConfig(paths.config)) ?? null,
   };
   if (options.includeAcceptedDecisions) {
@@ -60,6 +79,25 @@ async function buildStackReviewPacket(options: {
   const stacks = groups.map((group) =>
     reviewStackFromFingerprintStack(group.stack, group.changed_files),
   );
+  const contextSections = groups.map((group) => {
+    const context = fingerprintStackToPackageContext(
+      group.stack,
+      undefined,
+      group.changed_files,
+    );
+    return {
+      title: group.stack.layers.at(-1)?.dir ?? group.stack.fingerprint_dir,
+      markdown: formatContextEntrypointMarkdown(
+        buildContextEntrypoint(context, {
+          targetPaths: group.changed_files,
+        }),
+        {
+          heading: "### Selected Fingerprint Context",
+          includeIntro: false,
+        },
+      ),
+    };
+  });
   const first = stacks[0];
   const config = await readOptionalPackageConfig(
     resolve(first.package_dir, "config.yml"),
@@ -70,6 +108,7 @@ async function buildStackReviewPacket(options: {
       options.diffText,
     ),
     fingerprint: first.merged.fingerprint,
+    context_markdown: formatReviewContextMarkdown(contextSections),
     intent: first.merged.intent,
     checks: stringifyYaml(first.merged.checks, { lineWidth: 0 }),
     config: config ?? null,
@@ -140,6 +179,7 @@ interface ReviewPacket {
   schema: "ghost.advisory-review/v1";
   package_dir: string;
   fingerprint: unknown;
+  context_markdown: string;
   intent: string | null;
   checks: string | null;
   config: GhostPackageConfig | null;
@@ -180,11 +220,7 @@ If the diff exposes missing fingerprint grounding or layer coverage, report it a
 
 ${formatReviewStacksSection(packet.stacks ?? null)}
 
-## Fingerprint Layers
-
-\`\`\`yaml
-${stringifyYaml(packet.fingerprint)}
-\`\`\`
+${packet.context_markdown}
 
 ## Human Intent
 
@@ -195,12 +231,6 @@ ${packet.intent ?? "_No fingerprint/memory/intent.md present. Treat fingerprint 
 ${formatAcceptedDecisionsSection(packet.accepted_decisions ?? null)}
 
 ${formatConfigSection(packet.config)}
-
-## Active Checks
-
-\`\`\`yaml
-${packet.checks ?? "schema: ghost.checks/v1\nid: none\nchecks: []\n"}
-\`\`\`
 
 ## Diff
 
@@ -219,25 +249,29 @@ function formatReviewStacksSection(stacks: ReviewStackPacket[] | null): string {
     lines.push("");
     lines.push(`Changed files: ${stack.changed_files.join(", ") || "none"}`);
     lines.push(`Layers: ${stack.layer_dirs.join(" -> ")}`);
+    lines.push(`Merge: ${stack.provenance.merge}`);
     lines.push("");
-    lines.push("```yaml");
-    lines.push(
-      stringifyYaml(
-        {
-          fingerprint: stack.merged.fingerprint,
-          checks: stack.merged.checks,
-          provenance: stack.provenance,
-        },
-        { lineWidth: 0 },
-      ).trim(),
-    );
-    lines.push("```", "");
     if (stack.merged.intent?.trim()) {
       lines.push("```markdown", stack.merged.intent.trim(), "```", "");
     }
   }
 
   return `${lines.join("\n")}\n`;
+}
+
+function formatReviewContextMarkdown(
+  sections: Array<{ title: string; markdown: string }>,
+): string {
+  const lines = ["## Selected Fingerprint Context", ""];
+  for (const [index, section] of sections.entries()) {
+    if (sections.length > 1) {
+      lines.push(`### Context ${index + 1}: ${section.title}`, "");
+    }
+    lines.push(
+      section.markdown.replace(/^### Selected Fingerprint Context\n\n?/, ""),
+    );
+  }
+  return lines.join("\n").trim();
 }
 
 async function readOptional(path: string): Promise<string | undefined> {

--- a/packages/ghost/src/scan-emit-command.ts
+++ b/packages/ghost/src/scan-emit-command.ts
@@ -41,7 +41,7 @@ export function registerEmitCommand(cli: CAC): void {
   cli
     .command(
       "emit <kind>",
-      `Emit a derived artifact from the fingerprint package (review command or context-bundle generation packet)`,
+      `Emit a derived artifact from the fingerprint package (review command or compact context entrypoint)`,
     )
     .option(
       "--path <path>",
@@ -67,7 +67,7 @@ export function registerEmitCommand(cli: CAC): void {
     .option("--readme", "Include README.md (context-bundle)")
     .option(
       "--prompt-only",
-      "Emit only prompt.md (context-bundle generation packet)",
+      "Emit only prompt.md (context-bundle compact entrypoint)",
     )
     .option(
       "--name <name>",

--- a/packages/ghost/src/scan/context/entrypoint-markdown.ts
+++ b/packages/ghost/src/scan/context/entrypoint-markdown.ts
@@ -1,0 +1,196 @@
+import type { ContextEntrypoint, FingerprintGraphNode } from "./entrypoint.js";
+import type { PackageInventory } from "./package-context.js";
+
+export function formatContextEntrypointMarkdown(
+  entrypoint: ContextEntrypoint,
+  options: { heading?: string; includeIntro?: boolean } = {},
+): string {
+  const heading = options.heading ?? "# Agent Handoff";
+  const parts = [heading];
+  if (options.includeIntro ?? true) {
+    parts.push(
+      `You are working inside the **${entrypoint.name}** product-surface composition as captured by Ghost. This is a compact entrypoint into the fingerprint, not a replacement for the full files beside it.`,
+    );
+  }
+  parts.push(formatIdentity(entrypoint));
+  parts.push(formatMatch(entrypoint));
+  parts.push(formatReadFirst(entrypoint));
+  parts.push(formatValidation(entrypoint));
+  parts.push(formatGeneratedCache(entrypoint.generatedCache));
+  parts.push(formatSuggestedReads(entrypoint));
+  parts.push(formatOmissions(entrypoint));
+  parts.push(formatUseThisContext());
+  return `${parts.filter(Boolean).join("\n\n").trim()}\n`;
+}
+
+function formatIdentity(entrypoint: ContextEntrypoint): string {
+  const lines = ["## Identity Capsule"];
+  lines.push(`- Product: ${entrypoint.identity.product}`);
+  pushJoined(lines, "Audience", entrypoint.identity.audience);
+  pushJoined(lines, "Goals", entrypoint.identity.goals);
+  pushJoined(lines, "Anti-goals", entrypoint.identity.antiGoals);
+  pushJoined(lines, "Tradeoffs", entrypoint.identity.tradeoffs);
+  pushJoined(lines, "Tone", entrypoint.identity.tone);
+  return lines.join("\n");
+}
+
+function formatMatch(entrypoint: ContextEntrypoint): string {
+  const lines = ["## Context Match"];
+  lines.push(
+    `- Status: ${
+      entrypoint.match.status === "path-match"
+        ? "path matched"
+        : "global fallback"
+    }`,
+  );
+  pushJoined(lines, "Requested paths", entrypoint.match.requestedPaths, {
+    code: true,
+  });
+  pushJoined(lines, "Matched scopes", entrypoint.match.matchedScopes, {
+    code: true,
+  });
+  pushJoined(
+    lines,
+    "Matched surface types",
+    entrypoint.match.matchedSurfaceTypes,
+    { code: true },
+  );
+  pushJoined(lines, "Fingerprint layers", entrypoint.match.sourceLayers, {
+    code: true,
+  });
+  for (const reason of entrypoint.match.reasons) {
+    lines.push(`- Why: ${reason}`);
+  }
+  return lines.join("\n");
+}
+
+function formatReadFirst(entrypoint: ContextEntrypoint): string {
+  const lines = ["## Read First"];
+  appendNodeGroup(lines, "Prose Anchors", entrypoint.selected.prose);
+  appendNodeGroup(
+    lines,
+    "Composition Anchors",
+    entrypoint.selected.composition,
+  );
+  appendNodeGroup(lines, "Exemplars", entrypoint.selected.exemplars);
+  return lines.join("\n");
+}
+
+function formatValidation(entrypoint: ContextEntrypoint): string {
+  const lines = ["## Validation Notes"];
+  if (entrypoint.selected.checks.length === 0) {
+    lines.push(
+      "- No selected active checks. Proposed or disabled checks are not blocking validation.",
+    );
+    return lines.join("\n");
+  }
+  for (const node of entrypoint.selected.checks) {
+    lines.push(`- \`${node.ref}\` - ${node.summary}`);
+    for (const detail of node.details.slice(0, 2)) {
+      lines.push(`  - ${detail}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatGeneratedCache(inventory: PackageInventory): string {
+  const lines = ["## Generated Cache"];
+  lines.push(
+    "- Generated cache is optional source material, not canonical fingerprint context.",
+  );
+  if (inventory.state === "missing") {
+    lines.push("- State: missing.");
+    return lines.join("\n");
+  }
+  if (inventory.state === "unreadable") {
+    lines.push(
+      `- State: present at \`${inventory.path}\`, but it could not be read: ${inventory.error}.`,
+    );
+    return lines.join("\n");
+  }
+  lines.push(`- State: present at \`${inventory.path}\`.`);
+  pushJoined(lines, "Platform hints", inventory.summary.platform_hints, {
+    code: true,
+  });
+  pushJoined(lines, "Build hints", inventory.summary.build_system_hints, {
+    code: true,
+  });
+  pushJoined(lines, "Package manifests", inventory.summary.package_manifests, {
+    code: true,
+  });
+  pushJoined(
+    lines,
+    "Config candidates",
+    inventory.summary.candidate_config_files,
+    {
+      code: true,
+    },
+  );
+  return lines.join("\n");
+}
+
+function formatSuggestedReads(entrypoint: ContextEntrypoint): string {
+  const lines = ["## Suggested Reads"];
+  for (const read of entrypoint.suggestedReads) {
+    lines.push(`- \`${read.path}\` - ${read.reason}`);
+  }
+  return lines.join("\n");
+}
+
+function formatOmissions(entrypoint: ContextEntrypoint): string {
+  const lines = ["## Omissions"];
+  for (const omission of entrypoint.omissions) {
+    if (omission.omitted === 0) {
+      lines.push(`- ${omission.label}: none omitted.`);
+    } else {
+      lines.push(
+        `- ${omission.label}: ${omission.omitted} omitted; inspect \`${omission.source}\` if the task widens.`,
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatUseThisContext(): string {
+  return `## Use This Context
+- Start with the selected refs above, then read suggested files when the task is broader than this entrypoint.
+- Generate from prose + inventory + composition; use building blocks only when they support selected intent and patterns.
+- Treat checks as validation; only active checks are blocking.
+- When selected context is sparse or globally matched, label reasoning as provisional and non-Ghost-backed.
+- Treat fingerprint edits as ordinary Git-reviewed edits to \`fingerprint/\` files and optional local \`config.yml\` when present.`;
+}
+
+function appendNodeGroup(
+  lines: string[],
+  title: string,
+  nodes: FingerprintGraphNode[],
+): void {
+  lines.push(`### ${title}`);
+  if (nodes.length === 0) {
+    lines.push("- None selected.");
+    return;
+  }
+  for (const node of nodes) {
+    const path =
+      node.kind === "exemplar" && node.appliesTo.paths[0]
+        ? ` - \`${node.appliesTo.paths[0]}\``
+        : "";
+    lines.push(`- \`${node.ref}\`${path} - ${node.summary}`);
+    for (const detail of node.details.slice(0, 2)) {
+      lines.push(`  - ${detail}`);
+    }
+  }
+}
+
+function pushJoined(
+  lines: string[],
+  label: string,
+  values: string[] | undefined,
+  options: { code?: boolean } = {},
+): void {
+  if (!values?.length) return;
+  const formatted = values
+    .map((value) => (options.code ? `\`${value}\`` : value))
+    .join(", ");
+  lines.push(`- ${label}: ${formatted}`);
+}

--- a/packages/ghost/src/scan/context/entrypoint.ts
+++ b/packages/ghost/src/scan/context/entrypoint.ts
@@ -1,0 +1,271 @@
+import type { GhostFingerprintDocument } from "#ghost-core";
+import {
+  buildFingerprintGraph,
+  type FingerprintGraph,
+  type FingerprintGraphNode,
+  intersects,
+  matchScopes,
+  type NodeRef,
+  nodeMatchesTargets,
+  normalizeTargetPaths,
+  sortNodes,
+  unique,
+} from "./graph.js";
+import type { PackageContext, PackageInventory } from "./package-context.js";
+
+export type {
+  FingerprintGraph,
+  FingerprintGraphEdge,
+  FingerprintGraphNode,
+  FingerprintGraphScope,
+} from "./graph.js";
+export { buildFingerprintGraph } from "./graph.js";
+
+export interface ContextEntrypoint {
+  name: string;
+  match: {
+    status: "path-match" | "global-fallback";
+    requestedPaths: string[];
+    matchedScopes: string[];
+    matchedSurfaceTypes: string[];
+    sourceLayers: string[];
+    reasons: string[];
+  };
+  identity: {
+    product: string;
+    audience: string[];
+    goals: string[];
+    antiGoals: string[];
+    tradeoffs: string[];
+    tone: string[];
+  };
+  selected: {
+    prose: FingerprintGraphNode[];
+    composition: FingerprintGraphNode[];
+    exemplars: FingerprintGraphNode[];
+    checks: FingerprintGraphNode[];
+  };
+  suggestedReads: Array<{ path: string; reason: string }>;
+  omissions: Array<{ label: string; omitted: number; source: string }>;
+  generatedCache: PackageInventory;
+}
+
+export interface BuildContextEntrypointOptions {
+  targetPaths?: string[];
+}
+
+const CAPS = {
+  prose: 6,
+  composition: 6,
+  exemplars: 3,
+  checks: 6,
+} as const;
+
+export function buildContextEntrypoint(
+  context: PackageContext,
+  options: BuildContextEntrypointOptions = {},
+): ContextEntrypoint {
+  const graph = buildFingerprintGraph(context);
+  const requestedPaths = normalizeTargetPaths(
+    options.targetPaths ?? context.targetPaths ?? [],
+  );
+  const matchedScopes = matchScopes(graph.scopes, requestedPaths);
+  const matchedScopeIds = matchedScopes.map((scope) => scope.id);
+  const matchedSurfaceTypes = unique(
+    matchedScopes.flatMap((scope) => scope.surfaceTypes),
+  );
+  const directRefs = new Set<NodeRef>();
+
+  for (const node of graph.nodes) {
+    if (
+      nodeMatchesTargets(node, requestedPaths) ||
+      intersects(node.appliesTo.scopes, matchedScopeIds) ||
+      intersects(node.appliesTo.surfaceTypes, matchedSurfaceTypes)
+    ) {
+      directRefs.add(node.ref);
+    }
+  }
+
+  const selectedRefs =
+    directRefs.size > 0
+      ? expandOneHop(directRefs, graph)
+      : new Set<NodeRef>(graph.nodes.map((node) => node.ref));
+  const status = directRefs.size > 0 ? "path-match" : "global-fallback";
+  const selected = selectNodes(graph, selectedRefs);
+
+  return {
+    name: context.name,
+    match: {
+      status,
+      requestedPaths,
+      matchedScopes: matchedScopeIds,
+      matchedSurfaceTypes,
+      sourceLayers: context.layerDirs ?? [],
+      reasons: matchReasons(status, requestedPaths, matchedScopeIds),
+    },
+    identity: identityFromFingerprint(context.fingerprint, context.name),
+    selected,
+    suggestedReads: buildSuggestedReads(context, selected),
+    omissions: buildOmissions(graph, selected),
+    generatedCache: context.inventory,
+  };
+}
+
+function matchReasons(
+  status: ContextEntrypoint["match"]["status"],
+  requestedPaths: string[],
+  matchedScopeIds: string[],
+): string[] {
+  if (status === "path-match") {
+    return [
+      requestedPaths.length
+        ? `Matched requested path(s): ${requestedPaths.join(", ")}.`
+        : "Matched resolved fingerprint context.",
+      matchedScopeIds.length
+        ? `Matched scope(s): ${matchedScopeIds.join(", ")}.`
+        : "Selected directly applicable fingerprint refs.",
+      "Expanded selection by one explicit ref hop.",
+    ];
+  }
+  return [
+    requestedPaths.length
+      ? `No fingerprint scope matched: ${requestedPaths.join(", ")}.`
+      : "No target path was supplied.",
+    "Using compact global entrypoint; inspect full fingerprint files when the task is broad.",
+  ];
+}
+
+function identityFromFingerprint(
+  fingerprint: GhostFingerprintDocument,
+  name: string,
+): ContextEntrypoint["identity"] {
+  const summary = fingerprint.prose.summary;
+  return {
+    product: summary.product ?? name,
+    audience: summary.audience ?? [],
+    goals: summary.goals ?? [],
+    antiGoals: summary.anti_goals ?? [],
+    tradeoffs: summary.tradeoffs ?? [],
+    tone: summary.tone ?? [],
+  };
+}
+
+function selectNodes(
+  graph: FingerprintGraph,
+  selectedRefs: Set<NodeRef>,
+): ContextEntrypoint["selected"] {
+  const selectedNodes = sortNodes(
+    graph.nodes.filter((node) => selectedRefs.has(node.ref)),
+  );
+  return {
+    prose: selectedNodes
+      .filter((node) =>
+        ["situation", "principle", "experience_contract"].includes(node.kind),
+      )
+      .slice(0, CAPS.prose),
+    composition: selectedNodes
+      .filter((node) => node.kind === "pattern")
+      .slice(0, CAPS.composition),
+    exemplars: selectedNodes
+      .filter((node) => node.kind === "exemplar")
+      .slice(0, CAPS.exemplars),
+    checks: selectedNodes
+      .filter((node) => node.kind === "check")
+      .slice(0, CAPS.checks),
+  };
+}
+
+function expandOneHop(
+  refs: Set<NodeRef>,
+  graph: FingerprintGraph,
+): Set<NodeRef> {
+  const expanded = new Set(refs);
+  for (const edge of graph.edges) {
+    if (refs.has(edge.from)) expanded.add(edge.to);
+    if (refs.has(edge.to)) expanded.add(edge.from);
+  }
+  return expanded;
+}
+
+function buildSuggestedReads(
+  context: PackageContext,
+  selected: ContextEntrypoint["selected"],
+): ContextEntrypoint["suggestedReads"] {
+  const reads = new Map<string, string>();
+  if (selected.prose.length > 0) {
+    reads.set(
+      "fingerprint/prose.yml",
+      "selected prose anchors and full intent",
+    );
+  }
+  if (selected.composition.length > 0) {
+    reads.set(
+      "fingerprint/composition.yml",
+      "selected composition patterns and neighboring patterns",
+    );
+  }
+  if (selected.exemplars.length > 0) {
+    reads.set(
+      "fingerprint/inventory.yml",
+      "selected exemplars, topology, and building blocks",
+    );
+  }
+  if (selected.checks.length > 0) {
+    reads.set(
+      "fingerprint/enforcement/checks.yml",
+      "active deterministic validation rules",
+    );
+  }
+  for (const exemplar of selected.exemplars) {
+    const path = exemplar.appliesTo.paths[0];
+    if (path) reads.set(path, `source surface for ${exemplar.ref}`);
+  }
+  if (context.intent?.trim()) {
+    reads.set(
+      "fingerprint/memory/intent.md",
+      "supplemental human-authored intent",
+    );
+  }
+  if (reads.size === 0) {
+    reads.set("fingerprint/prose.yml", "global fingerprint intent");
+    reads.set("fingerprint/inventory.yml", "topology and exemplars");
+    reads.set("fingerprint/composition.yml", "composition patterns");
+  }
+  return [...reads.entries()].map(([path, reason]) => ({ path, reason }));
+}
+
+function buildOmissions(
+  graph: FingerprintGraph,
+  selected: ContextEntrypoint["selected"],
+): ContextEntrypoint["omissions"] {
+  const totals = {
+    prose: graph.nodes.filter((node) =>
+      ["situation", "principle", "experience_contract"].includes(node.kind),
+    ).length,
+    composition: graph.nodes.filter((node) => node.kind === "pattern").length,
+    exemplars: graph.nodes.filter((node) => node.kind === "exemplar").length,
+    checks: graph.nodes.filter((node) => node.kind === "check").length,
+  };
+  return [
+    {
+      label: "Prose anchors",
+      omitted: Math.max(0, totals.prose - selected.prose.length),
+      source: "fingerprint/prose.yml",
+    },
+    {
+      label: "Composition patterns",
+      omitted: Math.max(0, totals.composition - selected.composition.length),
+      source: "fingerprint/composition.yml",
+    },
+    {
+      label: "Exemplars",
+      omitted: Math.max(0, totals.exemplars - selected.exemplars.length),
+      source: "fingerprint/inventory.yml",
+    },
+    {
+      label: "Active checks",
+      omitted: Math.max(0, totals.checks - selected.checks.length),
+      source: "fingerprint/enforcement/checks.yml",
+    },
+  ];
+}

--- a/packages/ghost/src/scan/context/graph.ts
+++ b/packages/ghost/src/scan/context/graph.ts
@@ -1,0 +1,379 @@
+import type {
+  GhostCheck,
+  GhostFingerprintDocument,
+  GhostFingerprintRef,
+} from "#ghost-core";
+import type { PackageContext } from "./package-context.js";
+
+export type NodeKind =
+  | "situation"
+  | "principle"
+  | "experience_contract"
+  | "pattern"
+  | "exemplar"
+  | "check";
+
+export type NodeRef = GhostFingerprintRef;
+
+export interface Applicability {
+  paths: string[];
+  scopes: string[];
+  surfaceTypes: string[];
+}
+
+export interface FingerprintGraphNode {
+  ref: NodeRef;
+  id: string;
+  kind: NodeKind;
+  label: string;
+  summary: string;
+  details: string[];
+  sourceFile: string;
+  order: number;
+  appliesTo: Applicability;
+}
+
+export interface FingerprintGraphEdge {
+  from: NodeRef;
+  to: NodeRef;
+  reason: string;
+}
+
+export interface FingerprintGraphScope {
+  id: string;
+  paths: string[];
+  surfaceTypes: string[];
+}
+
+export interface FingerprintGraph {
+  nodes: FingerprintGraphNode[];
+  edges: FingerprintGraphEdge[];
+  scopes: FingerprintGraphScope[];
+  nodeByRef: Map<NodeRef, FingerprintGraphNode>;
+}
+
+const KIND_ORDER: Record<NodeKind, number> = {
+  situation: 0,
+  principle: 1,
+  experience_contract: 2,
+  pattern: 3,
+  exemplar: 4,
+  check: 5,
+};
+
+export function buildFingerprintGraph(
+  context: PackageContext,
+): FingerprintGraph {
+  const nodes: FingerprintGraphNode[] = [];
+  const pendingEdges: FingerprintGraphEdge[] = [];
+  let order = 0;
+
+  const addNode = (
+    node: Omit<FingerprintGraphNode, "order" | "appliesTo"> & {
+      appliesTo?: Partial<Applicability>;
+    },
+  ) => {
+    nodes.push({
+      ...node,
+      order: order++,
+      appliesTo: normalizeApplicability(node.appliesTo),
+    });
+  };
+
+  const fingerprint = context.fingerprint;
+  for (const situation of fingerprint.prose.situations) {
+    const ref = refFor("prose.situation", situation.id);
+    addNode({
+      ref,
+      id: situation.id,
+      kind: "situation",
+      label: situation.title ?? situation.id,
+      summary:
+        situation.product_obligation ??
+        situation.user_intent ??
+        situation.surface_type ??
+        "Recorded situation.",
+      details: [
+        situation.user_intent ? `User intent: ${situation.user_intent}` : "",
+        situation.product_obligation
+          ? `Product obligation: ${situation.product_obligation}`
+          : "",
+        ...(situation.refuses ?? []).map((entry) => `Refuses: ${entry}`),
+      ].filter(Boolean),
+      sourceFile: "fingerprint/prose.yml",
+      appliesTo: {
+        surfaceTypes: situation.surface_type ? [situation.surface_type] : [],
+        paths: evidencePaths(situation.evidence),
+      },
+    });
+    addRefEdges(ref, situation.principles, "situation principle");
+    addRefEdges(
+      ref,
+      situation.experience_contracts,
+      "situation experience contract",
+    );
+    addRefEdges(ref, situation.patterns, "situation composition pattern");
+  }
+
+  for (const principle of fingerprint.prose.principles) {
+    const ref = refFor("prose.principle", principle.id);
+    addNode({
+      ref,
+      id: principle.id,
+      kind: "principle",
+      label: principle.id,
+      summary: principle.principle,
+      details: [
+        ...(principle.guidance ?? []),
+        ...(principle.counterexamples ?? []).map(
+          (entry) => `Counterexample: ${entry}`,
+        ),
+      ],
+      sourceFile: "fingerprint/prose.yml",
+      appliesTo: applicabilityFromScope(principle.applies_to),
+    });
+    addRefEdges(ref, principle.check_refs, "principle check");
+  }
+
+  for (const contract of fingerprint.prose.experience_contracts) {
+    const ref = refFor("prose.experience_contract", contract.id);
+    addNode({
+      ref,
+      id: contract.id,
+      kind: "experience_contract",
+      label: contract.id,
+      summary: contract.contract,
+      details: contract.obligations ?? [],
+      sourceFile: "fingerprint/prose.yml",
+      appliesTo: applicabilityFromScope(contract.applies_to),
+    });
+    addRefEdges(ref, contract.check_refs, "experience contract check");
+  }
+
+  for (const pattern of fingerprint.composition.patterns) {
+    const ref = refFor("composition.pattern", pattern.id);
+    addNode({
+      ref,
+      id: pattern.id,
+      kind: "pattern",
+      label: `${pattern.id} (${pattern.kind})`,
+      summary: pattern.pattern,
+      details: [
+        ...(pattern.guidance ?? []),
+        ...(pattern.anti_patterns?.length
+          ? [`Avoid: ${pattern.anti_patterns.join("; ")}`]
+          : []),
+      ],
+      sourceFile: "fingerprint/composition.yml",
+      appliesTo: applicabilityFromScope(pattern.applies_to),
+    });
+    addRefEdges(ref, pattern.check_refs, "composition check");
+  }
+
+  for (const exemplar of fingerprint.inventory.exemplars) {
+    const ref = refFor("inventory.exemplar", exemplar.id);
+    addNode({
+      ref,
+      id: exemplar.id,
+      kind: "exemplar",
+      label: exemplar.title ?? exemplar.id,
+      summary: exemplar.why ?? exemplar.note ?? exemplar.path,
+      details: [
+        `Path: ${exemplar.path}`,
+        exemplar.surface_type ? `Surface type: ${exemplar.surface_type}` : "",
+        exemplar.scope ? `Scope: ${exemplar.scope}` : "",
+      ].filter(Boolean),
+      sourceFile: "fingerprint/inventory.yml",
+      appliesTo: {
+        paths: [exemplar.path],
+        scopes: exemplar.scope ? [exemplar.scope] : [],
+        surfaceTypes: exemplar.surface_type ? [exemplar.surface_type] : [],
+      },
+    });
+    addRefEdges(ref, exemplar.refs, "exemplar ref");
+  }
+
+  for (const check of activeChecks(context)) {
+    const ref = refFor("check", check.id);
+    addNode({
+      ref,
+      id: check.id,
+      kind: "check",
+      label: check.title,
+      summary: `${check.severity}: ${check.title}`,
+      details: [
+        check.repair ? `Repair: ${check.repair}` : "",
+        detectorSummary(check),
+      ].filter(Boolean),
+      sourceFile: "fingerprint/enforcement/checks.yml",
+      appliesTo: applicabilityFromCheck(check),
+    });
+    addRefEdges(ref, check.derivation?.prose, "check prose derivation");
+    addRefEdges(ref, check.derivation?.inventory, "check inventory derivation");
+    addRefEdges(
+      ref,
+      check.derivation?.composition,
+      "check composition derivation",
+    );
+  }
+
+  const nodeByRef = new Map(nodes.map((node) => [node.ref, node]));
+  const edges = pendingEdges.filter(
+    (edge) => nodeByRef.has(edge.from) && nodeByRef.has(edge.to),
+  );
+
+  return {
+    nodes,
+    edges,
+    scopes: buildScopes(fingerprint),
+    nodeByRef,
+  };
+
+  function addRefEdges(
+    from: NodeRef,
+    refs: readonly GhostFingerprintRef[] | undefined,
+    reason: string,
+  ) {
+    for (const to of refs ?? []) {
+      pendingEdges.push({ from, to, reason });
+    }
+  }
+}
+
+export function matchScopes(
+  scopes: FingerprintGraphScope[],
+  targetPaths: string[],
+): FingerprintGraphScope[] {
+  if (targetPaths.length === 0) return [];
+  return scopes.filter((scope) =>
+    scope.paths.some((scopePath) =>
+      targetPaths.some((targetPath) => pathsOverlap(scopePath, targetPath)),
+    ),
+  );
+}
+
+export function nodeMatchesTargets(
+  node: FingerprintGraphNode,
+  targetPaths: string[],
+): boolean {
+  return (
+    targetPaths.length > 0 &&
+    node.appliesTo.paths.some((nodePath) =>
+      targetPaths.some((targetPath) => pathsOverlap(nodePath, targetPath)),
+    )
+  );
+}
+
+export function normalizeTargetPaths(paths: string[]): string[] {
+  return unique(
+    paths
+      .map(normalizePath)
+      .filter((path) => path && path !== "." && path !== "/"),
+  );
+}
+
+export function sortNodes(
+  nodes: FingerprintGraphNode[],
+): FingerprintGraphNode[] {
+  return [...nodes].sort(
+    (a, b) =>
+      KIND_ORDER[a.kind] - KIND_ORDER[b.kind] ||
+      a.order - b.order ||
+      a.ref.localeCompare(b.ref),
+  );
+}
+
+export function intersects(a: string[], b: string[]): boolean {
+  if (a.length === 0 || b.length === 0) return false;
+  const values = new Set(a);
+  return b.some((value) => values.has(value));
+}
+
+export function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function pathsOverlap(a: string, b: string): boolean {
+  const left = normalizePath(a);
+  const right = normalizePath(b);
+  if (!left || !right) return false;
+  if (left === right) return true;
+  if (left.endsWith("*")) return right.startsWith(left.slice(0, -1));
+  if (right.endsWith("*")) return left.startsWith(right.slice(0, -1));
+  return left.startsWith(`${right}/`) || right.startsWith(`${left}/`);
+}
+
+function buildScopes(
+  fingerprint: GhostFingerprintDocument,
+): FingerprintGraphScope[] {
+  return (fingerprint.inventory.topology.scopes ?? []).map((scope) => ({
+    id: scope.id,
+    paths: scope.paths.map(normalizePath),
+    surfaceTypes: scope.surface_types ?? [],
+  }));
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/g, "");
+}
+
+function normalizeApplicability(
+  value: Partial<Applicability> | undefined,
+): Applicability {
+  return {
+    paths: unique((value?.paths ?? []).map(normalizePath).filter(Boolean)),
+    scopes: unique(value?.scopes ?? []),
+    surfaceTypes: unique(value?.surfaceTypes ?? []),
+  };
+}
+
+function applicabilityFromScope(
+  scope:
+    | {
+        paths?: string[];
+        scopes?: string[];
+        surface_types?: string[];
+      }
+    | undefined,
+): Partial<Applicability> {
+  return {
+    paths: scope?.paths ?? [],
+    scopes: scope?.scopes ?? [],
+    surfaceTypes: scope?.surface_types ?? [],
+  };
+}
+
+function applicabilityFromCheck(check: GhostCheck): Partial<Applicability> {
+  return {
+    paths: check.applies_to?.paths ?? [],
+    scopes: check.applies_to?.scopes ?? [],
+    surfaceTypes: check.applies_to?.surface_types ?? [],
+  };
+}
+
+function evidencePaths(
+  evidence: Array<{ path?: string }> | undefined,
+): string[] {
+  return (evidence ?? [])
+    .map((entry) => entry.path)
+    .filter((path): path is string => Boolean(path));
+}
+
+function activeChecks(context: PackageContext): GhostCheck[] {
+  return (
+    context.checks?.checks.filter((check) => check.status === "active") ?? []
+  );
+}
+
+function detectorSummary(check: GhostCheck): string {
+  const detector = check.detector;
+  return detector.pattern
+    ? `${detector.type}: ${detector.pattern}`
+    : detector.value
+      ? `${detector.type}: ${detector.value}`
+      : detector.type;
+}
+
+function refFor(prefix: string, id: string): NodeRef {
+  return `${prefix}:${id}` as NodeRef;
+}

--- a/packages/ghost/src/scan/context/package-context.ts
+++ b/packages/ghost/src/scan/context/package-context.ts
@@ -35,6 +35,8 @@ export type PackageInventory =
 export interface PackageContext {
   name: string;
   fingerprintDir?: string;
+  targetPaths?: string[];
+  layerDirs?: string[];
   fingerprint: GhostFingerprintDocument;
   fingerprintRaw: string;
   fingerprintLayers?: {

--- a/packages/ghost/src/scan/context/package-writer.ts
+++ b/packages/ghost/src/scan/context/package-writer.ts
@@ -3,6 +3,8 @@ import { dirname, join } from "node:path";
 import { stringify as stringifyYaml } from "yaml";
 import { GHOST_FINGERPRINT_PACKAGE_SCHEMA } from "#ghost-core";
 import type { FingerprintPackagePaths } from "../fingerprint-package.js";
+import { buildContextEntrypoint } from "./entrypoint.js";
+import { formatContextEntrypointMarkdown } from "./entrypoint-markdown.js";
 import { loadPackageContext, type PackageContext } from "./package-context.js";
 import type { WriteContextResult } from "./writer.js";
 
@@ -126,7 +128,7 @@ validate the resulting diff with Ghost checks or review when available.
 
 Read the files in this order:
 
-1. \`prompt.md\` - generation packet: prose, inventory, composition, and active checks.
+1. \`prompt.md\` - compact entrypoint: selected refs, suggested reads, omissions, and validation notes.
 2. \`fingerprint/prose.yml\`, \`fingerprint/inventory.yml\`, and \`fingerprint/composition.yml\` - canonical core layers.
 3. \`fingerprint/enforcement/checks.yml\` when present - deterministic gates; only \`active\` checks block.
 4. \`fingerprint/memory/intent.md\` when present - supplemental human-authored context.
@@ -148,84 +150,7 @@ are ordinary Git-reviewed edits to \`fingerprint/\` files and optional local
 }
 
 function buildPackagePromptMd(context: PackageContext): string {
-  const parts = [
-    `You are working inside the **${context.name}** product-surface composition as captured by Ghost.`,
-  ];
-
-  parts.push(`# Agent Handoff
-
-This packet is upstream input for agentic UI work, not post-hoc commentary. Use it before writing or revising product surfaces so the output extends the same surface composition instead of merely passing local checks.
-
-After generating, validate the diff with Ghost checks or review when available, and keep Ghost package edits as ordinary Git-reviewed edits to the source \`.ghost\` package.`);
-
-  parts.push(`# Prose
-
-Surface intent lives in \`fingerprint/prose.yml\`. Use situations, principles, and experience contracts as the source of intent for the work.
-
-\`\`\`yaml
-${stringifyYaml(context.fingerprint.prose, { lineWidth: 0 }).trim()}
-\`\`\``);
-
-  parts.push(`# Inventory
-
-${formatTopology(context)}
-
-${formatBuildingBlocks(context)}
-
-${formatExemplars(context)}
-
-${formatGeneratedCache(context)}`);
-
-  parts.push(`# Composition
-
-${formatComposition(context)}`);
-
-  if (context.checks) {
-    const activeChecks = context.checks.checks.filter(
-      (check) => check.status === "active",
-    );
-    if (activeChecks.length > 0) {
-      parts.push(`# Active Checks
-
-\`\`\`yaml
-${stringifyYaml(
-  {
-    ...context.checks,
-    checks: activeChecks,
-  },
-  { lineWidth: 0 },
-).trim()}
-\`\`\``);
-    } else {
-      parts.push(`# Active Checks
-
-No active checks are recorded. Proposed or disabled checks are not blocking validation.`);
-    }
-  }
-
-  if (context.intent?.trim()) {
-    parts.push(`# Human Context
-
-\`\`\`markdown
-${context.intent.trim()}
-\`\`\``);
-  }
-
-  parts.push(`# Use This Context
-
-- Treat this packet as the upstream handoff before generating or revising UI.
-- Generate from prose + inventory + composition.
-- Select the relevant situation before generating or reviewing UI.
-- Preserve applicable principles, experience contracts, and composition patterns.
-- Inspect inventory exemplars as concrete anchors for what good looks like.
-- Use inventory building blocks only when they support the selected prose and composition.
-- Treat checks as validation; only active checks are blocking.
-- After generating, run or request Ghost review/check when available so output is validated against the same fingerprint layers.
-- When fingerprint layers are silent, proceed from nearby product surfaces, local components, token and copy conventions, optional rationale files when present, and ordinary UX reasoning when safe.
-- Label silent-layer reasoning as provisional and non-Ghost-backed; ask the human before high-risk, irreversible, privacy/security/legal, or product-surface-defining choices.
-- Treat fingerprint edits as ordinary Git-reviewed edits to \`fingerprint/\` files and optional local \`config.yml\` when present.`);
-
-  return `${parts.join("\n\n")}\n`;
+  return formatContextEntrypointMarkdown(buildContextEntrypoint(context));
 }
 
 function buildPackageReadmeMd(context: PackageContext): string {
@@ -241,7 +166,7 @@ Ghost checks or review when available.
 ## Files
 
 - \`SKILL.md\` - agent skill manifest.
-- \`prompt.md\` - portable generation packet: prose, inventory, composition, and checks.
+- \`prompt.md\` - compact entrypoint with selected refs, suggested reads, omissions, and validation notes.
 - \`fingerprint/manifest.yml\` - portable fingerprint package anchor.
 - \`fingerprint/prose.yml\` - surface intent.
 - \`fingerprint/inventory.yml\` - canonical curated material and source links.
@@ -250,180 +175,6 @@ ${context.checksRaw ? "- `fingerprint/enforcement/checks.yml` - deterministic ga
 Regenerate this bundle when \`fingerprint/\` core layers, active checks, or
 optional rationale files change.
 `;
-}
-
-function formatTopology(context: PackageContext): string {
-  const { topology } = context.fingerprint.inventory;
-  const lines = ["## Topology"];
-  pushJoined(lines, "Surface types", topology.surface_types, { code: true });
-  if (topology.scopes?.length) {
-    for (const scope of topology.scopes.slice(0, 16)) {
-      const details = [
-        scope.paths.length
-          ? `paths: ${scope.paths.map((path) => `\`${path}\``).join(", ")}`
-          : undefined,
-        scope.surface_types?.length
-          ? `surface types: ${scope.surface_types.map((surfaceType) => `\`${surfaceType}\``).join(", ")}`
-          : undefined,
-      ].filter(Boolean);
-      lines.push(
-        `- \`${scope.id}\`${details.length ? ` - ${details.join("; ")}` : ""}`,
-      );
-    }
-    if (topology.scopes.length > 16) {
-      lines.push(
-        `- ${topology.scopes.length - 16} more scope(s); read \`fingerprint/inventory.yml\` before generating.`,
-      );
-    }
-  }
-  if (lines.length === 1) {
-    lines.push("- No inventory topology recorded yet.");
-  }
-  return lines.join("\n");
-}
-
-function formatGeneratedCache(context: PackageContext): string {
-  const { inventory } = context;
-  if (inventory.state === "missing") {
-    return `## Generated Cache
-
-No generated cache is present. Generated cache is optional source material; create it when useful with \`mkdir -p .ghost/fingerprint/sources/cache && ghost inventory > .ghost/fingerprint/sources/cache/inventory.json\`.`;
-  }
-  if (inventory.state === "unreadable") {
-    return `## Generated Cache
-
-Generated cache exists at \`${inventory.path}\`, but it could not be read: ${inventory.error}. Treat generated cache as unavailable until it is regenerated.`;
-  }
-
-  const { summary } = inventory;
-  const lines = [
-    "## Generated Cache",
-    `- Cache path: \`${inventory.path}\``,
-    "- Generated cache is optional source material, not canonical inventory.",
-  ];
-  pushJoined(lines, "Platform hints", summary.platform_hints, { code: true });
-  pushJoined(lines, "Build hints", summary.build_system_hints, { code: true });
-  if (summary.language_histogram.length) {
-    lines.push(
-      `- Languages: ${summary.language_histogram
-        .map((entry) => `${entry.name} (${entry.files})`)
-        .join(", ")}`,
-    );
-  }
-  pushJoined(lines, "Package manifests", summary.package_manifests, {
-    code: true,
-  });
-  pushJoined(lines, "Config candidates", summary.candidate_config_files, {
-    code: true,
-  });
-  pushJoined(lines, "Registry files", summary.registry_files, { code: true });
-  if (summary.top_level_tree.length) {
-    lines.push(
-      `- Top-level tree: ${summary.top_level_tree
-        .map((entry) => `\`${entry.path}\``)
-        .join(", ")}`,
-    );
-  }
-  if (summary.config?.targets?.length) {
-    lines.push(
-      `- Config targets: ${summary.config.targets
-        .map((target) => `\`${target.id}\``)
-        .join(", ")}`,
-    );
-  }
-  if (summary.config?.libraries?.length) {
-    lines.push(
-      `- Reference libraries: ${summary.config.libraries
-        .map((library) => `\`${library.id}\``)
-        .join(", ")}`,
-    );
-  }
-  return lines.join("\n");
-}
-
-function formatBuildingBlocks(context: PackageContext): string {
-  const { building_blocks: blocks } = context.fingerprint.inventory;
-  const lines = [
-    "## Building Blocks",
-    "- Use these as available material, not surface-composition authority.",
-  ];
-  pushJoined(lines, "Tokens", blocks.tokens, { code: true });
-  pushJoined(lines, "Components", blocks.components, { code: true });
-  pushJoined(lines, "Libraries", blocks.libraries, { code: true });
-  pushJoined(lines, "Assets", blocks.assets, { code: true });
-  pushJoined(lines, "Routes", blocks.routes, { code: true });
-  pushJoined(lines, "Files", blocks.files, { code: true });
-  pushJoined(lines, "Notes", blocks.notes);
-  if (lines.length === 2) {
-    lines.push("- No curated inventory building blocks recorded yet.");
-  }
-  return lines.join("\n");
-}
-
-function formatComposition(context: PackageContext): string {
-  const { patterns } = context.fingerprint.composition;
-  if (patterns.length === 0) {
-    return "No composition patterns are recorded yet. Use nearby product surfaces as provisional anchors and label that reasoning as non-Ghost-backed.";
-  }
-  const lines: string[] = [];
-  for (const pattern of patterns.slice(0, 16)) {
-    lines.push(`- \`${pattern.id}\` (${pattern.kind}) - ${pattern.pattern}`);
-    for (const guidance of pattern.guidance ?? []) {
-      lines.push(`  - ${guidance}`);
-    }
-    if (pattern.anti_patterns?.length) {
-      lines.push(`  - Avoid: ${pattern.anti_patterns.join("; ")}`);
-    }
-  }
-  if (patterns.length > 16) {
-    lines.push(
-      `- ${patterns.length - 16} more composition pattern(s); read \`fingerprint/composition.yml\` before generating.`,
-    );
-  }
-  return lines.join("\n");
-}
-
-function formatExemplars(context: PackageContext): string {
-  const { exemplars } = context.fingerprint.inventory;
-  if (exemplars.length === 0) {
-    return "## Exemplars\n\nNo curated exemplars are recorded yet. Use nearby product surfaces as provisional anchors and label that reasoning as non-Ghost-backed.";
-  }
-  const lines: string[] = ["## Exemplars"];
-  for (const exemplar of exemplars.slice(0, 16)) {
-    const detail = [
-      exemplar.title ?? exemplar.note,
-      exemplar.surface_type ? `surface: ${exemplar.surface_type}` : undefined,
-      exemplar.scope ? `scope: ${exemplar.scope}` : undefined,
-    ].filter(Boolean);
-    lines.push(
-      `- \`${exemplar.id}\` - \`${exemplar.path}\`${detail.length ? ` (${detail.join("; ")})` : ""}`,
-    );
-    if (exemplar.why) lines.push(`  - Why: ${exemplar.why}`);
-    if (exemplar.refs?.length) {
-      lines.push(
-        `  - Fingerprint refs: ${exemplar.refs.map((ref) => `\`${ref}\``).join(", ")}`,
-      );
-    }
-  }
-  if (exemplars.length > 16) {
-    lines.push(
-      `- ${exemplars.length - 16} more exemplar(s); read \`fingerprint/inventory.yml\` before generating.`,
-    );
-  }
-  return lines.join("\n");
-}
-
-function pushJoined(
-  lines: string[],
-  label: string,
-  values: string[] | undefined,
-  options: { code?: boolean } = {},
-): void {
-  if (!values?.length) return;
-  const formatted = values
-    .map((value) => (options.code ? `\`${value}\`` : value))
-    .join(", ");
-  lines.push(`- ${label}: ${formatted}`);
 }
 
 function ensureTrailingNewline(value: string): string {

--- a/packages/ghost/src/scan/fingerprint-stack.ts
+++ b/packages/ghost/src/scan/fingerprint-stack.ts
@@ -351,6 +351,7 @@ export async function loadFingerprintStackLayer(
 export function fingerprintStackToPackageContext(
   stack: GhostFingerprintStack,
   nameOverride?: string,
+  targetPaths: string[] = [stack.target_path],
 ): PackageContext {
   const name = sanitizeName(
     nameOverride ??
@@ -361,6 +362,8 @@ export function fingerprintStackToPackageContext(
   return {
     name,
     fingerprintDir: stack.fingerprint_dir,
+    targetPaths,
+    layerDirs: stack.layers.map((layer) => layer.dir),
     fingerprint: stack.merged.fingerprint,
     fingerprintRaw: stringifyYaml(stack.merged.fingerprint, { lineWidth: 0 }),
     checks: stack.merged.checks,

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -69,7 +69,7 @@ or check format.
 | `ghost verify [dir] --root <dir>` | Validate evidence paths, exemplar paths, and typed check refs. |
 | `ghost check --base <ref>` | Run active deterministic gates against a diff. |
 | `ghost review --base <ref>` | Emit an advisory review packet grounded in fingerprint layers, exemplars, checks, and diff evidence. |
-| `ghost emit <kind>` | Emit `review-command` or the `context-bundle` generation packet. |
+| `ghost emit <kind>` | Emit `review-command` or the `context-bundle` compact entrypoint. |
 | `ghost skill install` | Install this unified skill bundle. |
 
 ## Advanced CLI Verbs

--- a/packages/ghost/src/skill-bundle/references/verify.md
+++ b/packages/ghost/src/skill-bundle/references/verify.md
@@ -10,7 +10,8 @@ description: Verify generated UI or fingerprint edits against Ghost.
 2. Run `ghost check --base <ref>` after implementation changes.
 3. For advisory review, run `ghost review --base <ref> --include-memory`.
 4. For generation setup, run `ghost emit context-bundle` and inspect the
-   prose, inventory, composition, and active checks.
+   compact entrypoint first, then follow suggested reads into prose, inventory,
+   composition, and active checks when the task widens.
 5. Inspect generated UI manually or with screenshots when visual fidelity
    matters.
 

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -337,7 +337,7 @@ describe("ghost CLI", () => {
     expect(verify.code).toBe(0);
     expect(check.code).toBe(0);
     expect(review.code).toBe(0);
-    expect(review.stdout).toContain("schema: ghost.fingerprint/v1");
+    expect(review.stdout).toContain("## Selected Fingerprint Context");
     expect(reviewCommand.code).toBe(0);
     expect(contextBundle.code).toBe(0);
   });
@@ -791,27 +791,46 @@ checks:
       join(dir, "ghost-context", "prompt.md"),
       "utf-8",
     );
-    expect(prompt).toContain("# Prose");
+    expect(prompt).toContain("# Agent Handoff");
+    expect(prompt).toContain("compact entrypoint into the fingerprint");
     expect(prompt).toContain("Agent Handoff");
-    expect(prompt).toContain("upstream handoff before generating");
-    expect(prompt).toContain("# Inventory");
-    expect(prompt.indexOf("## Topology")).toBeLessThan(
-      prompt.indexOf("## Building Blocks"),
-    );
-    expect(prompt.indexOf("## Building Blocks")).toBeLessThan(
-      prompt.indexOf("## Exemplars"),
-    );
-    expect(prompt.indexOf("## Exemplars")).toBeLessThan(
-      prompt.indexOf("## Generated Cache"),
-    );
+    expect(prompt).toContain("## Identity Capsule");
+    expect(prompt).toContain("## Context Match");
+    expect(prompt).toContain("## Read First");
+    expect(prompt).toContain("## Suggested Reads");
+    expect(prompt).toContain("## Omissions");
+    expect(prompt).not.toContain("```yaml");
+    expect(prompt).not.toMatch(/^# Prose$/m);
+    expect(prompt).not.toMatch(/^# Inventory$/m);
+    expect(prompt).not.toMatch(/^# Composition$/m);
     expect(prompt).toContain("Generated cache is optional source material");
     expect(prompt).toContain("Package.swift");
-    expect(prompt).toContain("# Composition");
     expect(prompt).toContain("no-hardcoded-ui-color");
     expect(prompt).not.toContain("candidate-density-check");
     expect(prompt).not.toContain("status: proposed");
     expect(prompt).not.toContain("Proposal Threshold");
-    expect(prompt).toContain("Label silent-layer reasoning as provisional");
+    expect(prompt).toContain("provisional and non-Ghost-backed");
+    const scopedContextBundle = await runCli(
+      [
+        "emit",
+        "context-bundle",
+        "--path",
+        "Code/Features/Lending/LendingUI",
+        "-o",
+        "ghost-context-scoped",
+      ],
+      dir,
+    );
+    expect(scopedContextBundle.code).toBe(0);
+    const scopedPrompt = await readFile(
+      join(dir, "ghost-context-scoped", "prompt.md"),
+      "utf-8",
+    );
+    expect(scopedPrompt).toContain("Status: path matched");
+    expect(scopedPrompt).toContain("Matched scopes: `lending`");
+    expect(scopedPrompt).toContain(
+      "inventory.exemplar:lending-tokenized-screen",
+    );
     await expect(
       readFile(join(dir, "ghost-context", "SKILL.md"), "utf-8"),
     ).resolves.toContain("provisional and\nnon-Ghost-backed");
@@ -975,6 +994,11 @@ checks:
 
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("# Ghost Advisory Review");
+    expect(result.stdout).toContain("## Selected Fingerprint Context");
+    expect(result.stdout).toContain("## Identity Capsule");
+    expect(result.stdout).toContain("## Context Match");
+    expect(result.stdout).toContain("Status: path matched");
+    expect(result.stdout).toContain("Matched scopes: `lending`");
     expect(result.stdout).toContain("diff location");
     expect(result.stdout).toContain(
       "fingerprint/prose.yml, fingerprint/inventory.yml, fingerprint/composition.yml",
@@ -986,6 +1010,7 @@ checks:
     expect(result.stdout).toContain("missing-memory");
     expect(result.stdout).toContain("experience-gap");
     expect(result.stdout).toContain("repair or intentional-divergence");
+    expect(result.stdout).not.toContain("schema: ghost.fingerprint/v1");
   });
 
   it("review includes config reference registries when config.yml is present", async () => {

--- a/packages/ghost/test/context-entrypoint.test.ts
+++ b/packages/ghost/test/context-entrypoint.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildContextEntrypoint,
+  buildFingerprintGraph,
+} from "../src/scan/context/entrypoint.js";
+import type { PackageContext } from "../src/scan/context/package-context.js";
+
+describe("context entrypoint", () => {
+  it("builds graph nodes and explicit edges from fingerprint refs", () => {
+    const graph = buildFingerprintGraph(context());
+
+    expect([...graph.nodeByRef.keys()]).toEqual(
+      expect.arrayContaining([
+        "prose.situation:refund-review",
+        "prose.principle:trust-before-action",
+        "prose.experience_contract:reversible-action",
+        "composition.pattern:progressive-disclosure",
+        "inventory.exemplar:refund-settings-primary",
+        "check:no-hardcoded-ui-color",
+      ]),
+    );
+    expect([...graph.nodeByRef.keys()]).not.toContain("check:proposed-density");
+    expect(graph.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: "prose.situation:refund-review",
+          to: "prose.principle:trust-before-action",
+        }),
+        expect.objectContaining({
+          from: "inventory.exemplar:refund-settings-primary",
+          to: "composition.pattern:progressive-disclosure",
+        }),
+        expect.objectContaining({
+          from: "check:no-hardcoded-ui-color",
+          to: "prose.principle:trust-before-action",
+        }),
+      ]),
+    );
+  });
+
+  it("selects path-matched refs, one-hop neighbors, active checks, and omissions", () => {
+    const entrypoint = buildContextEntrypoint(context(), {
+      targetPaths: ["apps/refunds/settings/page.tsx"],
+    });
+
+    expect(entrypoint.match.status).toBe("path-match");
+    expect(entrypoint.match.matchedScopes).toEqual(["refund-settings"]);
+    expect(entrypoint.selected.prose.map((node) => node.ref)).toEqual(
+      expect.arrayContaining([
+        "prose.situation:refund-review",
+        "prose.principle:trust-before-action",
+        "prose.experience_contract:reversible-action",
+      ]),
+    );
+    expect(entrypoint.selected.composition.map((node) => node.ref)).toContain(
+      "composition.pattern:progressive-disclosure",
+    );
+    expect(entrypoint.selected.exemplars.map((node) => node.ref)).toEqual([
+      "inventory.exemplar:refund-settings-primary",
+      "inventory.exemplar:refund-settings-secondary",
+      "inventory.exemplar:refund-settings-tertiary",
+    ]);
+    expect(entrypoint.selected.checks.map((node) => node.ref)).toEqual([
+      "check:no-hardcoded-ui-color",
+    ]);
+    expect(entrypoint.omissions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Exemplars",
+          omitted: 2,
+          source: "fingerprint/inventory.yml",
+        }),
+      ]),
+    );
+  });
+
+  it("falls back to a compact global entrypoint when no scope matches", () => {
+    const entrypoint = buildContextEntrypoint(context(), {
+      targetPaths: ["apps/payroll/page.tsx"],
+    });
+
+    expect(entrypoint.match.status).toBe("global-fallback");
+    expect(entrypoint.match.reasons.join("\n")).toContain(
+      "No fingerprint scope matched",
+    );
+    expect(entrypoint.suggestedReads.map((read) => read.path)).toEqual(
+      expect.arrayContaining([
+        "fingerprint/prose.yml",
+        "fingerprint/inventory.yml",
+        "fingerprint/composition.yml",
+      ]),
+    );
+  });
+
+  it("carries source layer provenance from resolved stacks", () => {
+    const entrypoint = buildContextEntrypoint(context());
+
+    expect(entrypoint.match.sourceLayers).toEqual([
+      "/repo/.ghost",
+      "/repo/apps/refunds/.ghost",
+    ]);
+  });
+
+  it("keeps selected matching refs stable when unrelated entries reorder", () => {
+    const normal = buildContextEntrypoint(context());
+    const reordered = buildContextEntrypoint(
+      context({ reorderUnrelated: true }),
+    );
+
+    expect(reordered.selected.exemplars.map((node) => node.ref)).toEqual(
+      normal.selected.exemplars.map((node) => node.ref),
+    );
+    expect(reordered.selected.prose.map((node) => node.ref)).toEqual(
+      normal.selected.prose.map((node) => node.ref),
+    );
+  });
+});
+
+function context(options: { reorderUnrelated?: boolean } = {}): PackageContext {
+  const unrelated = {
+    id: "unrelated",
+    path: "apps/onboarding/page.tsx",
+    scope: "onboarding",
+    surface_type: "setup",
+    why: "Unrelated onboarding surface.",
+  };
+  const refundExemplars = [
+    exemplar("primary"),
+    exemplar("secondary"),
+    exemplar("tertiary"),
+    exemplar("quaternary"),
+  ];
+  return {
+    name: "cash-dashboard",
+    fingerprintDir: ".ghost",
+    targetPaths: ["apps/refunds/settings/page.tsx"],
+    layerDirs: ["/repo/.ghost", "/repo/apps/refunds/.ghost"],
+    fingerprintRaw: "",
+    inventory: {
+      state: "missing",
+      path: ".ghost/fingerprint/sources/cache/inventory.json",
+    },
+    fingerprintLayers: {
+      manifest: "schema: ghost.fingerprint-package/v1\nid: local\n",
+    },
+    fingerprint: {
+      schema: "ghost.fingerprint/v1",
+      prose: {
+        summary: {
+          product: "Cash Dashboard",
+          audience: ["operators"],
+          goals: ["make refund decisions feel reversible"],
+          anti_goals: ["hide money movement risk"],
+          tradeoffs: ["trust over throughput"],
+          tone: ["direct"],
+        },
+        situations: [
+          {
+            id: "refund-review",
+            title: "Refund review",
+            user_intent: "Understand refund impact before submitting.",
+            product_obligation: "Make reversibility and consequences visible.",
+            surface_type: "settings",
+            principles: ["prose.principle:trust-before-action"],
+            experience_contracts: [
+              "prose.experience_contract:reversible-action",
+            ],
+            patterns: ["composition.pattern:progressive-disclosure"],
+          },
+        ],
+        principles: [
+          {
+            id: "trust-before-action",
+            principle: "Trust cues should appear before irreversible actions.",
+            applies_to: {
+              scopes: ["refund-settings"],
+            },
+            guidance: ["Put consequence copy near the submit affordance."],
+            check_refs: ["check:no-hardcoded-ui-color"],
+          },
+        ],
+        experience_contracts: [
+          {
+            id: "reversible-action",
+            contract: "Important actions expose a recovery path.",
+            applies_to: {
+              surface_types: ["settings"],
+            },
+            obligations: ["Show cancel or edit before confirmation."],
+          },
+        ],
+      },
+      inventory: {
+        topology: {
+          scopes: [
+            {
+              id: "refund-settings",
+              paths: ["apps/refunds/settings"],
+              surface_types: ["settings"],
+            },
+          ],
+          surface_types: ["settings"],
+        },
+        building_blocks: {},
+        exemplars: options.reorderUnrelated
+          ? [unrelated, ...refundExemplars]
+          : [...refundExemplars, unrelated],
+        sources: [],
+      },
+      composition: {
+        patterns: [
+          {
+            id: "progressive-disclosure",
+            kind: "flow",
+            pattern: "Reveal advanced refund details only after the summary.",
+            applies_to: {
+              scopes: ["refund-settings"],
+            },
+            guidance: ["Keep the default state scannable."],
+            check_refs: ["check:no-hardcoded-ui-color"],
+          },
+        ],
+      },
+    },
+    checks: {
+      schema: "ghost.checks/v1",
+      id: "cash-dashboard",
+      checks: [
+        {
+          id: "no-hardcoded-ui-color",
+          title: "Use design tokens for UI color",
+          status: "active",
+          severity: "serious",
+          derivation: {
+            prose: ["prose.principle:trust-before-action"],
+            composition: ["composition.pattern:progressive-disclosure"],
+            inventory: ["inventory.exemplar:refund-settings-primary"],
+          },
+          applies_to: {
+            scopes: ["refund-settings"],
+            paths: ["apps/refunds/settings"],
+          },
+          detector: {
+            type: "forbidden-regex",
+            pattern: "#[0-9a-fA-F]{3,8}",
+          },
+          repair: "Use semantic tokens.",
+        },
+        {
+          id: "proposed-density",
+          title: "Proposed density check",
+          status: "proposed",
+          severity: "nit",
+          detector: {
+            type: "required-regex",
+            pattern: "Density",
+          },
+        },
+      ],
+    },
+  };
+}
+
+function exemplar(id: string) {
+  return {
+    id: `refund-settings-${id}`,
+    path: `apps/refunds/settings/${id}.tsx`,
+    title: `Refund settings ${id}`,
+    scope: "refund-settings",
+    surface_type: "settings",
+    why: `Shows refund settings ${id}.`,
+    refs: [
+      "prose.principle:trust-before-action",
+      "composition.pattern:progressive-disclosure",
+    ],
+  } as const;
+}


### PR DESCRIPTION
## Summary

- Derive a runtime fingerprint graph for Ghost context selection.
- Emit compact, path-aware context entrypoints instead of pasting the full fingerprint into `prompt.md`.
- Use the same selected context flow in `ghost review` markdown while preserving JSON compatibility.

## Validation

- `pnpm test`
- `pnpm check`
- `pnpm build`
- Pre-push hook reran `pnpm build`, `pnpm check`, and `pnpm test` successfully.

## Notes

Local sandbox and real-agent harness files used for manual testing are intentionally ignored locally and are not part of this PR.