### PR TITLE
Catch inline color literal patterns

### DIFF
--- a/.changeset/inline-color-patterns.md
+++ b/.changeset/inline-color-patterns.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Catch shorthand hex and named color literals in color-oriented design checks.

--- a/ideas/ci-pr-integration-recipes.md
+++ b/ideas/ci-pr-integration-recipes.md
@@ -1,0 +1,87 @@
+# Idea: CI / PR integration recipes
+
+_Captured 2026-06-11._
+
+## Problem
+
+People ask "how do I run Ghost on a PR — does it comment something?" Today the
+honest answer is: Ghost ships no PR bot and posts no comments. It deliberately
+stays a calculator. That's the right OSS boundary, but the missing piece is
+**copy-paste examples** so integrators don't have to figure out the glue from
+scratch.
+
+## Design principle (keep this intact)
+
+Ghost the **tool** stays neutral — it commits only to two stable contracts and
+refuses to own the last mile:
+
+| Contract | What it is | So that… |
+| --- | --- | --- |
+| `ghost check --format json` | Documented schema (`ghost.check-report/v1`): result, changed_files, routed_files, findings | …any CI parses pass/fail + findings with no LLM |
+| `ghost review` (text packet) | Self-contained agent prompt on stdout (fingerprint layers + checks + diff) | …any agent consumes it with zero integration code |
+
+Everything else — which CI, which agent, whether it comments — is the
+integrator's choice. This neutrality is exactly what makes it broad (same shape
+as ESLint emitting JSON/SARIF and letting reviewdog/Danger post it).
+
+Ghost the **docs/examples** should still hand people forkable starting points
+for common stacks. Examples lower adoption friction without locking the tool in.
+
+## Universal glue shape
+
+1. CI runs `ghost check` / `ghost review` on the PR diff — **Ghost's job (stable output)**
+2. Integrator decides what to do with the output — **your glue (10–30 lines)**
+3. Post / gate / ignore using your platform's tools (gh, glab, API, Slack…) — **your last mile**
+
+## Two comment strategies (map to the two contracts)
+
+- **Deterministic comment / blocking gate** → consume `check --format json`, fail
+  on exit code. No agent. Reproducible. Good default for a required check.
+- **Agent critique comment** → pipe `review` to *your* agent, post what it writes.
+  The BYOA taste layer. Advisory only (Ghost intentionally won't let an LLM block
+  a build).
+
+Most orgs run both: check gates, review adds a non-blocking design critique.
+
+## Recipes to write
+
+| Recipe | Demonstrates |
+| --- | --- |
+| GitHub Actions — deterministic gate | `ghost check --format json` → fail job on exit code. No agent. |
+| GitHub Actions — agent review comment | `ghost review` → pipe to agent → `gh pr comment`. BYOA layer. |
+| GitLab CI | Same two steps with `glab`. Proves host-agnostic core. |
+| Generic / any CI (plain shell) | Platform-free version for Jenkins/CircleCI/Buildkite. |
+| Pre-commit / local | `ghost check --base HEAD` before pushing. |
+
+## Rules that keep examples OSS-broad
+
+1. **Annotate "Ghost's part" vs "your glue"** in every example, so a reader on a
+   different stack sees the seam and can swap the last mile. Forkable, not
+   prescriptive.
+2. **Keep the agent step pluggable** — show it as `... | your-agent ...` with one
+   or two concrete fills (Claude Code, Codex), never a single hardcoded vendor.
+3. Frame everything as **recipes, not the blessed way**.
+
+## Where this should live (decide before writing)
+
+- `apps/docs` — a "CI & PR Integration" docs page. Most discoverable; matches the
+  ESLint Integrations model. (Lean toward this.)
+- `packages/ghost/src/skill-bundle/references/` — as skill recipes, so an installed
+  agent can set up the CI for the user. (Also do this.)
+- Top-level `examples/` — liftable files. Optional.
+
+Recommendation: **docs page + skill reference**, with workflow YAML inlined so
+it's literally copy-paste.
+
+## Open questions
+
+- Should `ghost emit` grow a `ci-workflow` kind that scaffolds a starter workflow
+  file, the way it already emits `review-command` and `context-bundle`? Would keep
+  the "neutral tool" line while still being helpful.
+- Do we document SARIF output for `check` so GitHub code-scanning / reviewdog work
+  out of the box?
+
+## Next step
+
+Check where docs/skill references currently live and match existing style, then
+draft the CI Recipes page content for review before it lands.

