### PR TITLE
Update Relay generation docs

### DIFF
--- a/.changeset/bright-relay-docs.md
+++ b/.changeset/bright-relay-docs.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Update documentation to point generation-context workflows at `ghost relay gather`.

--- a/docs/fingerprint-format.md
+++ b/docs/fingerprint-format.md
@@ -38,7 +38,7 @@ id: local
 
 The raw layer files can be sparse. Missing files or sections normalize to empty
 layers when Ghost assembles the internal `ghost.fingerprint/v1` document used
-by checks, review packets, context bundles, compare, and stack merges.
+by checks, review packets, Relay briefs, compare, and stack merges.
 
 ## Core Layers
 
@@ -251,7 +251,7 @@ ghost verify .ghost --root .
 ghost check --base main --format json
 ghost review --base main --include-memory
 ghost emit review-command --path apps/checkout/review/page.tsx
-ghost emit context-bundle
+ghost relay gather apps/checkout/review/page.tsx
 ```
 
 `ghost scan` reports readiness in the same three-layer vocabulary. Useful

--- a/docs/generation-loop.md
+++ b/docs/generation-loop.md
@@ -22,7 +22,11 @@ deterministic gates + advisory surface-composition findings
 
 ## Before Generation
 
-Build a brief from the generation packet:
+Build a brief from the resolved fingerprint stack:
+
+```bash
+ghost relay gather apps/checkout/review/page.tsx
+```
 
 1. Read `.ghost/fingerprint/prose.yml`, `.ghost/fingerprint/inventory.yml`, and
    `.ghost/fingerprint/composition.yml`.

--- a/docs/host-adapters.md
+++ b/docs/host-adapters.md
@@ -18,7 +18,8 @@ Ghost provides:
 - `ghost check --format json` as the stable `ghost.check-report/v1` contract.
 - `ghost review --format json` for advisory packets grounded in the resolved
   fingerprint stack.
-- `ghost emit context-bundle` for a split generation packet.
+- `ghost relay gather [target] --format json` as the `ghost.relay.gather/v1`
+  contract for generation context.
 - `--memory-dir <relative-dir>` for wrappers that store Ghost package roots
   somewhere other than `.ghost`.
 
@@ -62,6 +63,7 @@ at `fingerprint/`. Wrappers can use any safe relative package root:
 ```bash
 ghost init --scope apps/checkout --memory-dir .design/memory
 ghost stack apps/checkout/review/page.tsx --memory-dir .design/memory --format json
+ghost relay gather apps/checkout/review/page.tsx --memory-dir .design/memory --format json
 ghost check --base main --memory-dir .design/memory --format json
 ghost review --base main --memory-dir .design/memory --format json
 ```

--- a/docs/ideas/fingerprint-first-architecture.md
+++ b/docs/ideas/fingerprint-first-architecture.md
@@ -51,7 +51,7 @@ and flow.
 
 That makes the fingerprint more like an upstream contract than a static
 guideline or a downstream inspection report. Review, linting, comparison,
-generation packets, authoring tools, marketing workflows, and vibe-coding
+Relay briefs, authoring tools, marketing workflows, and vibe-coding
 workflows can all use the same checked-in surface context. Their outputs differ,
 but their source of truth is the fingerprint.
 
@@ -69,7 +69,7 @@ fingerprint lifecycle:
 | --- | --- | --- |
 | Capture | `init`, `inventory`, `scan` | Create the package, gather optional source material, and report layer readiness. |
 | Validate | `lint`, `verify` | Check schema shape, refs, evidence, exemplars, and deterministic package quality. |
-| Generate / apply | `emit context-bundle`, host agents, future generation consumers | Give agents the upstream surface-composition contract before they build or revise. |
+| Generate / apply | `relay gather`, host agents, future generation consumers | Give agents the upstream surface-composition contract before they build or revise. |
 | Govern | `check`, `review`, `ack`, `track`, `diverge` | Validate changed surfaces, produce advisory findings, and record stance toward divergence. |
 | Compare | `compare`, fleet-style analysis | Understand distance, cohorts, reference relationships, and change across packages. |
 


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users see the supported Relay gather workflow instead of a removed context-bundle command.
**Problem:** Several lower-level docs still described generation context through `ghost emit context-bundle`, but the current CLI intentionally rejects that emit kind. That leaves readers with a stale command path when they are trying to brief an agent before generation.
**Solution:** Point generation-context documentation at `ghost relay gather`, name the `ghost.relay.gather/v1` adapter contract, and keep the fingerprint-first architecture memo aligned with the current lifecycle language.

**Validation:**
- `pnpm exec vitest run packages/ghost/test/cli.test.ts packages/ghost/test/skill-bundle-manifest.test.ts packages/ghost/test/public-exports.test.ts`: passed, 51 tests
- `pnpm check:docs`: passed
- `pnpm check:install-bundle`: passed
- `pnpm check:cli-manifest`: passed
- `pnpm check:terminology`: passed
- `git diff --check`: passed
- pre-commit `pnpm check`: passed
- pre-push `pnpm build`: passed
- pre-push `pnpm check`: passed
- pre-push `pnpm test`: passed, 36 files / 358 tests

**Changeset:** added patch changeset for public docs that affect `@anarchitecture/ghost` users.

**Ghost Review:**
- `node packages/ghost/dist/bin.js check --base origin/main`: passed, no active deterministic check failures
- `node packages/ghost/dist/bin.js review --base origin/main --include-memory`: advisory packet generated for the docs diff; no blocking checks selected

<details>
<summary>File changes</summary>

**.changeset/bright-relay-docs.md**
Adds a patch changeset for the public documentation correction.

**docs/fingerprint-format.md**
Replaces the removed `ghost emit context-bundle` example with `ghost relay gather` and renames context-bundle wording to Relay briefs.

**docs/generation-loop.md**
Adds the current pre-generation `ghost relay gather` command to the generation loop.

**docs/host-adapters.md**
Documents `ghost relay gather [target] --format json` as the generation-context adapter contract and includes it in custom memory-dir examples.

**docs/ideas/fingerprint-first-architecture.md**
Updates lifecycle and rationale language from context/generation packets to Relay briefs and `relay gather`.

</details>

**Screenshots/Demos:** N/A, documentation-only change.