### PR TITLE
Add Relay context hits contract

### DIFF
--- a/.changeset/relay-context-hits.md
+++ b/.changeset/relay-context-hits.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": minor
+---
+
+Change Relay gather output to the `ghost.relay.gather/v2` context hits contract.

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Before generating or revising UI, gather the Relay brief for the target path:
 ghost relay gather apps/checkout/review/page.tsx
 ```
 
-Relay compiles selected context from the resolved stack: matched packages,
-intent, active obligations, composition, inventory, validation checks, and gaps.
+Relay compiles selected context from the resolved stack as context hits:
+fingerprint refs, why they matched, suggested reads, omissions, and gaps.
 The important shift is timing: Ghost gives agents surface-composition context
 before they build, not only after a review finds drift.
 

--- a/docs/generation-loop.md
+++ b/docs/generation-loop.md
@@ -28,14 +28,14 @@ Build a brief from the resolved fingerprint stack:
 ghost relay gather apps/checkout/review/page.tsx
 ```
 
-Relay compiles selected context from the resolved stack: matched packages,
-intent, active obligations, composition, inventory, validation checks, and gaps.
+Relay compiles selected context from the resolved stack as context hits:
+fingerprint refs, why they matched, suggested reads, omissions, and gaps.
 
 Use the brief in this order:
 
-1. Start from the selected intent and active obligations.
-2. Express that intent through the selected composition.
-3. Inspect matching inventory exemplars as concrete anchors.
+1. Start from the selected context hits and their match reasons.
+2. Apply intent and composition hits before choosing implementation details.
+3. Inspect inventory hits as concrete anchors.
 4. Use `inventory.building_blocks` as curated material.
 5. Run `ghost signals` when raw repo observations would help find evidence.
 6. Skim active checks in `.ghost/fingerprint/validate.yml` so generation avoids