--- a/packages/ghost/src/core/check.ts
+++ b/packages/ghost/src/core/check.ts
@@ -19,6 +19,10 @@ import {
   mapFromFingerprint,
   resolveFingerprintPackage,
 } from "../scan/index.js";
+import {
+  INLINE_COLOR_LITERAL_PATTERN,
+  isInlineColorDetector,
+} from "./inline-color-literals.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -363,14 +367,16 @@ function evaluateCheck(
   check: GhostCheck,
   file: GhostDriftChangedFile,
 ): GhostDriftCheckFinding[] {
-  const regex = detectorRegex(check);
-  if (!regex) return [];
+  const regexes = detectorRegexes(check);
+  if (regexes.length === 0) return [];
 
   if (isRequiredDetector(check)) {
     if (file.added_lines.length === 0) return [];
     const hasMatch = file.added_lines.some((line) => {
-      regex.lastIndex = 0;
-      return regex.test(line.text);
+      return regexes.some((regex) => {
+        regex.lastIndex = 0;
+        return regex.test(line.text);
+      });
     });
     if (hasMatch) return [];
     const firstLine = file.added_lines[0];
@@ -389,34 +395,46 @@ function evaluateCheck(
   }
 
   const findings: GhostDriftCheckFinding[] = [];
+  const seen = new Set<string>();
   for (const line of file.added_lines) {
-    regex.lastIndex = 0;
-    let match = regex.exec(line.text);
-    while (match !== null) {
-      findings.push({
-        check_id: check.id,
-        title: check.title,
-        severity: check.severity,
-        path: file.path,
-        line: line.line,
-        detector: check.detector.type,
-        message: forbiddenMessage(check),
-        match: match[0],
-        ...(check.repair ? { repair: check.repair } : {}),
-      });
-      if (match[0] === "") regex.lastIndex += 1;
-      match = regex.exec(line.text);
+    for (const regex of regexes) {
+      regex.lastIndex = 0;
+      let match = regex.exec(line.text);
+      while (match !== null) {
+        const key = `${line.line}:${match.index}:${match[0]}`;
+        if (!seen.has(key)) {
+          findings.push({
+            check_id: check.id,
+            title: check.title,
+            severity: check.severity,
+            path: file.path,
+            line: line.line,
+            detector: check.detector.type,
+            message: forbiddenMessage(check),
+            match: match[0],
+            ...(check.repair ? { repair: check.repair } : {}),
+          });
+          seen.add(key);
+        }
+        if (match[0] === "") regex.lastIndex += 1;
+        match = regex.exec(line.text);
+      }
     }
   }
   return findings;
 }
 
-function detectorRegex(check: GhostCheck): RegExp | null {
+function detectorRegexes(check: GhostCheck): RegExp[] {
   const source =
     check.detector.pattern ??
     (check.detector.value ? escapeRegExp(check.detector.value) : undefined);
-  if (!source) return null;
-  return new RegExp(source, "g");
+  if (!source) return [];
+
+  const regexes = [new RegExp(source, "g")];
+  if (isInlineColorDetector(check, source)) {
+    regexes.push(new RegExp(INLINE_COLOR_LITERAL_PATTERN, "gi"));
+  }
+  return regexes;
 }
 
 function detectorAppliesToPath(check: GhostCheck, path: string): boolean {

--- a/packages/ghost/src/core/inline-color-literals.ts
+++ b/packages/ghost/src/core/inline-color-literals.ts
@@ -1,0 +1,63 @@
+import type { GhostCheck } from "#ghost-core";
+
+const CSS_NAMED_COLOR_NAMES = [
+  "white",
+  "black",
+  "red",
+  "green",
+  "blue",
+  "yellow",
+  "orange",
+  "purple",
+  "pink",
+  "gray",
+  "grey",
+  "navy",
+  "teal",
+  "coral",
+  "salmon",
+  "tomato",
+  "gold",
+  "silver",
+  "maroon",
+  "aqua",
+  "cyan",
+  "lime",
+  "indigo",
+  "violet",
+  "crimson",
+  "magenta",
+  "turquoise",
+  "ivory",
+  "beige",
+  "khaki",
+];
+
+const CSS_NAMED_COLOR_PATTERN = CSS_NAMED_COLOR_NAMES.join("|");
+
+export const INLINE_COLOR_LITERAL_PATTERN = [
+  "#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])",
+  `\\b(?:Color|UIColor|NSColor)\\.(?:${CSS_NAMED_COLOR_PATTERN})\\b`,
+  `\\b(?:${CSS_NAMED_COLOR_PATTERN})\\b`,
+].join("|");
+
+export function isInlineColorDetector(
+  check: Pick<GhostCheck, "id" | "title" | "repair" | "detector">,
+  source: string,
+): boolean {
+  if (check.detector.type !== "forbidden-regex") return false;
+  const description = [
+    check.id,
+    check.title,
+    check.repair,
+    check.detector.value,
+    check.detector.pattern,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    /\bcolou?r\b|\bhex\b/i.test(description) ||
+    /#[0-9a-fA-F]{3,8}\b/.test(source) ||
+    /#(?:[0-9a-fA-F]|\[[^\]]*(?:a-f|0-9)[^\]]*\]|\(\?:)/i.test(source)
+  );
+}

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -957,6 +957,26 @@ checks:
     });
   });
 
