### PR TITLE
fix: serialize pre-push hook to avoid dist/ race

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,12 +7,10 @@ pre-commit:
     test:
       run: just test
 
+# Serial on purpose: `just check` (via check:packed-package) and `just build`
+# both rebuild packages/ghost/dist while `just test` runs the CLI tests against
+# dist/bin.js. Running them in parallel races on dist/ and fails flakily.
 pre-push:
-  parallel: true
   commands:
-    check:
-      run: just check
-    test:
-      run: just test
-    build:
-      run: just build
+    ci:
+      run: just ci


### PR DESCRIPTION
**Category:** infrastructure
**User Impact:** Contributors no longer hit flaky pre-push failures caused by parallel hook commands racing on build output.
**Problem:** The pre-push hook ran `check`, `test`, and `build` with `parallel: true`. Both `just check` (via `check:packed-package`) and `just build` rebuild `packages/ghost/dist` while `just test` runs CLI tests against `dist/bin.js`, so pushes failed flakily on tests that pass in isolation. This bit during the docs pass in #216, which had to push with `--no-verify`.
**Solution:** Replace the three parallel commands with one serial `just ci` (check → test → build, already defined in the justfile), with a comment explaining why serial is deliberate.

**Validation:**
- `git push`: pre-push hook ran the serialized `just ci` end to end and passed (this branch's own push)
- pre-commit hook (check + test): passed on commit

**Changeset:** not needed — repo hook config only; nothing ships through `@design-intelligence/ghost`.

**Ghost Review:**
- `ghost check` / `ghost review`: not run — no fingerprint-claimed surface touched.

<details>
<summary>File changes</summary>

**lefthook.yml**
Pre-push: drop `parallel: true` and the three separate commands; run `just ci` serially. Comment documents the dist/ race so nobody re-parallelizes it later.

</details>

**Screenshots/Demos:** N/A
