### PR TITLE
Document fingerprints as steering guidance

### DIFF
--- a/.changeset/steering-fingerprint-docs.md
+++ b/.changeset/steering-fingerprint-docs.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Document how to author fingerprints as steering guidance for generation.

--- a/apps/docs/src/content/docs/fingerprint-authoring.mdx
+++ b/apps/docs/src/content/docs/fingerprint-authoring.mdx
@@ -97,6 +97,31 @@ Keep each claim in the file that will make it useful later:
 
 </DocSection>
 
+<DocSection title="Authoring For Steering">
+
+A useful fingerprint should help future agents choose, restrain, route, anchor,
+and review. It should not only describe what exists or collect every available
+style detail.
+
+Write layer content so generation decisions become explicit:
+
+- `goals` name what generated work should preserve.
+- `anti_goals` block plausible defaults that would make the surface feel
+  generic or wrong.
+- `tradeoffs` say which value wins when choices conflict.
+- `situations` route guidance by task, surface type, state, or audience need.
+- `principles` capture broad product intent.
+- `experience_contracts` turn taste, trust, recovery, or disclosure into
+  obligations.
+- `composition.patterns` give repeatable layout, flow, state, content,
+  behavior, or visual rules.
+- `inventory.exemplars` anchor the guidance in concrete material an agent can
+  inspect.
+
+Write less like a brand book and more like a decision engine.
+
+</DocSection>
+
 <DocSection title="Nested Packages">
 
 Nested fingerprints are opt-in. Create a local `.ghost/` only when a surface

--- a/docs/fingerprint-format.md
+++ b/docs/fingerprint-format.md
@@ -62,6 +62,10 @@ Use prose for durable claims about audience needs, product obligations,
 acceptable tradeoffs, what the surface refuses to become, and contracts that
 should shape agent behavior.
 
+High-quality layer content makes generation choices explicit: what to preserve,
+what to avoid, which tradeoffs win, which situations route guidance, and which
+exemplars ground the claim.
+
 `inventory.yml` points to curated material and optional source links:
 
 ```yaml

--- a/packages/ghost/src/skill-bundle/references/capture.md
+++ b/packages/ghost/src/skill-bundle/references/capture.md
@@ -121,6 +121,10 @@ Treat generated cache as scratch material. Do not copy raw inventory into
 
 Edit the smallest useful durable layer content:
 
+- Before writing, ask whether the draft will help future agents choose what
+  matters most, avoid plausible-but-wrong defaults, resolve competing
+  priorities, route guidance by situation, inspect concrete exemplars, and
+  review whether generated work preserved the intended experience.
 - `prose.yml`: summary, situations, principles, and experience contracts.
 - `inventory.yml`: topology, building blocks, exemplars, and `sources[]` links.
 - `composition.yml`: rules, layouts, structures, flows, states, content,

--- a/packages/ghost/src/skill-bundle/references/patterns.md
+++ b/packages/ghost/src/skill-bundle/references/patterns.md
@@ -25,6 +25,13 @@ Add a pattern when it helps a future agent choose or review:
 - a visual treatment tied to product meaning
 - a restraint rule that preserves hierarchy, density, trust, or pacing
 
+A strong pattern usually does one of three jobs:
+
+- selection: it tells the agent what structure, flow, state, content, behavior,
+  or visual treatment to choose
+- restraint: it tells the agent which tempting default to avoid
+- review: it gives a future reviewer something observable to check
+
 Do not add a pattern just because a value or component exists. Put raw
 observations in `.ghost/fingerprint/sources/cache/` or keep them in scratch notes.
 


### PR DESCRIPTION
> ♻️ Recreated from #164, which GitHub auto-closed during a repository history rewrite (dogfood removal). Same branch, same commit, same work — no changes lost.

---

**Category:** improvement
**User Impact:** Fingerprint authors get clearer guidance for writing fingerprints that steer generation and review instead of collecting style inventory.
**Problem:** The public docs and bundled agent recipes explain the fingerprint layers, but they did not explicitly teach authors how to turn those layers into generation decisions. That made it easier for future fingerprints to drift toward descriptive catalogs instead of durable steering guidance.
**Solution:** Add concise public and agent-facing guidance that frames fingerprints as decision engines: preserve goals, block anti-goals, resolve tradeoffs, route by situation, cite exemplars, and write patterns for selection, restraint, and review.

**Validation:**
- `pnpm check`: passed via pre-commit
- `pnpm check:docs`: passed, `3 docs OK`
- `pnpm check:install-bundle`: passed, `13 files OK`
- `pnpm check:terminology`: passed
- `git diff --check`: passed
- `pnpm build`: passed via pre-push
- `pnpm test`: failed in `packages/ghost/test/context-sandbox.test.ts` on an existing compact Relay brief assertion expecting no `## Generated Cache` section; reproduced separately and unrelated to these docs-only changes

**Changeset:** added patch changeset for `@anarchitecture/ghost`.

**Ghost Review:**
- `node packages/ghost/dist/bin.js check --base origin/main`: passed, no active deterministic check failures
- `node packages/ghost/dist/bin.js review --base origin/main --include-memory`: emitted advisory review packet for the docs/surface-model change

<details>
<summary>File changes</summary>

**.changeset/steering-fingerprint-docs.md**
Adds a patch changeset for user-facing fingerprint authoring docs.

**apps/docs/src/content/docs/fingerprint-authoring.mdx**
Adds an "Authoring For Steering" section after layer responsibilities, with a compact checklist for goals, anti-goals, tradeoffs, situations, principles, contracts, patterns, and exemplars.

**docs/fingerprint-format.md**
Adds a short format-reference note that high-quality layer content should make generation choices explicit.

**packages/ghost/src/skill-bundle/references/capture.md**
Adds a steering checklist to the capture recipe before agents write core layers.

**packages/ghost/src/skill-bundle/references/patterns.md**
Names the three useful jobs of a pattern: selection, restraint, and review.

</details>

**Screenshots/Demos:** N/A, docs-only change.