+  it("check treats inline color detectors as literal patterns, not exact values", async () => {
+    await writeCheckPackage(dir, { detectorPattern: "#000000" });
+    await writeFile(
+      join(dir, "change.patch"),
+      lendingPatch("let colors = [Color(#000), Color.black]"),
+    );
+
+    const result = await runCli(
+      ["check", "--diff", "change.patch", "--format", "json"],
+      dir,
+    );
+
+    expect(result.code, result.stderr).toBe(1);
+    const report = JSON.parse(result.stdout);
+    expect(report.result).toBe("fail");
+    expect(
+      report.findings.map((finding: { match: string }) => finding.match),
+    ).toEqual(["#000", "Color.black"]);
+  });
+
   it("check passes when active scoped checks do not match", async () => {
     await writeCheckPackage(dir);
     await writeFile(
@@ -1437,9 +1457,11 @@ libraries:
 
 async function writeCheckPackage(
   dir: string,
-  options: { checks?: boolean } = {},
+  options: { checks?: boolean; detectorPattern?: string } = {},
 ): Promise<void> {
   const pkg = join(dir, ".ghost");
+  const detectorPattern =
+    options.detectorPattern ?? "#[0-9a-fA-F]{3,8}|UIColor\\(";
   await mkdir(pkg, { recursive: true });
   await writeSplitFingerprintPackage(
     pkg,
@@ -1498,7 +1520,7 @@ checks:
       paths: [Code/Features/Lending]
     detector:
       type: forbidden-regex
-      pattern: '#[0-9a-fA-F]{3,8}|UIColor\\('
+      pattern: '${detectorPattern}'
       contexts: [swift]
     evidence:
       support: 0.94


### PR DESCRIPTION
## Why
Ghost color checks could miss common literal forms like shorthand hex and named colors when the authored detector was narrower than the underlying design rule. The PR also captures a follow-up idea for CI and PR integration recipes.

## What
- Add a shared inline color literal matcher for shorthand hex and named color forms
- Apply that matcher to color-oriented forbidden checks alongside the authored detector
- Add CLI regression coverage and a patch changeset
- Capture the CI / PR integration recipe idea under `ideas/`

It will now capture all variants of hex codes / css colors:
<img width="1028" height="371" alt="image" src="https://github.com/user-attachments/assets/edf00c34-dea1-499c-afbd-9e69c32091c8" />
<img width="958" height="339" alt="image" src="https://github.com/user-attachments/assets/b452ff80-a6df-4e4f-afcd-2b70948b2362" />
<img width="956" height="339" alt="image" src="https://github.com/user-attachments/assets/9e020a3a-ac9e-4527-8710-77fc33b8ff2b" />


## Risk Assessment
Low. This broadens findings for color-oriented forbidden checks, leaves required detectors and non-color checks unchanged, and adds a standalone idea note.

## References
- Pre-commit hook: `pnpm check` passed
- Pre-push hook: `pnpm build`, `pnpm check`, and `pnpm test` passed
- Idea note: `ideas/ci-pr-integration-recipes.md`

Generated with Codex