@@ -71,7 +71,7 @@ stack and runs merged checks for each group. Only active checks can block.
 ghost review --base main
 ```
 
-Advisory review packets include the current diff, the same selected context as
+Advisory review packets include the current diff, the same context-hit model as
 Relay, active checks, and finding categories for fixes, intentional
 divergence, missing fingerprint grounding, experience gaps, and eval
 uncertainty.

--- a/docs/host-adapters.md
+++ b/docs/host-adapters.md
@@ -17,9 +17,9 @@ Ghost provides:
 - `ghost check --format json` as the stable `ghost.check-report/v1` contract.
 - `ghost review --format json` for advisory packets grounded in the resolved
   fingerprint stack.
-- `ghost relay gather [target] --format json` as the `ghost.relay.gather/v1`
-  contract for generation context, including `selected_context` grouped by
-  stack, intent, obligations, composition, inventory, validation, and gaps.
+- `ghost relay gather [target] --format json` as the `ghost.relay.gather/v2`
+  contract for generation context, including selected `context_hits`, match
+  reasons, suggested reads, omissions, and gaps.
 - `--memory-dir <relative-dir>` for wrappers that store Ghost package roots
   somewhere other than `.ghost`.
 

--- a/packages/ghost/src/context/entrypoint.ts
+++ b/packages/ghost/src/context/entrypoint.ts
@@ -12,6 +12,13 @@ import {
   unique,
 } from "./graph.js";
 import type { PackageContext } from "./package-context.js";
+import {
+  addSelectionReason,
+  directSelectionReasons,
+  expandOneHopWithReasons,
+  globalFallbackRefs,
+  type SelectionReason,
+} from "./selection-reasons.js";
 
 export type {
   FingerprintGraph,
@@ -51,9 +58,12 @@ export interface ContextEntrypoint {
     exemplars: FingerprintGraphNode[];
     checks: FingerprintGraphNode[];
   };
+  selectionReasons: Record<string, SelectionReason[]>;
   suggestedReads: Array<{ path: string; reason: string }>;
   omissions: Array<{ label: string; omitted: number; source: string }>;
 }
+
+export type { SelectionReason } from "./selection-reasons.js";
 
 export interface BuildContextEntrypointOptions {
   targetPaths?: string[];
@@ -81,22 +91,27 @@ export function buildContextEntrypoint(
     matchedScopes.flatMap((scope) => scope.surfaceTypes),
   );
   const directRefs = new Set<NodeRef>();
+  const selectionReasons = new Map<NodeRef, SelectionReason[]>();
 
   for (const node of graph.nodes) {
-    if (
-      nodeMatchesTargets(node, requestedPaths) ||
-      intersects(node.appliesTo.scopes, matchedScopeIds) ||
-      intersects(node.appliesTo.surfaceTypes, matchedSurfaceTypes)
-    ) {
+    const reasons = directSelectionReasons(node, {
+      requestedPaths,
+      matchedScopeIds,
+      matchedSurfaceTypes,
+    });
+    if (reasons.length > 0) {
       directRefs.add(node.ref);
+      for (const reason of reasons) {
+        addSelectionReason(selectionReasons, node.ref, reason);
+      }
     }
   }
 
+  const status = directRefs.size > 0 ? "path-match" : "global-fallback";
   const selectedRefs =
     directRefs.size > 0
-      ? expandOneHop(directRefs, graph)
-      : new Set<NodeRef>(graph.nodes.map((node) => node.ref));
-  const status = directRefs.size > 0 ? "path-match" : "global-fallback";
+      ? expandOneHopWithReasons(directRefs, graph, selectionReasons)
+      : globalFallbackRefs(graph, requestedPaths, selectionReasons);
   const selected = selectNodes(graph, selectedRefs, {
     directRefs,
     matchedScopeIds,
@@ -120,6 +135,7 @@ export function buildContextEntrypoint(
     identity,
     actionContract: buildActionContract(identity, selected, suggestedReads),
     selected,
+    selectionReasons: Object.fromEntries(selectionReasons),
     suggestedReads,
     omissions: buildOmissions(graph, selected),
   };
@@ -239,18 +255,6 @@ function isConnectedToDirectRef(
       (edge.from === ref && directRefs.has(edge.to)) ||
       (edge.to === ref && directRefs.has(edge.from)),
   );
-}
-
-function expandOneHop(
-  refs: Set<NodeRef>,
-  graph: FingerprintGraph,
-): Set<NodeRef> {
-  const expanded = new Set(refs);
-  for (const edge of graph.edges) {
-    if (refs.has(edge.from)) expanded.add(edge.to);
-    if (refs.has(edge.to)) expanded.add(edge.from);
-  }
-  return expanded;
 }
 
 function buildSuggestedReads(

--- a/packages/ghost/src/context/graph.ts
+++ b/packages/ghost/src/context/graph.ts
@@ -293,7 +293,7 @@ export function unique(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
 }
 
-function pathsOverlap(a: string, b: string): boolean {
+export function pathsOverlap(a: string, b: string): boolean {
   const left = normalizePath(a);
   const right = normalizePath(b);
   if (!left || !right) return false;

--- a/packages/ghost/src/context/selected-context.ts
+++ b/packages/ghost/src/context/selected-context.ts
@@ -1,4 +1,8 @@
-import type { ContextEntrypoint, FingerprintGraphNode } from "./entrypoint.js";
+import type {
+  ContextEntrypoint,
+  FingerprintGraphNode,
+  SelectionReason,
+} from "./entrypoint.js";
 import type { PackageContext } from "./package-context.js";
 
 export interface SelectedContext {
@@ -12,12 +16,7 @@ export interface SelectedContext {
     reasons: string[];
   };
   posture: SelectedContextPosture;
-  intent: SelectedContextNodeSummary[];
-  active_obligations: SelectedContextObligation[];
-  composition: SelectedContextNodeSummary[];
-  inventory: SelectedContextInventoryItem[];
-  validation: SelectedContextNodeSummary[];
-  guidance: SelectedContextGuidance;
+  context_hits: SelectedContextHit[];
   suggested_reads: SelectedContextRead[];
   omissions: SelectedContextOmission[];
   gaps: SelectedContextGap[];
@@ -37,30 +36,14 @@ export interface SelectedContextPosture {
   tone: string[];
 }
 
-export interface SelectedContextNodeSummary {
+export interface SelectedContextHit {
   ref: string;
-  label: string;
+  kind: "intent" | "composition" | "inventory" | "validation";
   summary: string;
-  details: string[];
   source_file: string;
-}
-
-export interface SelectedContextInventoryItem
-  extends SelectedContextNodeSummary {
+  details: string[];
   path?: string;
-}
-
-export interface SelectedContextObligation {
-  ref: string;
-  text: string;
-  source: string;
-}
-
-export interface SelectedContextGuidance {
-  preserve: string[];
-  inspect: SelectedContextRead[];
-  avoid: string[];
-  validate: string[];
+  why_selected: SelectionReason[];
 }
 
 export interface SelectedContextRead {
@@ -98,13 +81,12 @@ export function buildSelectedContext(
     dir,
     label: packageLabel(dir, index, packageDirs.length),
   }));
-  const intent = entrypoint.selected.intent.map(nodeSummary);
-  const composition = entrypoint.selected.composition.map(nodeSummary);
-  const inventory = entrypoint.selected.exemplars.map((node) => ({
-    ...nodeSummary(node),
-    ...(pathForNode(node) ? { path: pathForNode(node) } : {}),
-  }));
-  const validation = entrypoint.selected.checks.map(nodeSummary);
+  const contextHits = [
+    ...entrypoint.selected.intent,
+    ...entrypoint.selected.composition,
+    ...entrypoint.selected.exemplars,
+    ...entrypoint.selected.checks,
+  ].map((node) => contextHit(node, entrypoint));
 
   return {
     title: `${entrypoint.name} Relay Brief`,
@@ -117,17 +99,7 @@ export function buildSelectedContext(
       reasons: entrypoint.match.reasons,
     },
     posture: postureFromEntrypoint(entrypoint),
-    intent,
-    active_obligations: obligationsFromIntent(entrypoint.selected.intent),
-    composition,
-    inventory,
-    validation,
-    guidance: {
-      preserve: entrypoint.actionContract.preserve,
-      inspect: entrypoint.actionContract.inspect,
-      avoid: entrypoint.actionContract.avoid,
-      validate: entrypoint.actionContract.validate,
-    },
+    context_hits: contextHits,
     suggested_reads: entrypoint.suggestedReads,
     omissions: entrypoint.omissions,
     gaps: gapsFromEntrypoint(entrypoint),
@@ -150,15 +122,7 @@ export function formatSelectedContextMarkdown(
     formatStack(context, sectionHeading),
     formatMatch(context, sectionHeading),
     formatPosture(context, sectionHeading),
-    formatNodeSection("Intent", context.intent, sectionHeading),
-    formatObligations(context, sectionHeading),
-    formatNodeSection("Composition", context.composition, sectionHeading),
-    formatInventory(context, sectionHeading),
-    formatNodeSection("Validation", context.validation, sectionHeading, {
-      empty:
-        "No selected active checks. Proposed or disabled checks are not blocking validation.",
-    }),
-    formatGuidance(context, sectionHeading),
+    formatContextHits(context, sectionHeading),
     formatSuggestedReads(context, sectionHeading),
     formatOmissions(context, sectionHeading),
     formatGaps(context, sectionHeading),
@@ -192,16 +156,6 @@ function packageLabel(_dir: string, index: number, count: number): string {
   return `package ${index + 1}`;
 }
 
-function nodeSummary(node: FingerprintGraphNode): SelectedContextNodeSummary {
-  return {
-    ref: node.ref,
-    label: node.label,
-    summary: node.summary,
-    details: node.details,
-    source_file: node.sourceFile,
-  };
-}
-
 function pathForNode(node: FingerprintGraphNode): string | undefined {
   const directPath = node.appliesTo.paths[0];
   if (directPath) return directPath;
@@ -209,30 +163,30 @@ function pathForNode(node: FingerprintGraphNode): string | undefined {
   return pathDetail?.slice("Path: ".length).trim();
 }
 
-function obligationsFromIntent(
-  nodes: FingerprintGraphNode[],
-): SelectedContextObligation[] {
-  const out: SelectedContextObligation[] = [];
-  const seen = new Set<string>();
-  for (const node of nodes) {
-    for (const text of obligationTexts(node)) {
-      const normalized = text.trim();
-      if (!normalized || seen.has(`${node.ref}\n${normalized}`)) continue;
-      seen.add(`${node.ref}\n${normalized}`);
-      out.push({ ref: node.ref, text: normalized, source: node.sourceFile });
-    }
-  }
-  return out.slice(0, 10);
+function contextHit(
+  node: FingerprintGraphNode,
+  entrypoint: ContextEntrypoint,
+): SelectedContextHit {
+  const hit: SelectedContextHit = {
+    ref: node.ref,
+    kind: contextHitKind(node),
+    summary: node.summary,
+    source_file: node.sourceFile,
+    details: node.details,
+    why_selected: entrypoint.selectionReasons[node.ref] ?? [],
+  };
+  const path = pathForNode(node);
+  if (path) hit.path = path;
+  return hit;
 }
 
-function obligationTexts(node: FingerprintGraphNode): string[] {
-  const details = node.details.filter(
-    (detail) => !/^(Refuses|Counterexample|Avoid):/.test(detail),
-  );
-  if (node.kind === "situation") return [...details, node.summary];
-  if (node.kind === "experience_contract") return [node.summary, ...details];
-  if (node.kind === "principle") return [node.summary, ...details];
-  return [node.summary, ...details];
+function contextHitKind(
+  node: FingerprintGraphNode,
+): SelectedContextHit["kind"] {
+  if (node.kind === "pattern") return "composition";
+  if (node.kind === "exemplar") return "inventory";
+  if (node.kind === "check") return "validation";
+  return "intent";
 }
 
 function gapsFromEntrypoint(
@@ -329,62 +283,24 @@ function formatPosture(context: SelectedContext, heading: string): string {
   return lines.join("\n");
 }
 
-function formatNodeSection(
-  title: string,
-  nodes: SelectedContextNodeSummary[],
-  heading: string,
-  options: { empty?: string } = {},
-): string {
-  const lines = [`${heading} ${title}`];
-  if (nodes.length === 0) {
-    lines.push(`- ${options.empty ?? "None selected."}`);
+function formatContextHits(context: SelectedContext, heading: string): string {
+  const lines = [`${heading} Context Hits`];
+  if (context.context_hits.length === 0) {
+    lines.push("- None selected.");
     return lines.join("\n");
   }
-  for (const node of nodes) {
-    lines.push(`- \`${node.ref}\` — ${node.summary}`);
-    for (const detail of node.details.slice(0, 3)) {
-      lines.push(`  - ${detail}`);
+  for (const hit of context.context_hits) {
+    const path = hit.path ? ` — \`${hit.path}\`` : "";
+    lines.push(`- \`${hit.ref}\` (${hit.kind})${path} — ${hit.summary}`);
+    for (const reason of hit.why_selected) {
+      lines.push(`  - why: ${reason.kind}=${reason.value}`);
     }
-  }
-  return lines.join("\n");
-}
-
-function formatObligations(context: SelectedContext, heading: string): string {
-  const lines = [`${heading} Active Obligations`];
-  if (context.active_obligations.length === 0) {
-    lines.push("- None selected.");
-    return lines.join("\n");
-  }
-  for (const obligation of context.active_obligations) {
-    lines.push(`- ${obligation.text} (from \`${obligation.ref}\`)`);
-  }
-  return lines.join("\n");
-}
-
-function formatInventory(context: SelectedContext, heading: string): string {
-  const lines = [`${heading} Inventory`];
-  if (context.inventory.length === 0) {
-    lines.push("- None selected.");
-    return lines.join("\n");
-  }
-  for (const item of context.inventory) {
-    const path = item.path ? ` — \`${item.path}\`` : "";
-    lines.push(`- \`${item.ref}\`${path} — ${item.summary}`);
-    for (const detail of item.details
+    for (const detail of hit.details
       .filter((entry) => !entry.startsWith("Path: "))
       .slice(0, 2)) {
       lines.push(`  - ${detail}`);
     }
   }
-  return lines.join("\n");
-}
-
-function formatGuidance(context: SelectedContext, heading: string): string {
-  const lines = [`${heading} Guidance`];
-  appendStringGroup(lines, "Preserve", context.guidance.preserve);
-  appendReadGroup(lines, "Inspect", context.guidance.inspect);
-  appendStringGroup(lines, "Avoid", context.guidance.avoid);
-  appendStringGroup(lines, "Validate", context.guidance.validate);
   return lines.join("\n");
 }
 
@@ -431,41 +347,11 @@ function formatGaps(context: SelectedContext, heading: string): string {
 
 function formatUseThisContext(heading: string): string {
   return `${heading} Use This Context
-- Start from posture, then preserve the selected situations, principles, contracts, and obligations.
-- Express intent through composition: use selected patterns to shape hierarchy, flow, state, behavior, and content.
-- Inspect inventory as evidence and material; do not let available components override intent.
-- Treat validation as deterministic enforcement; only active checks can block.
+- Start from posture, then use context hits as the compact routing set for this task.
+- Express intent through composition hits: shape hierarchy, flow, state, behavior, and content from the selected evidence.
+- Inspect inventory hits as evidence and material; do not let available components override intent.
+- Treat validation hits as deterministic enforcement; only active checks can block.
 - When gaps are present, label local reasoning as provisional and non-Ghost-backed.`;
-}
-
-function appendStringGroup(
-  lines: string[],
-  title: string,
-  values: string[],
-): void {
-  lines.push(`- ${title}:`);
-  if (values.length === 0) {
-    lines.push("  - None selected.");
-    return;
-  }
-  for (const value of values) {
-    lines.push(`  - ${value}`);
-  }
-}
-
-function appendReadGroup(
-  lines: string[],
-  title: string,
-  reads: SelectedContextRead[],
-): void {
-  lines.push(`- ${title}:`);
-  if (reads.length === 0) {
-    lines.push("  - None selected.");
-    return;
-  }
-  for (const read of reads) {
-    lines.push(`  - \`${read.path}\` - ${read.reason}`);
-  }
 }
 
 function pushPostureValues(

--- a/packages/ghost/src/context/selection-reasons.ts
+++ b/packages/ghost/src/context/selection-reasons.ts
@@ -1,0 +1,118 @@
+import type {
+  FingerprintGraph,
+  FingerprintGraphNode,
+  NodeRef,
+} from "./graph.js";
+import { pathsOverlap, unique } from "./graph.js";
+
+export interface SelectionReason {
+  kind: "path" | "scope" | "surface_type" | "linked_ref" | "global_fallback";
+  value: string;
+}
+
+export function directSelectionReasons(
+  node: FingerprintGraphNode,
+  options: {
+    requestedPaths: string[];
+    matchedScopeIds: string[];
+    matchedSurfaceTypes: string[];
+  },
+): SelectionReason[] {
+  const reasons: SelectionReason[] = [];
+  for (const path of matchingPaths(
+    node.appliesTo.paths,
+    options.requestedPaths,
+  )) {
+    reasons.push({ kind: "path", value: path });
+  }
+  for (const scope of matchingValues(
+    node.appliesTo.scopes,
+    options.matchedScopeIds,
+  )) {
+    reasons.push({ kind: "scope", value: scope });
+  }
+  for (const surfaceType of matchingValues(
+    node.appliesTo.surfaceTypes,
+    options.matchedSurfaceTypes,
+  )) {
+    reasons.push({ kind: "surface_type", value: surfaceType });
+  }
+  return reasons;
+}
+
+export function expandOneHopWithReasons(
+  refs: Set<NodeRef>,
+  graph: FingerprintGraph,
+  selectionReasons: Map<NodeRef, SelectionReason[]>,
+): Set<NodeRef> {
+  const expanded = new Set(refs);
+  for (const edge of graph.edges) {
+    if (refs.has(edge.from)) {
+      expanded.add(edge.to);
+      if (!refs.has(edge.to)) {
+        addSelectionReason(selectionReasons, edge.to, {
+          kind: "linked_ref",
+          value: edge.from,
+        });
+      }
+    }
+    if (refs.has(edge.to)) {
+      expanded.add(edge.from);
+      if (!refs.has(edge.from)) {
+        addSelectionReason(selectionReasons, edge.from, {
+          kind: "linked_ref",
+          value: edge.to,
+        });
+      }
+    }
+  }
+  return expanded;
+}
+
+export function globalFallbackRefs(
+  graph: FingerprintGraph,
+  requestedPaths: string[],
+  selectionReasons: Map<NodeRef, SelectionReason[]>,
+): Set<NodeRef> {
+  const refs = new Set<NodeRef>();
+  const value = requestedPaths.join(", ") || ".";
+  for (const node of graph.nodes) {
+    refs.add(node.ref);
+    addSelectionReason(selectionReasons, node.ref, {
+      kind: "global_fallback",
+      value,
+    });
+  }
+  return refs;
+}
+
+export function addSelectionReason(
+  reasons: Map<NodeRef, SelectionReason[]>,
+  ref: NodeRef,
+  reason: SelectionReason,
+): void {
+  const current = reasons.get(ref) ?? [];
+  if (
+    !current.some(
+      (entry) => entry.kind === reason.kind && entry.value === reason.value,
+    )
+  ) {
+    current.push(reason);
+  }
+  reasons.set(ref, current);
+}
+
+function matchingPaths(paths: string[], requestedPaths: string[]): string[] {
+  const out: string[] = [];
+  for (const targetPath of requestedPaths) {
+    if (paths.some((path) => pathsOverlap(path, targetPath))) {
+      out.push(targetPath);
+    }
+  }
+  return unique(out);
+}
+
+function matchingValues(values: string[], candidates: string[]): string[] {
+  const candidateSet = new Set(candidates);
+  return values.filter((value) => candidateSet.has(value));
+}

--- a/packages/ghost/src/relay.ts
+++ b/packages/ghost/src/relay.ts
@@ -20,17 +20,14 @@ import {
 export type {
   SelectedContext,
   SelectedContextGap,
-  SelectedContextGuidance,
-  SelectedContextInventoryItem,
-  SelectedContextNodeSummary,
-  SelectedContextObligation,
+  SelectedContextHit,
   SelectedContextOmission,
   SelectedContextPackage,
   SelectedContextPosture,
   SelectedContextRead,
 } from "./context/selected-context.js";
 
-export const RELAY_GATHER_SCHEMA = "ghost.relay.gather/v1" as const;
+export const RELAY_GATHER_SCHEMA = "ghost.relay.gather/v2" as const;
 
 export interface GatherRelayContextOptions {
   cwd?: string;

--- a/packages/ghost/src/skill-bundle/references/review.md
+++ b/packages/ghost/src/skill-bundle/references/review.md
@@ -26,7 +26,7 @@ ghost review --base <ref>
 
 Use the emitted packet as context. It includes:
 
-- selected context: stack, match, intent, obligations, composition, inventory, validation, and gaps
+- selected context hits: fingerprint refs, why they matched, suggested reads, omissions, and gaps
 - active checks from `fingerprint/validate.yml`
 - optional stack or config context when present or requested
 - the diff
@@ -42,7 +42,8 @@ exemplars when useful, active check when blocking, selected-context gap or
 local-evidence rationale when context is silent, and repair or intentional-divergence
 rationale.
 
-Use the selected context in order: intent → composition → inventory → validation.
+Use the selected context hits first, then follow suggested reads when the task
+needs deeper evidence.
 When fingerprint facets are silent or selected-context gaps show the fingerprint is
 silent, local evidence can still support advisory critique. Label those findings
 as provisional and non-Ghost-backed.

--- a/packages/ghost/src/skill-bundle/references/verify.md
+++ b/packages/ghost/src/skill-bundle/references/verify.md
@@ -10,8 +10,7 @@ description: Verify generated UI or fingerprint edits against Ghost.
 2. Run `ghost check --base <ref>` after implementation changes.
 3. For advisory review, run `ghost review --base <ref>`.
 4. For generation setup, run `ghost relay gather <target>` and read the brief:
-   stack, intent, active obligations, composition, inventory, validation, and
-   gaps.
+   context hits, why they matched, suggested reads, omissions, and gaps.
 5. Inspect generated UI manually or with screenshots when visual fidelity
    matters.
 

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -1803,12 +1803,7 @@ checks:
     expect(result.stdout).toContain("## Match");
     expect(result.stdout).toContain("Status: path matched");
     expect(result.stdout).toContain("Matched scopes: `lending`");
-    expect(result.stdout).toContain("## Intent");
-    expect(result.stdout).toContain("## Active Obligations");
-    expect(result.stdout).toContain("## Composition");
-    expect(result.stdout).toContain("## Inventory");
-    expect(result.stdout).toContain("## Validation");
-    expect(result.stdout).toContain("## Guidance");
+    expect(result.stdout).toContain("## Context Hits");
     expect(result.stdout).toContain("## Suggested Reads");
     expect(result.stdout).toContain("## Omissions");
     expect(result.stdout).toContain("## Gaps");
@@ -1816,6 +1811,9 @@ checks:
     expect(result.stdout).toContain("composition.pattern:tokenized-ui-color");
     expect(result.stdout).toContain(
       "inventory.exemplar:lending-tokenized-screen",
+    );
+    expect(result.stdout).toContain(
+      "why: path=Code/Features/Lending/LendingUI",
     );
     expect(result.stdout).toContain("no-hardcoded-ui-color");
     expect(result.stdout).not.toContain("candidate-density-check");
@@ -1839,16 +1837,54 @@ checks:
 
     expect(result.code).toBe(0);
     const json = JSON.parse(result.stdout);
-    expect(json.schema).toBe("ghost.relay.gather/v1");
+    expect(json.schema).toBe("ghost.relay.gather/v2");
     expect(json.source.kind).toBe("package");
     expect(json.targetPaths).toEqual(["Code/Features/Lending/LendingUI"]);
     expect(json.entrypoint).toBeUndefined();
     expect(json.cascade_brief).toBeUndefined();
     expect(json.selected_context.match.status).toBe("path-match");
-    expect(json.selected_context.guidance.preserve).toContain(
-      "UI colors should come from the product token system.",
+    expect(json.selected_context).not.toHaveProperty("intent");
+    expect(json.selected_context).not.toHaveProperty("composition");
+    expect(json.selected_context).not.toHaveProperty("inventory");
+    expect(json.selected_context).not.toHaveProperty("validation");
+    expect(json.selected_context).not.toHaveProperty("guidance");
+    expect(json.selected_context).not.toHaveProperty("active_obligations");
+    expect(json.selected_context.context_hits).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ref: "intent.principle:tokenized-ui-color",
+          kind: "intent",
+          why_selected: expect.arrayContaining([
+            {
+              kind: "linked_ref",
+              value: "inventory.exemplar:lending-tokenized-screen",
+            },
+          ]),
+        }),
+        expect.objectContaining({
+          ref: "composition.pattern:tokenized-ui-color",
+          kind: "composition",
+        }),
+        expect.objectContaining({
+          ref: "inventory.exemplar:lending-tokenized-screen",
+          kind: "inventory",
+          path: "Code/Features/Lending/LendingUI",
+          why_selected: expect.arrayContaining([
+            { kind: "path", value: "Code/Features/Lending/LendingUI" },
+            { kind: "scope", value: "lending" },
+            { kind: "surface_type", value: "native-feature" },
+          ]),
+        }),
+        expect.objectContaining({
+          ref: "validate.check:no-hardcoded-ui-color",
+          kind: "validation",
+        }),
+      ]),
     );
-    expect(json.selected_context.guidance.inspect).toEqual(
+    expect(
+      json.selected_context.context_hits.map((hit: { ref: string }) => hit.ref),
+    ).not.toContain("validate.check:candidate-density-check");
+    expect(json.selected_context.suggested_reads).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           path: "Code/Features/Lending/LendingUI",
@@ -1857,23 +1893,8 @@ checks:
         }),
       ]),
     );
