### PR TITLE
Make Relay briefs action-shaped

### DIFF
--- a/.changeset/action-shaped-relay-briefs.md
+++ b/.changeset/action-shaped-relay-briefs.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": minor
+---
+
+Add a Task Contract to Relay gather output with preserve, inspect, avoid, and validate actions.

--- a/.changeset/bright-relay-shortlists.md
+++ b/.changeset/bright-relay-shortlists.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Improve Relay selected-ref shortlisting with relevance-aware ordering.

--- a/.changeset/clean-relay-briefs.md
+++ b/.changeset/clean-relay-briefs.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Improve Relay brief readability and refresh Ghost's own fingerprint anchors.

--- a/.ghost/fingerprint/composition.yml
+++ b/.ghost/fingerprint/composition.yml
@@ -18,7 +18,7 @@ patterns:
       - Prefer short ordered workflows over broad conceptual lectures.
       - Name missing fingerprint grounding or layer coverage plainly without creating a separate fingerprint-change workflow.
     evidence:
-      - path: packages/ghost/src/scan/context/package-review-command.ts
+      - path: packages/ghost/src/context/package-review-command.ts
   - id: editorial-workbench-docs
     kind: visual
     pattern: Ghost docs combine restrained editorial explanation with concrete command and schema work surfaces.

--- a/.ghost/fingerprint/inventory.yml
+++ b/.ghost/fingerprint/inventory.yml
@@ -59,8 +59,10 @@ building_blocks:
     - README.md
     - docs/fingerprint-format.md
     - docs/generation-loop.md
-    - packages/ghost/src/scan/context/package-writer.ts
-    - packages/ghost/src/scan/context/package-review-command.ts
+    - packages/ghost/src/relay.ts
+    - packages/ghost/src/context/entrypoint.ts
+    - packages/ghost/src/context/entrypoint-markdown.ts
+    - packages/ghost/src/context/package-review-command.ts
   notes:
     - Inventory is replaceable material; prose captures intent and composition captures how material is assembled.
     - Correct components or tokens do not prove a surface is aligned.
@@ -76,7 +78,7 @@ exemplars:
       - prose.principle:fingerprint-folder-is-canonical
       - prose.principle:generated-cache-is-source-material
   - id: review-command-fingerprint-packet
-    path: packages/ghost/src/scan/context/package-review-command.ts
+    path: packages/ghost/src/context/package-review-command.ts
     title: Generated review command
     surface_type: emitted-agent-prompt
     scope: public-cli

--- a/.ghost/fingerprint/prose.yml
+++ b/.ghost/fingerprint/prose.yml
@@ -100,7 +100,7 @@ experience_contracts:
       - Use active checks only when a finding should block.
       - Use missing-memory or experience-gap when the fingerprint cannot support a confident finding.
     evidence:
-      - path: packages/ghost/src/scan/context/package-review-command.ts
+      - path: packages/ghost/src/context/package-review-command.ts
         note: Emitted review command tells agents what to cite.
   - id: git-is-approval-boundary
     contract: Fingerprint edits use ordinary Git workflow; checked-in fingerprint/ files are truth.
@@ -116,7 +116,7 @@ experience_contracts:
       - Default emit paths load the resolved fingerprint package or stack.
       - Legacy direct markdown emit is unsupported for package context.
     evidence:
-      - path: packages/ghost/src/scan/context/package-writer.ts
+      - path: packages/ghost/src/context/entrypoint-markdown.ts
       - path: packages/ghost/src/scan-emit-command.ts
   - id: interfaces-preserve-operability
     contract: Ghost interfaces should preserve operability, readable examples, and responsive access before visual polish.

