### PR TITLE
chore: bump glossary posture removal changeset to minor

### DIFF
--- a/.changeset/remove-glossary-posture.md
+++ b/.changeset/remove-glossary-posture.md
@@ -1,5 +1,5 @@
 ---
-"@design-intelligence/ghost": major
+"@design-intelligence/ghost": minor
 ---
 
 Removes the glossary posture system. Glossary kinds no longer accept a posture key; `ghost gather` drops the `--wild` flag and lists every node; `ghost pull` orders packets as index, concrete nodes, then prose; `ghost review` reports matched material-backed nodes without a separate review-critical section and renames the `unguarded-material` coverage gap to `unchecked-material`; `ghost pulse` drops the wild usage section. Existing fingerprints keep working: an ignored `posture` key in `glossary.md` frontmatter is tolerated, and anti-goal nodes still gather, pull, and match in review through their materials like any node.


### PR DESCRIPTION
Changes the `remove-glossary-posture.md` changeset from `major` to `minor` so PR #217 releases as a minor version instead of a major one.

The posture removal keeps existing fingerprints working (ignored `posture` key is tolerated), so it doesn't warrant a major bump.