### PR TITLE
Add path override flags to Ghost stance commands

### DIFF
--- a/.changeset/stance-path-flags.md
+++ b/.changeset/stance-path-flags.md
@@ -1,0 +1,5 @@
+---
+"@anarchitecture/ghost": minor
+---
+
+ghost ack and ghost diverge accept --tracked, --local, and --sync path flags, matching ghost drift check, so stance verbs work without a ghost.config file.

--- a/apps/docs/src/generated/cli-manifest.json
+++ b/apps/docs/src/generated/cli-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-17T18:35:34.326Z",
+  "generatedAt": "2026-07-09T21:11:25.823Z",
   "tools": [
     {
       "tool": "ghost",
@@ -482,6 +482,30 @@
               "negated": false
             },
             {
+              "rawName": "--local <path>",
+              "name": "local",
+              "description": "Local fingerprint or bundle (default: .ghost)",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--tracked <path>",
+              "name": "tracked",
+              "description": "Tracked/reference fingerprint or bundle (overrides config tracks)",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--sync <path>",
+              "name": "sync",
+              "description": "Sync manifest path (default: ./.ghost-sync.json)",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
               "rawName": "--format <fmt>",
               "name": "format",
               "description": "Output format: cli or json",
@@ -541,6 +565,30 @@
               "rawName": "-r, --reason <text>",
               "name": "reason",
               "description": "Why this dimension is intentionally diverging",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--local <path>",
+              "name": "local",
+              "description": "Local fingerprint or bundle (default: .ghost)",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--tracked <path>",
+              "name": "tracked",
+              "description": "Tracked/reference fingerprint or bundle (overrides config tracks)",
+              "default": null,
+              "takesValue": true,
+              "negated": false
+            },
+            {
+              "rawName": "--sync <path>",
+              "name": "sync",
+              "description": "Sync manifest path (default: ./.ghost-sync.json)",
               "default": null,
               "takesValue": true,
               "negated": false

--- a/packages/ghost/src/core/evolution/sync.ts
+++ b/packages/ghost/src/core/evolution/sync.ts
@@ -13,31 +13,33 @@ import { compareFingerprints } from "#ghost-core";
 
 const SYNC_FILENAME = ".ghost-sync.json";
 
-function syncPath(cwd: string): string {
-  return resolve(cwd, SYNC_FILENAME);
+function syncPath(cwd: string, override?: string): string {
+  return resolve(cwd, override ?? SYNC_FILENAME);
 }
 
 /**
- * Read the sync manifest from .ghost-sync.json.
+ * Read the sync manifest from .ghost-sync.json (or an explicit path).
  * Returns null if no manifest exists.
  */
 export async function readSyncManifest(
   cwd: string = process.cwd(),
+  syncPathOverride?: string,
 ): Promise<SyncManifest | null> {
-  const path = syncPath(cwd);
+  const path = syncPath(cwd, syncPathOverride);
   if (!existsSync(path)) return null;
   const data = await readFile(path, "utf-8");
   return JSON.parse(data) as SyncManifest;
 }
 
 /**
- * Write the sync manifest to .ghost-sync.json.
+ * Write the sync manifest to .ghost-sync.json (or an explicit path).
  */
 export async function writeSyncManifest(
   manifest: SyncManifest,
   cwd: string = process.cwd(),
+  syncPathOverride?: string,
 ): Promise<string> {
-  const path = syncPath(cwd);
+  const path = syncPath(cwd, syncPathOverride);
   await writeFile(path, JSON.stringify(manifest, null, 2), "utf-8");
   return path;
 }
@@ -59,13 +61,15 @@ export async function acknowledge(opts: {
   reason?: string;
   tolerance?: number;
   cwd?: string;
+  /** Explicit sync manifest path (default: <cwd>/.ghost-sync.json). */
+  syncPath?: string;
 }): Promise<{ manifest: SyncManifest; comparison: FingerprintComparison }> {
   const cwd = opts.cwd ?? process.cwd();
   const comparison = compareFingerprints(opts.tracked, opts.local);
   const now = new Date().toISOString();
 
   // Load existing manifest to preserve previous acks
-  const existing = await readSyncManifest(cwd);
+  const existing = await readSyncManifest(cwd, opts.syncPath);
 
   const dimensions: Record<string, DimensionAck> = {};
 
@@ -99,7 +103,7 @@ export async function acknowledge(opts: {
     overallDistance: comparison.distance,
   };
 
-  await writeSyncManifest(manifest, cwd);
+  await writeSyncManifest(manifest, cwd, opts.syncPath);
 
   return { manifest, comparison };
 }

--- a/packages/ghost/src/evolution-commands.ts
+++ b/packages/ghost/src/evolution-commands.ts
@@ -9,8 +9,30 @@ import {
   resolveTrackedFingerprint,
 } from "./core/index.js";
 
-async function loadLocalFingerprint() {
-  return loadComparableFingerprint(".ghost");
+const DEFAULT_SYNC_PATH = ".ghost-sync.json";
+
+async function loadLocalFingerprint(localPath?: string) {
+  return loadComparableFingerprint(localPath ?? ".ghost");
+}
+
+// resolveTracks gives ack/diverge the same escape hatch drift check already
+// has: an explicit --tracked path wins over ghost.config.* `tracks`, so stance
+// verbs work in every invocation pattern the drift gate accepts. Throws when
+// neither is available; the command's catch handler prints and exits 2.
+async function resolveTracks(opts: {
+  tracked?: string;
+  config?: string;
+}): Promise<Target> {
+  if (opts.tracked) {
+    return { type: "path", value: opts.tracked };
+  }
+  const config = await loadConfig(opts.config);
+  if (!config.tracks) {
+    throw new Error(
+      "No tracked fingerprint declared. Set `tracks` in ghost.config.ts or pass --tracked <path>.",
+    );
+  }
+  return config.tracks;
 }
 
 async function loadTrackedComparableFingerprint(
@@ -42,30 +64,28 @@ export function registerAckCommand(cli: CAC): void {
       default: "accepted",
     })
     .option("--reason <text>", "Reason for this acknowledgment")
+    .option("--local <path>", "Local fingerprint or bundle (default: .ghost)")
+    .option(
+      "--tracked <path>",
+      "Tracked/reference fingerprint or bundle (overrides config tracks)",
+    )
+    .option("--sync <path>", "Sync manifest path (default: ./.ghost-sync.json)")
     .option("--format <fmt>", "Output format: cli or json", { default: "cli" })
     .action(async (opts) => {
       try {
-        const config = await loadConfig(opts.config);
-
-        if (!config.tracks) {
-          console.error(
-            "Error: No tracked fingerprint declared. Set `tracks` in ghost.config.ts.",
-          );
-          process.exit(2);
-        }
-
-        const trackedFingerprint = await loadTrackedComparableFingerprint(
-          config.tracks,
-        );
-        const localFingerprint = await loadLocalFingerprint();
+        const tracks = await resolveTracks(opts);
+        const trackedFingerprint =
+          await loadTrackedComparableFingerprint(tracks);
+        const localFingerprint = await loadLocalFingerprint(opts.local);
 
         const { manifest, comparison } = await acknowledge({
           local: localFingerprint,
           tracked: trackedFingerprint,
-          tracks: config.tracks,
+          tracks,
           dimension: opts.dimension,
           stance: opts.stance as DimensionStance,
           reason: opts.reason,
+          syncPath: opts.sync,
         });
 
         if (opts.format === "json") {
@@ -89,7 +109,7 @@ export function registerAckCommand(cli: CAC): void {
             );
           }
           console.log();
-          console.log("Written to .ghost-sync.json");
+          console.log(`Written to ${opts.sync ?? DEFAULT_SYNC_PATH}`);
         }
 
         process.exit(0);
@@ -159,30 +179,28 @@ export function registerDivergeCommand(cli: CAC): void {
       "-r, --reason <text>",
       "Why this dimension is intentionally diverging",
     )
+    .option("--local <path>", "Local fingerprint or bundle (default: .ghost)")
+    .option(
+      "--tracked <path>",
+      "Tracked/reference fingerprint or bundle (overrides config tracks)",
+    )
+    .option("--sync <path>", "Sync manifest path (default: ./.ghost-sync.json)")
     .option("--format <fmt>", "Output format: cli or json", { default: "cli" })
     .action(async (dimension: string, opts) => {
       try {
-        const config = await loadConfig(opts.config);
-
-        if (!config.tracks) {
-          console.error(
-            "Error: No tracked fingerprint declared. Set `tracks` in ghost.config.ts.",
-          );
-          process.exit(2);
-        }
-
-        const trackedFingerprint = await loadTrackedComparableFingerprint(
-          config.tracks,
-        );
-        const localFingerprint = await loadLocalFingerprint();
+        const tracks = await resolveTracks(opts);
+        const trackedFingerprint =
+          await loadTrackedComparableFingerprint(tracks);
+        const localFingerprint = await loadLocalFingerprint(opts.local);
 
         const { manifest } = await acknowledge({
           local: localFingerprint,
           tracked: trackedFingerprint,
-          tracks: config.tracks,
+          tracks,
           dimension,
           stance: "diverging",
           reason: opts.reason,
+          syncPath: opts.sync,
         });
 
         const ack = manifest.dimensions[dimension];
@@ -198,7 +216,7 @@ export function registerDivergeCommand(cli: CAC): void {
             console.log(`  Reason: ${opts.reason}`);
           }
           console.log();
-          console.log("Updated .ghost-sync.json");
+          console.log(`Updated ${opts.sync ?? DEFAULT_SYNC_PATH}`);
         }
 
         process.exit(0);

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -344,6 +344,80 @@ describe("ghost CLI", () => {
     expect(manifest.dimensions.typography.reason).toBe("editorial");
   });
 
+  it("ack and diverge accept --tracked/--local/--sync without a ghost config", async () => {
+    await mkdir(join(dir, "app", ".ghost"), { recursive: true });
+    await writeFile(
+      join(dir, "app", ".ghost", "fingerprint.md"),
+      fingerprintWithId("local"),
+    );
+    await writeFile(
+      join(dir, "tracked.fingerprint.md"),
+      fingerprintWithId("tracked"),
+    );
+
+    const ack = await runCli(
+      [
+        "ack",
+        "--tracked",
+        "tracked.fingerprint.md",
+        "--local",
+        "app/.ghost",
+        "--sync",
+        "app/.ghost-sync.json",
+        "--stance",
+        "aligned",
+        "--reason",
+        "baseline",
+        "--format",
+        "json",
+      ],
+      dir,
+    );
+    const diverge = await runCli(
+      [
+        "diverge",
+        "typography",
+        "--tracked",
+        "tracked.fingerprint.md",
+        "--local",
+        "app/.ghost",
+        "--sync",
+        "app/.ghost-sync.json",
+        "--reason",
+        "editorial",
+        "--format",
+        "json",
+      ],
+      dir,
+    );
+
+    expect(ack.code).toBe(0);
+    expect(JSON.parse(ack.stdout).trackedFingerprintId).toBe("tracked");
+    expect(diverge.code).toBe(0);
+    const manifest = JSON.parse(
+      await readFile(join(dir, "app", ".ghost-sync.json"), "utf-8"),
+    ) as Record<string, Record<string, Record<string, unknown>>>;
+    expect(manifest.tracks).toEqual({
+      type: "path",
+      value: "tracked.fingerprint.md",
+    });
+    expect(manifest.dimensions.typography.stance).toBe("diverging");
+    expect(manifest.dimensions.typography.reason).toBe("editorial");
+  });
+
+  it("ack without config or --tracked exits 2 with a --tracked hint", async () => {
+    await mkdir(join(dir, ".ghost"), { recursive: true });
+    await writeFile(
+      join(dir, ".ghost", "fingerprint.md"),
+      fingerprintWithId("local"),
+    );
+
+    const ack = await runCli(["ack", "--format", "json"], dir);
+
+    expect(ack.code).toBe(2);
+    expect(ack.stderr).toContain("--tracked");
+  });
+
   it("ack reads canonical fingerprint packages from config tracks", async () => {
     await writeCheckPackage(dir, { checks: false });
     await writeCheckPackage(join(dir, "tracked"), { checks: false });


### PR DESCRIPTION
🤖 Ryan's Agent speaking...

## Summary

- Add `--tracked`, `--local`, and `--sync` path flags to `ghost ack`
- Add the same path flags to `ghost diverge`
- Thread the explicit sync path through stance writes so the stance verbs have path parity with `ghost drift check`
- Regenerate the CLI manifest and add CLI coverage for the new flags

## Verification

- `pnpm build`
- `pnpm test` — 385 tests passed
- `pnpm check`

## Release note

Includes a minor changeset for `@anarchitecture/ghost` because this adds public CLI flags.