--- a/packages/ghost/src/context/entrypoint-markdown.ts
+++ b/packages/ghost/src/context/entrypoint-markdown.ts
@@ -26,10 +26,10 @@ export function formatContextEntrypointMarkdown(
 function formatIdentity(entrypoint: ContextEntrypoint): string {
   const lines = ["## Identity Capsule"];
   lines.push(`- Product: ${entrypoint.identity.product}`);
-  pushJoined(lines, "Audience", entrypoint.identity.audience);
-  pushJoined(lines, "Goals", entrypoint.identity.goals);
-  pushJoined(lines, "Anti-goals", entrypoint.identity.antiGoals);
-  pushJoined(lines, "Tradeoffs", entrypoint.identity.tradeoffs);
+  pushIdentityValues(lines, "Audience", entrypoint.identity.audience);
+  pushIdentityValues(lines, "Goals", entrypoint.identity.goals);
+  pushIdentityValues(lines, "Anti-goals", entrypoint.identity.antiGoals);
+  pushIdentityValues(lines, "Tradeoffs", entrypoint.identity.tradeoffs);
   pushJoined(lines, "Tone", entrypoint.identity.tone);
   return lines.join("\n");
 }
@@ -193,4 +193,28 @@ function pushJoined(
     .map((value) => (options.code ? `\`${value}\`` : value))
     .join(", ");
   lines.push(`- ${label}: ${formatted}`);
+}
+
+function pushIdentityValues(
+  lines: string[],
+  label: string,
+  values: string[] | undefined,
+): void {
+  if (!values?.length) return;
+  if (!shouldUseMultilineIdentity(values)) {
+    pushJoined(lines, label, values);
+    return;
+  }
+  lines.push(`- ${label}:`);
+  for (const value of values) {
+    lines.push(`  - ${value}`);
+  }
+}
+
+function shouldUseMultilineIdentity(values: string[]): boolean {
+  if (values.length < 2) return false;
+  const joined = values.join(", ");
+  return (
+    values.some((value) => /[.!?]$/.test(value.trim())) || joined.length > 100
+  );
 }

--- a/packages/ghost/src/context/entrypoint-markdown.ts
+++ b/packages/ghost/src/context/entrypoint-markdown.ts
@@ -14,6 +14,7 @@ export function formatContextEntrypointMarkdown(
   }
   parts.push(formatIdentity(entrypoint));
   parts.push(formatMatch(entrypoint));
+  parts.push(formatActionContract(entrypoint));
   parts.push(formatReadFirst(entrypoint));
   parts.push(formatValidation(entrypoint));
   parts.push(formatGeneratedCache(entrypoint.generatedCache));
@@ -61,6 +62,15 @@ function formatMatch(entrypoint: ContextEntrypoint): string {
   for (const reason of entrypoint.match.reasons) {
     lines.push(`- Why: ${reason}`);
   }
+  return lines.join("\n");
+}
+
+function formatActionContract(entrypoint: ContextEntrypoint): string {
+  const lines = ["## Task Contract"];
+  appendStringGroup(lines, "Preserve", entrypoint.actionContract.preserve);
+  appendReadGroup(lines, "Inspect", entrypoint.actionContract.inspect);
+  appendStringGroup(lines, "Avoid", entrypoint.actionContract.avoid);
+  appendStringGroup(lines, "Validate", entrypoint.actionContract.validate);
   return lines.join("\n");
 }
 
@@ -179,6 +189,36 @@ function appendNodeGroup(
     for (const detail of node.details.slice(0, 2)) {
       lines.push(`  - ${detail}`);
     }
+  }
+}
+
+function appendStringGroup(
+  lines: string[],
+  title: string,
+  values: string[],
+): void {
+  lines.push(`### ${title}`);
+  if (values.length === 0) {
+    lines.push("- None selected.");
+    return;
+  }
+  for (const value of values) {
+    lines.push(`- ${value}`);
+  }
+}
+
+function appendReadGroup(
+  lines: string[],
+  title: string,
+  reads: Array<{ path: string; reason: string }>,
+): void {
+  lines.push(`### ${title}`);
+  if (reads.length === 0) {
+    lines.push("- None selected.");
+    return;
+  }
+  for (const read of reads) {
+    lines.push(`- \`${read.path}\` - ${read.reason}`);
   }
 }
 

