### PR TITLE
fix: honor GHOST_PACKAGE_DIR in drift, ack, history, and review-command paths

### DIFF
--- a/.changeset/ghost-package-dir-everywhere.md
+++ b/.changeset/ghost-package-dir-everywhere.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": patch
+---
+
+Honor `GHOST_PACKAGE_DIR` in the drift, ack, diverge, compare-history, and review-command emit paths so relocated fingerprint packages resolve consistently.

--- a/packages/ghost/src/context/package-review-command.ts
+++ b/packages/ghost/src/context/package-review-command.ts
@@ -7,6 +7,7 @@ import type {
   GhostFingerprintPrinciple,
   GhostFingerprintSituation,
 } from "#ghost-core";
+import { resolveGhostDirDefault } from "../scan/index.js";
 import type { PackageContext } from "./package-context.js";
 
 export interface EmitPackageReviewInput {
@@ -285,7 +286,7 @@ Generated from \`${packageDir}/\` for ${context.name}. Re-run \`ghost emit revie
 }
 
 function displayPackageDir(context: PackageContext): string {
-  return displayPath(context.packageDir ?? ".ghost");
+  return displayPath(context.packageDir ?? resolveGhostDirDefault());
 }
 
 function displayPath(path: string): string {

--- a/packages/ghost/src/core/evolution/history.ts
+++ b/packages/ghost/src/core/evolution/history.ts
@@ -2,23 +2,24 @@ import { existsSync } from "node:fs";
 import { appendFile, mkdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import type { FingerprintHistoryEntry } from "#ghost-core";
+import { resolveGhostDirDefault } from "../../scan/index.js";
 
-const GHOST_DIR = ".ghost";
 const HISTORY_FILE = "history.jsonl";
 
 function historyPath(cwd: string): string {
-  return resolve(cwd, GHOST_DIR, HISTORY_FILE);
+  return resolve(cwd, resolveGhostDirDefault(), HISTORY_FILE);
 }
 
 /**
- * Append a fingerprint history entry to .ghost/history.jsonl.
- * Creates the .ghost directory if it doesn't exist.
+ * Append a fingerprint history entry to the fingerprint package's
+ * history.jsonl (honors GHOST_PACKAGE_DIR; defaults to .ghost).
+ * Creates the package directory if it doesn't exist.
  */
 export async function appendHistory(
   entry: FingerprintHistoryEntry,
   cwd: string = process.cwd(),
 ): Promise<void> {
-  const dir = resolve(cwd, GHOST_DIR);
+  const dir = resolve(cwd, resolveGhostDirDefault());
   if (!existsSync(dir)) {
     await mkdir(dir, { recursive: true });
   }
@@ -27,7 +28,7 @@ export async function appendHistory(
 }
 
 /**
- * Read all history entries from .ghost/history.jsonl.
+ * Read all history entries from the package history.jsonl.
  * Returns an empty array if no history exists.
  */
 export async function readHistory(

--- a/packages/ghost/src/drift-command.ts
+++ b/packages/ghost/src/drift-command.ts
@@ -15,6 +15,7 @@ import {
   resolveTrackedFingerprint,
 } from "./core/index.js";
 import { resolveFingerprintPackage } from "./fingerprint.js";
+import { resolveGhostDirDefault } from "./scan/index.js";
 
 const DEFAULT_SYNC_PATH = ".ghost-sync.json";
 const DRIFT_STATUS_SCHEMA = "ghost.drift.status/v1" as const;
@@ -243,14 +244,18 @@ async function loadLocalFingerprint(
   localPath: string | undefined,
   packageDir: string | undefined,
 ): Promise<Fingerprint> {
-  const source = localPath ?? packageDir ?? ".ghost";
+  const ghostDir = resolveGhostDirDefault();
+  const source = localPath ?? packageDir ?? ghostDir;
   try {
     return await loadComparableFingerprintFrom(cwd, source);
   } catch (err) {
     const defaultPackage = !localPath && !packageDir;
     const manifestPath = resolve(cwd, source, "manifest.yml");
     if (!defaultPackage || existsSync(manifestPath)) throw err;
-    return await loadComparableFingerprintFrom(cwd, ".ghost/fingerprint.md");
+    return await loadComparableFingerprintFrom(
+      cwd,
+      `${ghostDir}/fingerprint.md`,
+    );
   }
 }
 

--- a/packages/ghost/src/evolution-commands.ts
+++ b/packages/ghost/src/evolution-commands.ts
@@ -8,9 +8,10 @@ import {
   loadConfig,
   resolveTrackedFingerprint,
 } from "./core/index.js";
+import { resolveGhostDirDefault } from "./scan/index.js";
 
 async function loadLocalFingerprint() {
-  return loadComparableFingerprint(".ghost");
+  return loadComparableFingerprint(resolveGhostDirDefault());
 }
 
 async function loadTrackedComparableFingerprint(

--- a/packages/ghost/test/evolution/history-package-dir.test.ts
+++ b/packages/ghost/test/evolution/history-package-dir.test.ts
@@ -1,0 +1,47 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendHistory, readHistory } from "../../src/core/evolution/index.js";
+
+const ENV = "GHOST_PACKAGE_DIR";
+
+describe("history honors GHOST_PACKAGE_DIR", () => {
+  let cwd: string;
+  let prev: string | undefined;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), "ghost-history-"));
+    prev = process.env[ENV];
+  });
+
+  afterEach(async () => {
+    if (prev === undefined) delete process.env[ENV];
+    else process.env[ENV] = prev;
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  const entry = {
+    schema: "ghost.fingerprint.history/v1" as const,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    target: "self",
+  } as unknown as Parameters<typeof appendHistory>[0];
+
+  it("defaults to .ghost/history.jsonl", async () => {
+    delete process.env[ENV];
+    await appendHistory(entry, cwd);
+    expect(existsSync(join(cwd, ".ghost", "history.jsonl"))).toBe(true);
+    expect(await readHistory(cwd)).toHaveLength(1);
+  });
+
+  it("writes under the configured package dir (.agents/ghost)", async () => {
+    process.env[ENV] = ".agents/ghost";
+    await appendHistory(entry, cwd);
+    expect(existsSync(join(cwd, ".agents", "ghost", "history.jsonl"))).toBe(
+      true,
+    );
+    expect(existsSync(join(cwd, ".ghost", "history.jsonl"))).toBe(false);
+    expect(await readHistory(cwd)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Why

Ghost supports relocating the fingerprint package via `GHOST_PACKAGE_DIR` (documented in `SKILL.md` for host wrappers and nested packages). But several commands still hardcoded the literal `.ghost`, so they ignored the configured directory. A repo whose package lives at, say, `.agents/ghost/` works for `init`/`scan`/`lint`/`verify`/`check`/`review`, but silently breaks for `drift`, `ack`, `diverge`, `compare --temporal`, and the `emit review-command` footer.

This makes `GHOST_PACKAGE_DIR` resolution consistent across all local-package paths.

## What

Replace hardcoded local-package `.ghost` literals with `resolveGhostDirDefault()` (which honors `GHOST_PACKAGE_DIR` and falls back to `.ghost`):

- **`evolution-commands.ts`** — `loadLocalFingerprint()` resolves the configured dir (fixes `ack` / `diverge`).
- **`drift-command.ts`** — local source fallback and the legacy `fingerprint.md` fallback resolve the configured dir.
- **`core/evolution/history.ts`** — `appendHistory` / `readHistory` write and read `history.jsonl` under the configured dir (fixes `compare --temporal`).
- **`context/package-review-command.ts`** — the emit footer's display fallback uses the configured dir.

Intentionally **left as `.ghost`**:
- The `FINGERPRINT_PACKAGE_DIR` constants — that *is* the upstream default `resolveGhostDirDefault()` returns when unset.
- `node_modules/<pkg>/.ghost` lookups — published npm packages ship their fingerprint at `.ghost`; a consumer's `GHOST_PACKAGE_DIR` does not apply to dependencies.

## Tests

- New `test/evolution/history-package-dir.test.ts`: history writes to `.ghost` by default and to `.agents/ghost` when `GHOST_PACKAGE_DIR` is set (and not to `.ghost`).
- Full suite green: **411 tests passed**.
- `pnpm check` green (biome, typecheck, file-size, docs, bundle, CLI manifest).
- Manual: `GHOST_PACKAGE_DIR=.agents/ghost ghost init` then `ghost ack` resolves the package from `.agents/ghost` (previously failed looking in `.ghost`); plain `ghost init` still defaults to `.ghost`.

Generated with Goose
