### PR TITLE
ci: attach .tgz to GitHub Release on npm publish

### DIFF
--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -1,17 +1,16 @@
 name: Publish tarball to GitHub Release
 
-# Temporary distribution channel while npm publish is blocked. Packs
+# Manual fallback for the tarball distribution channel. Packs
 # @anarchitecture/ghost and attaches the .tgz to a GitHub Release, so consumers can:
 #
 #   npm install https://github.com/block/ghost/releases/download/<tag>/<file>.tgz
 #
-# Triggered by pushing a tag of the form `anarchitecture-ghost@<version>` or by
-# manual workflow_dispatch.
+# The normal path is release.yml, which attaches the tarball automatically on
+# every Changesets publish. This workflow is dispatch-only so a Changesets-
+# created tag does not fire both workflows and race on the same Release. Use it
+# to (re)cut a tarball for an existing version without a fresh npm publish.
 
 on:
-  push:
-    tags:
-      - "anarchitecture-ghost@*"
   workflow_dispatch:
     inputs:
       version:
@@ -60,17 +59,16 @@ jobs:
       # controlled (anyone with Actions write can trigger). Pass them in via
       # `env:` and reference as shell variables so they can't be interpolated
       # as shell syntax — that's what the semgrep shell-injection rule wants.
+      # Inputs from workflow_dispatch are attacker-controlled (anyone with
+      # Actions write can trigger). Pass them in via `env:` and reference as
+      # shell variables so they can't be interpolated as shell syntax — that's
+      # what the semgrep shell-injection rule wants.
       - name: Resolve tag
         id: tag
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ "$EVENT_NAME" = "push" ]; then
-            TAG="$GITHUB_REF_NAME"
-          else
-            TAG="anarchitecture-ghost@$INPUT_VERSION"
-          fi
+          TAG="anarchitecture-ghost@$INPUT_VERSION"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       - run: pnpm --filter @anarchitecture/ghost build
 
       - name: Create Release PR or publish
+        id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: npm publish ./packages/ghost --access public --provenance
@@ -47,3 +48,28 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GHOST_NPM_PUBLISH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GHOST_NPM_PUBLISH_TOKEN }}
+
+      # When a publish actually happened, Changesets has already created and
+      # tagged a GitHub Release (createGithubReleases defaults to true). Pack
+      # the public package and attach the .tgz to that same Release so the
+      # tarball distribution channel stays in sync with npm — no separate tag
+      # push required.
+      - name: Attach tarball to GitHub Release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          VERSION="$(echo "$PUBLISHED_PACKAGES" \
+            | python3 -c "import json,sys; pkgs=json.load(sys.stdin); print(next(p['version'] for p in pkgs if p['name']=='@anarchitecture/ghost'))")"
+          TAG="anarchitecture-ghost@${VERSION}"
+          mkdir -p dist-tarball
+          pnpm --filter @anarchitecture/ghost pack --pack-destination "$GITHUB_WORKSPACE/dist-tarball"
+          ls -la dist-tarball
+          # Changesets creates the GitHub Release (createGithubReleases default).
+          # If it ever isn't there yet, create it so the upload always has a
+          # target — keeps the release from failing on a tooling change.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi
+          gh release upload "$TAG" dist-tarball/*.tgz --clobber


### PR DESCRIPTION
## What

When the Changesets "version packages" PR (e.g. #148) is merged to `main`, `release.yml` already publishes `@anarchitecture/ghost` to npm and Changesets creates the tagged GitHub Release. This adds a step that **attaches the packed `.tgz` to that same Release**, so the GitHub Release tarball distribution channel stays in sync with npm automatically — no separate tag push or manual `release-tarball.yml` run.

## How

- Added `id: changesets` to the existing publish step to read its outputs.
- New step gated on `steps.changesets.outputs.published == 'true'` so it only runs on an actual publish (not when the action is just opening/updating the version PR).
- Reads the version from `publishedPackages`, reconstructs the tag `anarchitecture-ghost@<version>` (the format Changesets already uses — see the existing `anarchitecture-ghost@0.1.0` tag), packs the tarball, and `gh release upload --clobber` attaches it.
- Defensive guard: if the Release doesn't exist yet, create it first so the release never fails on a tooling change.

## Why

Today npm publish (`release.yml`) and the GitHub Release tarball (`release-tarball.yml`) are two independent pipelines. The tarball one only fires on a manually pushed tag, so the GitHub Release tarball lags behind npm. Consumers that pin a GitHub Release `url` + `sha256` (e.g. Homebrew-style manifests) end up pointing at versions that were never released as tarballs. This couples the two so a single merge keeps them aligned.

## Notes

- `release-tarball.yml` is now redundant for the tag-push path; it can be kept as a manual `workflow_dispatch` fallback or have its `push: tags` trigger dropped to avoid double-runs. Left as-is for now.
- Forward-looking only — does not retroactively create older Releases.
- Workflow YAML can't be fully validated locally; worth watching the next release run.