### PR TITLE
Fix Pages deploy: point workflow and lockfile at renamed vessel-react package

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Build Ghost CLI package
         run: pnpm --filter @design-intelligence/ghost build
 
-      - name: Build ghost-ui library
-        run: pnpm --filter @design-intelligence/vessel build:lib
+      - name: Build vessel-react library
+        run: pnpm --filter @design-intelligence/vessel-react build:lib
 
       - name: Build shadcn registry
-        run: pnpm --filter @design-intelligence/vessel build:registry
+        run: pnpm --filter @design-intelligence/vessel-react build:registry
 
       - name: Build docs site (base=/ghost/)
         env:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
     dependencies:
       '@design-intelligence/vessel-react':
         specifier: workspace:*
-        version: link:../../packages/vessel
+        version: link:../../packages/vessel-react
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.1.0))
@@ -315,6 +315,8 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+
+  packages/steering-eval: {}
 
   packages/vessel-react:
     dependencies:


### PR DESCRIPTION
The Pages deploy workflow ([run 29028833507](https://github.com/block/ghost/actions/runs/29028833507/job/86155797526)) failed because `apps/docs` couldn't resolve `@design-intelligence/vessel-react` after the package was renamed from `packages/vessel` in #207.

Two stale references:
- **`pnpm-lock.yaml`** still linked `ghost-docs` → `link:../../packages/vessel`, so `pnpm install --frozen-lockfile` created a dangling symlink and `tsc` failed with TS2307.
- **`.github/workflows/deploy-pages.yml`** filtered on the old package name `@design-intelligence/vessel` for the `build:lib` and `build:registry` steps.

Verified locally: `DEPLOY_BASE=/ghost/ pnpm --filter ghost-docs build` now passes after a clean `pnpm install --frozen-lockfile`.