-    expect(json.selected_context.guidance.validate).toContain(
-      "validate.check:no-hardcoded-ui-color - serious: Use design tokens for UI color",
-    );
-    expect(json.selected_context.guidance.validate.join("\n")).not.toContain(
-      "candidate-density-check",
-    );
-    expect(json.selected_context.intent[0].ref).toBe(
-      "intent.principle:tokenized-ui-color",
-    );
-    expect(json.selected_context.composition[0].ref).toBe(
-      "composition.pattern:tokenized-ui-color",
-    );
-    expect(json.selected_context.validation[0].ref).toBe(
-      "validate.check:no-hardcoded-ui-color",
-    );
     expect(json.brief).toContain("# Ghost Relay Brief");
-    expect(json.brief).toContain("## Intent");
+    expect(json.brief).toContain("## Context Hits");
   });
 
   it("ignores memory-dir when gathering Relay context from an exact package", async () => {
@@ -2067,12 +2088,7 @@ checks:
     expect(result.stdout).toContain("### Selected Context");
     expect(result.stdout).toContain("#### Stack");
     expect(result.stdout).toContain("#### Match");
-    expect(result.stdout).toContain("#### Intent");
-    expect(result.stdout).toContain("#### Active Obligations");
-    expect(result.stdout).toContain("#### Composition");
-    expect(result.stdout).toContain("#### Inventory");
-    expect(result.stdout).toContain("#### Validation");
-    expect(result.stdout).toContain("#### Guidance");
+    expect(result.stdout).toContain("#### Context Hits");
     expect(result.stdout).toContain("#### Suggested Reads");
     expect(result.stdout).toContain("#### Omissions");
     expect(result.stdout).toContain("#### Gaps");

--- a/packages/ghost/test/relay.test.ts
+++ b/packages/ghost/test/relay.test.ts
@@ -24,7 +24,7 @@ describe("relay", () => {
       target: "apps/refunds/settings/page.tsx",
     });
 
-    expect(result.schema).toBe("ghost.relay.gather/v1");
+    expect(result.schema).toBe("ghost.relay.gather/v2");
     expect(result.source.kind).toBe("stack");
     expect(result.targetPaths).toEqual(["apps/refunds/settings/page.tsx"]);
     expect(result.selected_context.match.status).toBe("path-match");
@@ -32,20 +32,43 @@ describe("relay", () => {
       "refund-settings",
     ]);
     expect(result.selected_context.stack).toHaveLength(1);
-    expect(result.selected_context.intent.map((node) => node.ref)).toContain(
-      "intent.principle:refund-trust",
+    expect(result.selected_context.context_hits).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ref: "intent.principle:refund-trust",
+          kind: "intent",
+          why_selected: expect.arrayContaining([
+            { kind: "scope", value: "refund-settings" },
+          ]),
+        }),
+        expect.objectContaining({
+          ref: "composition.pattern:refund-disclosure",
+          kind: "composition",
+          why_selected: expect.arrayContaining([
+            { kind: "scope", value: "refund-settings" },
+          ]),
+        }),
+        expect.objectContaining({
+          ref: "validate.check:no-hardcoded-ui-color",
+          kind: "validation",
+          why_selected: expect.arrayContaining([
+            { kind: "path", value: "apps/refunds/settings/page.tsx" },
+          ]),
+        }),
+      ]),
     );