--- a/packages/ghost/src/context/entrypoint.ts
+++ b/packages/ghost/src/context/entrypoint.ts
@@ -98,7 +98,13 @@ export function buildContextEntrypoint(
       ? expandOneHop(directRefs, graph)
       : new Set<NodeRef>(graph.nodes.map((node) => node.ref));
   const status = directRefs.size > 0 ? "path-match" : "global-fallback";
-  const selected = selectNodes(graph, selectedRefs);
+  const selected = selectNodes(graph, selectedRefs, {
+    directRefs,
+    matchedScopeIds,
+    matchedSurfaceTypes,
+    requestedPaths,
+    useRelevance: status === "path-match",
+  });
   const identity = identityFromFingerprint(context.fingerprint, context.name);
   const suggestedReads = buildSuggestedReads(context, selected);
 
@@ -163,9 +169,12 @@ function identityFromFingerprint(
 function selectNodes(
   graph: FingerprintGraph,
   selectedRefs: Set<NodeRef>,
+  ranking: SelectionRanking,
 ): ContextEntrypoint["selected"] {
-  const selectedNodes = sortNodes(
+  const selectedNodes = sortSelectedNodes(
+    graph,
     graph.nodes.filter((node) => selectedRefs.has(node.ref)),
+    ranking,
   );
   return {
     prose: selectedNodes
@@ -183,6 +192,55 @@ function selectNodes(
       .filter((node) => node.kind === "check")
       .slice(0, CAPS.checks),
   };
+}
+
+interface SelectionRanking {
+  directRefs: Set<NodeRef>;
+  matchedScopeIds: string[];
+  matchedSurfaceTypes: string[];
+  requestedPaths: string[];
+  useRelevance: boolean;
+}
+
+function sortSelectedNodes(
+  graph: FingerprintGraph,
+  nodes: FingerprintGraphNode[],
+  ranking: SelectionRanking,
+): FingerprintGraphNode[] {
+  const sorted = sortNodes(nodes);
+  if (!ranking.useRelevance) return sorted;
+  return sorted.sort(
+    (a, b) =>
+      relevanceScore(b, graph, ranking) - relevanceScore(a, graph, ranking) ||
+      a.order - b.order,
+  );
+}
+
+function relevanceScore(
+  node: FingerprintGraphNode,
+  graph: FingerprintGraph,
+  ranking: SelectionRanking,
+): number {
+  let score = 0;
+  if (nodeMatchesTargets(node, ranking.requestedPaths)) score += 100;
+  if (intersects(node.appliesTo.scopes, ranking.matchedScopeIds)) score += 50;
+  if (intersects(node.appliesTo.surfaceTypes, ranking.matchedSurfaceTypes)) {
+    score += 20;
+  }
+  if (isConnectedToDirectRef(node.ref, graph, ranking.directRefs)) score += 10;
+  return score;
+}
+
+function isConnectedToDirectRef(
+  ref: NodeRef,
+  graph: FingerprintGraph,
+  directRefs: Set<NodeRef>,
+): boolean {
+  return graph.edges.some(
+    (edge) =>
+      (edge.from === ref && directRefs.has(edge.to)) ||
+      (edge.to === ref && directRefs.has(edge.from)),
+  );
 }
 
 function expandOneHop(
@@ -249,10 +307,12 @@ function buildActionContract(
   selected: ContextEntrypoint["selected"],
   suggestedReads: ContextEntrypoint["suggestedReads"],
 ): ContextEntrypoint["actionContract"] {
+  const prose = sortNodes(selected.prose);
+  const composition = sortNodes(selected.composition);
   const preserve = uniqueCapped([
-    ...selected.prose.map((node) => node.summary),
-    ...selected.composition.map((node) => node.summary),
-    ...selected.prose.flatMap((node) =>
+    ...prose.map((node) => node.summary),
+    ...composition.map((node) => node.summary),
+    ...prose.flatMap((node) =>
       node.details.filter((detail) => !isAvoidanceDetail(detail)),
     ),
   ]);
@@ -271,10 +331,8 @@ function buildActionContract(
   ]);
   const avoid = uniqueCapped([
     ...identity.antiGoals,
-    ...selected.prose.flatMap((node) => node.details.filter(isAvoidanceDetail)),
-    ...selected.composition.flatMap((node) =>
-      node.details.filter(isAvoidanceDetail),
-    ),
+    ...prose.flatMap((node) => node.details.filter(isAvoidanceDetail)),
+    ...composition.flatMap((node) => node.details.filter(isAvoidanceDetail)),
   ]);
   const validate =
     selected.checks.length > 0

--- a/packages/ghost/src/context/entrypoint.ts
+++ b/packages/ghost/src/context/entrypoint.ts
@@ -39,6 +39,12 @@ export interface ContextEntrypoint {
     tradeoffs: string[];
     tone: string[];
   };
+  actionContract: {
+    preserve: string[];
+    inspect: Array<{ path: string; reason: string }>;
+    avoid: string[];
+    validate: string[];
+  };
   selected: {
     prose: FingerprintGraphNode[];
     composition: FingerprintGraphNode[];
@@ -60,6 +66,7 @@ const CAPS = {
   exemplars: 3,
   checks: 6,
 } as const;
+const ACTION_CONTRACT_CAP = 5;
 
 export function buildContextEntrypoint(
   context: PackageContext,
@@ -92,6 +99,8 @@ export function buildContextEntrypoint(
       : new Set<NodeRef>(graph.nodes.map((node) => node.ref));
   const status = directRefs.size > 0 ? "path-match" : "global-fallback";
   const selected = selectNodes(graph, selectedRefs);
+  const identity = identityFromFingerprint(context.fingerprint, context.name);
+  const suggestedReads = buildSuggestedReads(context, selected);
 
   return {
     name: context.name,
@@ -103,9 +112,10 @@ export function buildContextEntrypoint(
       sourceLayers: context.layerDirs ?? [],
       reasons: matchReasons(status, requestedPaths, matchedScopeIds),
     },
-    identity: identityFromFingerprint(context.fingerprint, context.name),
+    identity,
+    actionContract: buildActionContract(identity, selected, suggestedReads),
     selected,
-    suggestedReads: buildSuggestedReads(context, selected),
+    suggestedReads,
     omissions: buildOmissions(graph, selected),
     generatedCache: context.inventory,
   };
@@ -234,6 +244,50 @@ function buildSuggestedReads(
   return [...reads.entries()].map(([path, reason]) => ({ path, reason }));
 }
 
+function buildActionContract(
+  identity: ContextEntrypoint["identity"],
+  selected: ContextEntrypoint["selected"],
+  suggestedReads: ContextEntrypoint["suggestedReads"],
+): ContextEntrypoint["actionContract"] {
+  const preserve = uniqueCapped([
+    ...selected.prose.map((node) => node.summary),
+    ...selected.composition.map((node) => node.summary),
+    ...selected.prose.flatMap((node) =>
+      node.details.filter((detail) => !isAvoidanceDetail(detail)),
+    ),
+  ]);
+  const inspect = uniqueInspectReads([
+    ...selected.exemplars
+      .map((exemplar) => {
+        const path = exemplar.appliesTo.paths[0];
+        return path
+          ? { path, reason: `source surface for ${exemplar.ref}` }
+          : undefined;
+      })
+      .filter((read): read is { path: string; reason: string } =>
+        Boolean(read),
+      ),
+    ...suggestedReads,
+  ]);
+  const avoid = uniqueCapped([
+    ...identity.antiGoals,
+    ...selected.prose.flatMap((node) => node.details.filter(isAvoidanceDetail)),
+    ...selected.composition.flatMap((node) =>
+      node.details.filter(isAvoidanceDetail),
+    ),
+  ]);
+  const validate =
+    selected.checks.length > 0
+      ? uniqueCapped(
+          selected.checks.map((node) => `${node.ref} - ${node.summary}`),
+        )
+      : [
+          "No selected active checks. Proposed or disabled checks are not blocking validation.",
+        ];
+
+  return { preserve, inspect, avoid, validate };
+}
+
 function buildOmissions(
   graph: FingerprintGraph,
   selected: ContextEntrypoint["selected"],
@@ -268,4 +322,36 @@ function buildOmissions(
       source: "fingerprint/enforcement/checks.yml",
     },
   ];
+}
+
+function uniqueCapped(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+    if (out.length >= ACTION_CONTRACT_CAP) break;
+  }
+  return out;
+}
+
+function uniqueInspectReads(
+  reads: Array<{ path: string; reason: string }>,
+): Array<{ path: string; reason: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ path: string; reason: string }> = [];
+  for (const read of reads) {
+    const path = read.path.trim();
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    out.push({ path, reason: read.reason });
+    if (out.length >= ACTION_CONTRACT_CAP) break;
+  }
+  return out;
+}
+
+function isAvoidanceDetail(detail: string): boolean {
+  return /^(Refuses|Counterexample|Avoid):/.test(detail);
 }

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -904,6 +904,8 @@ checks:
     expect(result.stdout).toContain("# Ghost Relay Brief");
     expect(result.stdout).toContain("Status: path matched");
     expect(result.stdout).toContain("Matched scopes: `lending`");
+    expect(result.stdout).toContain("## Task Contract");
+    expect(result.stdout).toContain("### Preserve");
     expect(result.stdout).toContain("prose.principle:tokenized-ui-color");
     expect(result.stdout).toContain("composition.pattern:tokenized-ui-color");
     expect(result.stdout).toContain(
@@ -935,7 +937,26 @@ checks:
     expect(json.source.kind).toBe("package");
     expect(json.targetPaths).toEqual(["Code/Features/Lending/LendingUI"]);
     expect(json.entrypoint.match.status).toBe("path-match");
+    expect(json.entrypoint.actionContract.preserve).toContain(
+      "UI colors should come from the product token system.",
+    );
+    expect(json.entrypoint.actionContract.inspect).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "Code/Features/Lending/LendingUI",
+          reason:
+            "source surface for inventory.exemplar:lending-tokenized-screen",
+        }),
+      ]),
+    );
+    expect(json.entrypoint.actionContract.validate).toContain(
+      "check:no-hardcoded-ui-color - serious: Use design tokens for UI color",
+    );
+    expect(json.entrypoint.actionContract.validate.join("\n")).not.toContain(
+      "candidate-density-check",
+    );
     expect(json.brief).toContain("# Ghost Relay Brief");
+    expect(json.brief).toContain("## Task Contract");
   });
 
   it("ignores memory-dir when gathering Relay context from an exact package", async () => {

--- a/packages/ghost/test/context-entrypoint.test.ts
+++ b/packages/ghost/test/context-entrypoint.test.ts
@@ -3,6 +3,7 @@ import {
   buildContextEntrypoint,
   buildFingerprintGraph,
 } from "../src/context/entrypoint.js";
+import { formatContextEntrypointMarkdown } from "../src/context/entrypoint-markdown.js";
 import type { PackageContext } from "../src/context/package-context.js";
 
 describe("context entrypoint", () => {
@@ -101,6 +102,20 @@ describe("context entrypoint", () => {
     ]);
   });
 
+  it("formats multi-sentence identity fields as readable bullets", () => {
+    const entrypoint = buildContextEntrypoint(
+      context({ multiSentenceIdentity: true }),
+    );
+
+    const markdown = formatContextEntrypointMarkdown(entrypoint);
+
+    expect(markdown).toContain(
+      "- Goals:\n  - Keep product-surface composition fingerprints easy for agents to read.\n  - Preserve surface composition across generation and review.",
+    );
+    expect(markdown).toContain("- Tone: plain, precise");
+    expect(markdown).not.toContain("read., Preserve");
+  });
+
   it("keeps selected matching refs stable when unrelated entries reorder", () => {
     const normal = buildContextEntrypoint(context());
     const reordered = buildContextEntrypoint(
@@ -116,7 +131,9 @@ describe("context entrypoint", () => {
   });
 });
 
-function context(options: { reorderUnrelated?: boolean } = {}): PackageContext {
+function context(
+  options: { reorderUnrelated?: boolean; multiSentenceIdentity?: boolean } = {},
+): PackageContext {
   const unrelated = {
     id: "unrelated",
     path: "apps/onboarding/page.tsx",
@@ -148,11 +165,30 @@ function context(options: { reorderUnrelated?: boolean } = {}): PackageContext {
       prose: {
         summary: {
           product: "Cash Dashboard",
-          audience: ["operators"],
-          goals: ["make refund decisions feel reversible"],
-          anti_goals: ["hide money movement risk"],
-          tradeoffs: ["trust over throughput"],
-          tone: ["direct"],
+          audience: options.multiSentenceIdentity
+            ? ["operators", "agents generating product UI"]
+            : ["operators"],
+          goals: options.multiSentenceIdentity
+            ? [
+                "Keep product-surface composition fingerprints easy for agents to read.",
+                "Preserve surface composition across generation and review.",
+              ]
+            : ["make refund decisions feel reversible"],
+          anti_goals: options.multiSentenceIdentity
+            ? [
+                "Treat raw inventory as canonical surface guidance.",
+                "Let advisory review block work without deterministic checks.",
+              ]
+            : ["hide money movement risk"],
+          tradeoffs: options.multiSentenceIdentity
+            ? [
+                "Prefer compact durable prose over exhaustive surveys.",
+                "Preserve portable language over company-specific strategy.",
+              ]
+            : ["trust over throughput"],
+          tone: options.multiSentenceIdentity
+            ? ["plain", "precise"]
+            : ["direct"],
         },
         situations: [
           {

--- a/packages/ghost/test/context-entrypoint.test.ts
+++ b/packages/ghost/test/context-entrypoint.test.ts
@@ -75,6 +75,55 @@ describe("context entrypoint", () => {
     );
   });
 
+  it("builds an action contract from selected context", () => {
+    const entrypoint = buildContextEntrypoint(context(), {
+      targetPaths: ["apps/refunds/settings/page.tsx"],
+    });
+
+    expect(entrypoint.actionContract.preserve).toEqual([
+      "Make reversibility and consequences visible.",
+      "Trust cues should appear before irreversible actions.",
+      "Important actions expose a recovery path.",
+      "Reveal advanced refund details only after the summary.",
+      "User intent: Understand refund impact before submitting.",
+    ]);
+    expect(entrypoint.actionContract.inspect).toEqual([
+      {
+        path: "apps/refunds/settings/primary.tsx",
+        reason: "source surface for inventory.exemplar:refund-settings-primary",
+      },
+      {
+        path: "apps/refunds/settings/secondary.tsx",
+        reason:
+          "source surface for inventory.exemplar:refund-settings-secondary",
+      },
+      {
+        path: "apps/refunds/settings/tertiary.tsx",
+        reason:
+          "source surface for inventory.exemplar:refund-settings-tertiary",
+      },
+      {
+        path: "fingerprint/prose.yml",
+        reason: "selected prose anchors and full intent",
+      },
+      {
+        path: "fingerprint/composition.yml",
+        reason: "selected composition patterns and neighboring patterns",
+      },
+    ]);
+    expect(entrypoint.actionContract.avoid).toEqual([
+      "hide money movement risk",
+      "Counterexample: Hide consequence copy until after submission.",
+      "Avoid: Bury the refund summary behind advanced controls.",
+    ]);
+    expect(entrypoint.actionContract.validate).toEqual([
+      "check:no-hardcoded-ui-color - serious: Use design tokens for UI color",
+    ]);
+    expect(entrypoint.actionContract.validate.join("\n")).not.toContain(
+      "proposed-density",
+    );
+  });
+
   it("falls back to a compact global entrypoint when no scope matches", () => {
     const entrypoint = buildContextEntrypoint(context(), {
       targetPaths: ["apps/payroll/page.tsx"],
@@ -114,6 +163,20 @@ describe("context entrypoint", () => {
     );
     expect(markdown).toContain("- Tone: plain, precise");
     expect(markdown).not.toContain("read., Preserve");
+  });
+
+  it("renders the task contract before detailed read-first refs", () => {
+    const markdown = formatContextEntrypointMarkdown(
+      buildContextEntrypoint(context(), {
+        targetPaths: ["apps/refunds/settings/page.tsx"],
+      }),
+    );
+
+    expect(markdown).toContain("## Task Contract");
+    expect(markdown).toContain("### Preserve");
+    expect(markdown.indexOf("## Task Contract")).toBeLessThan(
+      markdown.indexOf("## Read First"),
+    );
   });
 
   it("keeps selected matching refs stable when unrelated entries reorder", () => {
@@ -212,6 +275,7 @@ function context(
               scopes: ["refund-settings"],
             },
             guidance: ["Put consequence copy near the submit affordance."],
+            counterexamples: ["Hide consequence copy until after submission."],
             check_refs: ["check:no-hardcoded-ui-color"],
           },
         ],
@@ -253,6 +317,9 @@ function context(
               scopes: ["refund-settings"],
             },
             guidance: ["Keep the default state scannable."],
+            anti_patterns: [
+              "Bury the refund summary behind advanced controls.",
+            ],
             check_refs: ["check:no-hardcoded-ui-color"],
           },
         ],

--- a/packages/ghost/test/context-entrypoint.test.ts
+++ b/packages/ghost/test/context-entrypoint.test.ts
@@ -75,6 +75,66 @@ describe("context entrypoint", () => {
     );
   });
 
+  it("ranks direct path exemplars ahead of same-scope exemplars", () => {
+    const entrypoint = buildContextEntrypoint(context(), {
+      targetPaths: ["apps/refunds/settings/quaternary.tsx"],
+    });
+
+    expect(entrypoint.selected.exemplars.map((node) => node.ref)).toEqual([
+      "inventory.exemplar:refund-settings-quaternary",
+      "inventory.exemplar:refund-settings-primary",
+      "inventory.exemplar:refund-settings-secondary",
+    ]);
+  });
+
+  it("ranks scope matches ahead of surface-only matches within a node kind", () => {
+    const entrypoint = buildContextEntrypoint(
+      context({ rankingPressure: true }),
+      {
+        targetPaths: ["apps/refunds/settings/page.tsx"],
+      },
+    );
+
+    expect(
+      entrypoint.selected.prose
+        .filter((node) => node.kind === "principle")
+        .map((node) => node.ref)
+        .slice(0, 2),
+    ).toEqual([
+      "prose.principle:trust-before-action",
+      "prose.principle:surface-only-guidance",
+    ]);
+  });
+
+  it("keeps one-hop refs below directly matched refs", () => {
+    const entrypoint = buildContextEntrypoint(
+      context({ rankingPressure: true }),
+      {
+        targetPaths: ["apps/refunds/settings/page.tsx"],
+      },
+    );
+
+    expect(entrypoint.selected.composition.map((node) => node.ref)).toEqual([
+      "composition.pattern:progressive-disclosure",
+      "composition.pattern:scope-density",
+      "composition.pattern:one-hop-recovery",
+    ]);
+  });
+
+  it("ranks checks connected to selected refs ahead of unrelated active checks", () => {
+    const entrypoint = buildContextEntrypoint(
+      context({ rankingPressure: true }),
+      {
+        targetPaths: ["apps/refunds/settings/page.tsx"],
+      },
+    );
+
+    expect(entrypoint.selected.checks.map((node) => node.ref)).toEqual([
+      "check:no-hardcoded-ui-color",
+      "check:unrelated-same-scope",
+    ]);
+  });
+
   it("builds an action contract from selected context", () => {
     const entrypoint = buildContextEntrypoint(context(), {
       targetPaths: ["apps/refunds/settings/page.tsx"],
@@ -195,7 +255,11 @@ describe("context entrypoint", () => {
 });
 
 function context(
-  options: { reorderUnrelated?: boolean; multiSentenceIdentity?: boolean } = {},
+  options: {
+    reorderUnrelated?: boolean;
+    multiSentenceIdentity?: boolean;
+    rankingPressure?: boolean;
+  } = {},
 ): PackageContext {
   const unrelated = {
     id: "unrelated",
@@ -204,11 +268,21 @@ function context(
     surface_type: "setup",
     why: "Unrelated onboarding surface.",
   };
+  const oneHopExemplar = {
+    id: "refund-settings-one-hop",
+    path: "apps/refunds/settings/one-hop.tsx",
+    title: "Refund settings one-hop",
+    scope: "refund-settings",
+    surface_type: "settings",
+    why: "Connects to the one-hop recovery pattern.",
+    refs: ["composition.pattern:one-hop-recovery"],
+  } as const;
   const refundExemplars = [
     exemplar("primary"),
     exemplar("secondary"),
     exemplar("tertiary"),
     exemplar("quaternary"),
+    ...(options.rankingPressure ? [oneHopExemplar] : []),
   ];
   return {
     name: "cash-dashboard",
@@ -268,6 +342,18 @@ function context(
           },
         ],
         principles: [
+          ...(options.rankingPressure
+            ? [
+                {
+                  id: "surface-only-guidance",
+                  principle: "Surface-only refund guidance.",
+                  applies_to: {
+                    surface_types: ["settings"],
+                  },
+                  guidance: ["Applies to settings surfaces broadly."],
+                },
+              ]
+            : []),
           {
             id: "trust-before-action",
             principle: "Trust cues should appear before irreversible actions.",
@@ -309,6 +395,17 @@ function context(
       },
       composition: {
         patterns: [
+          ...(options.rankingPressure
+            ? [
+                {
+                  id: "one-hop-recovery",
+                  kind: "flow",
+                  pattern:
+                    "Show recovery details when an exemplar calls for them.",
+                  guidance: ["This pattern is reached only through refs."],
+                },
+              ]
+            : []),
           {
             id: "progressive-disclosure",
             kind: "flow",
@@ -322,6 +419,19 @@ function context(
             ],
             check_refs: ["check:no-hardcoded-ui-color"],
           },
+          ...(options.rankingPressure
+            ? [
+                {
+                  id: "scope-density",
+                  kind: "layout",
+                  pattern: "Keep refund settings density consistent.",
+                  applies_to: {
+                    scopes: ["refund-settings"],
+                  },
+                  guidance: ["This pattern is directly scoped."],
+                },
+              ]
+            : []),
         ],
       },
     },
@@ -329,6 +439,24 @@ function context(
       schema: "ghost.checks/v1",
       id: "cash-dashboard",
       checks: [
+        ...(options.rankingPressure
+          ? [
+              {
+                id: "unrelated-same-scope",
+                title: "Unrelated same-scope check",
+                status: "active",
+                severity: "nit",
+                applies_to: {
+                  scopes: ["refund-settings"],
+                  paths: ["apps/refunds/settings"],
+                },
+                detector: {
+                  type: "required-regex",
+                  pattern: "Refund",
+                },
+              },
+            ]
+          : []),
         {
           id: "no-hardcoded-ui-color",
           title: "Use design tokens for UI color",

--- a/packages/ghost/test/dogfood-fingerprint.test.ts
+++ b/packages/ghost/test/dogfood-fingerprint.test.ts
@@ -1,0 +1,18 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { verifyFingerprintPackage } from "../src/scan/verify-package.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+describe("dogfood fingerprint", () => {
+  it("keeps Ghost's own fingerprint evidence and exemplars reachable", async () => {
+    const report = await verifyFingerprintPackage(".ghost", REPO_ROOT, {
+      root: ".",
+    });
+
+    expect(report.issues).toEqual([]);
+    expect(report.errors).toBe(0);
+    expect(report.warnings).toBe(0);
+  });
+});


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Agents get clearer, action-oriented Relay briefs before generating or reviewing product-surface work.
**Problem:** Relay selected useful fingerprint refs, but the brief still made host agents infer the immediate actions from contextual detail. When multiple applicable refs were selected, the capped shortlist could also lean on canonical order instead of the most target-relevant anchors.
**Solution:** Add a deterministic Task Contract to Relay gather output with preserve, inspect, avoid, and validate actions. The PR also improves identity-list readability, relevance-ranks selected refs for path-matched Relay briefs, and refreshes Ghost's own fingerprint anchors so exemplars point at live source files.

**Validation:**
- `pnpm build`: passed manually after rebase and in pre-push hook
- `pnpm test`: passed manually and in pre-push hook, 375 tests
- `pnpm check`: passed manually, in pre-commit, and in pre-push hook
- `node packages/ghost/dist/bin.js lint .ghost`: passed, 0 errors / 0 warnings / 0 info
- `node packages/ghost/dist/bin.js verify .ghost --root .`: passed, 0 errors / 0 warnings / 0 info
- `git diff --check origin/main...HEAD`: passed

**Changeset:** added minor changeset for the public Relay Task Contract addition and patch changesets for Relay readability, fingerprint anchor cleanup, and relevance-aware shortlisting.

**Ghost Review:**
- `node packages/ghost/dist/bin.js check --base origin/main`: PASS, no active deterministic check failures
- `node packages/ghost/dist/bin.js review --base origin/main --include-memory`: advisory packet generated successfully

<details>
<summary>File changes</summary>

**.changeset/action-shaped-relay-briefs.md**
Adds a minor release note for the new Relay Task Contract output.

**.changeset/bright-relay-shortlists.md**
Adds a patch release note for relevance-aware Relay selected-ref ordering.

**.changeset/clean-relay-briefs.md**
Adds a patch release note for Relay brief readability and refreshed fingerprint anchors.

**.ghost/fingerprint/composition.yml**
Updates the compact-agent-handoff evidence path to the current context module location.

**.ghost/fingerprint/inventory.yml**
Refreshes Ghost inventory building blocks and exemplar paths for the Relay/context modules.

**.ghost/fingerprint/prose.yml**
Updates evidence paths that moved out of the old scan/context folder.

**packages/ghost/src/context/entrypoint-markdown.ts**
Renders readable identity bullets and inserts the Task Contract before detailed selected refs.

**packages/ghost/src/context/entrypoint.ts**
Adds `entrypoint.actionContract` and relevance-aware selected-ref ordering for path-matched Relay context.

**packages/ghost/test/cli.test.ts**
Covers Relay Markdown and JSON output for the new Task Contract shape.

**packages/ghost/test/context-entrypoint.test.ts**
Covers action contract derivation, Markdown placement, readable identity formatting, proposed-check exclusion, and relevance ranking.

**packages/ghost/test/dogfood-fingerprint.test.ts**
Adds dogfood coverage that Ghost's own fingerprint verifies cleanly.

</details>

**Screenshots/Demos:** N/A, CLI/JSON behavior only.