-    expect(
-      result.selected_context.composition.map((node) => node.ref),
-    ).toContain("composition.pattern:refund-disclosure");
-    expect(
-      result.selected_context.validation.map((node) => node.ref),
-    ).toContain("validate.check:no-hardcoded-ui-color");
     expect(result.brief).toContain("# Ghost Relay Brief");
-    expect(result.brief).toContain("## Intent");
+    expect(result.brief).toContain("## Context Hits");
     expect(result.brief).toContain("intent.principle:refund-trust");
+    expect(result.brief).toContain("why: scope=refund-settings");
     expect(result).not.toHaveProperty("entrypoint");
     expect(result).not.toHaveProperty("cascade_brief");
+    expect(result.selected_context).not.toHaveProperty("intent");
+    expect(result.selected_context).not.toHaveProperty("composition");
+    expect(result.selected_context).not.toHaveProperty("inventory");
+    expect(result.selected_context).not.toHaveProperty("validation");
+    expect(result.selected_context).not.toHaveProperty("guidance");
+    expect(result.selected_context).not.toHaveProperty("active_obligations");
   });
 
   it("renders a three-package sparse posture stack in root-to-leaf order", async () => {
@@ -81,7 +104,9 @@ describe("relay", () => {
     expect(result.brief.indexOf("package 2: `")).toBeLessThan(
       result.brief.indexOf("leaf: `"),
     );
-    expect(result.selected_context.intent.map((node) => node.ref)).toEqual(
+    expect(
+      result.selected_context.context_hits.map((node) => node.ref),
+    ).toEqual(
       expect.arrayContaining([
         "intent.principle:protect-money-movement",
         "intent.principle:seller-operational-confidence",
@@ -114,7 +139,11 @@ describe("relay", () => {
       target: "app/settings/page.tsx",
     });
 
-    expect(result.selected_context.intent).toEqual([]);
+    expect(
+      result.selected_context.context_hits.filter(
+        (hit) => hit.kind === "intent",
+      ),
+    ).toEqual([]);
     expect(result.selected_context.posture).toMatchObject({
       product: "Settings Console",
       audience: ["operators"],
@@ -141,12 +170,54 @@ describe("relay", () => {
     expect(result.brief).toContain("Start from posture");
   });
 
+  it("records surface-type, linked-ref, and global-fallback hit reasons", async () => {
+    const root = await track(createSingleSurfaceSandbox());
+    const linkedRoot = await track(createLinkedReasonSandbox());
+
+    const result = await gatherRelayContext({
+      cwd: root,
+      target: "apps/refunds/settings/page.tsx",
+    });
+
+    expect(hitReasons(result, "intent.situation:refund-review")).toContainEqual(
+      { kind: "surface_type", value: "settings" },
+    );
+    const linked = await gatherRelayContext({
+      cwd: linkedRoot,
+      target: "app/page.tsx",
+    });
+    expect(
+      hitReasons(linked, "composition.pattern:linked-panel"),
+    ).toContainEqual({
+      kind: "linked_ref",
+      value: "intent.situation:settings-task",
+    });
+
+    const fallback = await gatherRelayContext({
+      cwd: root,
+      target: "apps/payroll/page.tsx",
+    });
+
+    expect(fallback.selected_context.match.status).toBe("global-fallback");
+    expect(fallback.selected_context.context_hits[0].why_selected).toEqual([
+      { kind: "global_fallback", value: "apps/payroll/page.tsx" },
+    ]);
+  });
+
   async function track(rootPromise: Promise<string>): Promise<string> {
     const root = await rootPromise;
     roots.push(root);
     return root;
   }
 });
+
+function hitReasons(
+  result: Awaited<ReturnType<typeof gatherRelayContext>>,
+  ref: string,
+) {
+  return result.selected_context.context_hits.find((hit) => hit.ref === ref)
+    ?.why_selected;
+}
 
 async function createThreeLayerPostureSandbox(): Promise<string> {
   const root = join(
@@ -261,6 +332,43 @@ checks:
       observed_count: 2
       examples:
         - review.tsx
+`,
+  );
+
+  return root;
+}
+
+async function createLinkedReasonSandbox(): Promise<string> {
+  const root = join(
+    tmpdir(),
+    `ghost-relay-linked-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await mkdir(join(root, "app"), { recursive: true });
+  await writeFile(join(root, "app", "page.tsx"), "");
+
+  await writeSplitFingerprintPackage(
+    join(root, ".ghost"),
+    `schema: ghost.fingerprint/v1
+intent:
+  summary:
+    product: Linked
+  situations:
+    - id: settings-task
+      user_intent: Change settings.
+      product_obligation: Keep linked panel visible.
+      surface_type: settings
+      patterns: [composition.pattern:linked-panel]
+inventory:
+  topology:
+    scopes:
+      - id: app
+        paths: [app]
+        surface_types: [settings]
+composition:
+  patterns:
+    - id: linked-panel
+      kind: layout
+      pattern: Keep the linked panel beside the settings task.
 `,
   );
 

--- a/scripts/check-terminology.mjs
+++ b/scripts/check-terminology.mjs
@@ -93,6 +93,8 @@ const ALLOWED_MEMORY_TERMS = [
   "memory/decisions",
 ];
 
+const ALLOWED_VERSION_MARKERS = ["ghost.relay.gather/v2"];
+
 const forbiddenPatterns = FORBIDDEN_PHRASES.map((phrase) => ({
   phrase,
   pattern: new RegExp(escapeRegExp(phrase), "i"),
@@ -108,6 +110,7 @@ for (const root of ROOTS) {
     lines.forEach((line, index) => {
       for (const { phrase, pattern } of forbiddenPatterns) {
         if (!pattern.test(line)) continue;
+        if (isAllowedTerminologyUse(line, phrase)) continue;
         violations.push({
           file,
           line: index + 1,
@@ -133,6 +136,13 @@ if (violations.length > 0) {
 }
 
 console.log("Terminology check passed.");
+
+function isAllowedTerminologyUse(line, phrase) {
+  if (phrase === "future version marker") {
+    return ALLOWED_VERSION_MARKERS.some((marker) => line.includes(marker));
+  }
+  return false;
+}
 
 function collectFiles(path) {
   const results = [];


### PR DESCRIPTION
**Category:** improvement
**Stack:** Stacked on #176 (`codex/selected-context-terminology`).
**User Impact:** Relay now gives host agents compact context hits with structured match reasons so they can decide what context to use next.
**Problem:** Relay still exposed several parallel selected-context arrays, which made the harness contract broader than the actual decision point. Agents need candidate context items, reasons, and routing support without Ghost over-prescribing how each hit should be used.
**Solution:** This changes Relay gather to `ghost.relay.gather/v2`, replaces the public grouped selected-context JSON with `context_hits`, records why each selected ref matched, and updates markdown, review packets, docs, and tests around the same routing model.

**Validation:**
- `pnpm --filter @anarchitecture/ghost test -- relay context-entrypoint cli`: passed
- `pnpm --filter @anarchitecture/ghost build`: passed
- `pnpm check`: passed
- `pnpm test`: passed, 37 files / 403 tests
- pre-push hook `pnpm build`, `pnpm test`, `pnpm check`: passed

**Changeset:** added `.changeset/relay-context-hits.md` as a minor change for the Relay JSON contract update.

**Ghost Review:**
- `node packages/ghost/dist/bin.js check --base codex/selected-context-terminology`: PASS, 0 findings
- `node packages/ghost/dist/bin.js review --base codex/selected-context-terminology`: emitted advisory packet successfully

<details>
<summary>File changes</summary>

**.changeset/relay-context-hits.md**
Adds the public package changeset for the v2 Relay context-hits contract.

**README.md**
Updates the Relay description to describe context hits, match reasons, suggested reads, omissions, and gaps.

**docs/generation-loop.md**
Updates generation guidance to start from selected context hits and their match reasons.

**docs/host-adapters.md**
Documents `ghost.relay.gather/v2` and the `context_hits` machine contract for host adapters.

**packages/ghost/src/context/entrypoint.ts**
Tracks selection reasons while resolving direct matches, one-hop linked refs, and global fallback refs.

**packages/ghost/src/context/graph.ts**
Exports the shared path-overlap helper so reason tracking uses the same path semantics as graph matching.

**packages/ghost/src/context/selected-context.ts**
Replaces public grouped selected-context JSON with `context_hits` and renders Relay/review markdown from those hits.

**packages/ghost/src/context/selection-reasons.ts**
Adds the structured selection-reason helpers for path, scope, surface type, linked ref, and global fallback matches.

**packages/ghost/src/relay.ts**
Bumps the Relay gather schema to `ghost.relay.gather/v2` and updates public type exports.

**packages/ghost/src/skill-bundle/references/review.md**
Updates review recipe language to use the context-hit model.

**packages/ghost/src/skill-bundle/references/verify.md**
Updates verification recipe language to use selected context hits.

**packages/ghost/test/cli.test.ts**
Updates CLI markdown and JSON assertions for v2, context hits, structured reasons, and review packet rendering.

**packages/ghost/test/relay.test.ts**
Adds Relay contract coverage for v2, removed grouped arrays, and all `why_selected` reason kinds.

**scripts/check-terminology.mjs**
Allows the new `ghost.relay.gather/v2` version marker in public terminology checks.

</details>

**Screenshots/Demos:** N/A; this is a CLI/API contract change.