### PR TITLE
fix: preserve materials frontmatter in serializeNode

### DIFF
--- a/.changeset/serialize-node-materials.md
+++ b/.changeset/serialize-node-materials.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": patch
+---
+
+serializeNode preserves the materials frontmatter field instead of dropping it.

--- a/packages/ghost/src/ghost-core/node/serialize.ts
+++ b/packages/ghost/src/ghost-core/node/serialize.ts
@@ -3,8 +3,8 @@ import type { GhostNodeDocument, GhostNodeFrontmatter } from "./types.js";
 
 /**
  * Serialize a node back to its `---\n<yaml>\n---\n<body>` markdown form. Keys
- * are emitted in a stable order (description) so round-trips and diffs are
- * deterministic. Identity and kind are not serialized — they come from the
+ * are emitted in a stable order (description, materials) so round-trips and
+ * diffs are deterministic. Identity and kind are not serialized — they come from the
  * node's file path and optional filename prefix. Undefined fields are omitted; a node
  * with no frontmatter fields emits an empty block.
  */
@@ -12,6 +12,7 @@ export function serializeNode(node: GhostNodeDocument): string {
   const fm = node.frontmatter;
   const ordered: Record<string, unknown> = {};
   if (fm.description !== undefined) ordered.description = fm.description;
+  if (fm.materials !== undefined) ordered.materials = fm.materials;
 
   // An empty frontmatter object stringifies to "{}"; emit a bare block instead.
   const yaml =

--- a/packages/ghost/test/ghost-core/node-schema.test.ts
+++ b/packages/ghost/test/ghost-core/node-schema.test.ts
@@ -52,6 +52,23 @@ describe("ghost.node/v1 schema", () => {
     expect(reparsed.node?.body).toBe(original.body);
   });
 
+  it("round-trips materials frontmatter through serialize/parse", () => {
+    const original: GhostNodeDocument = {
+      frontmatter: {
+        description: "Checkout trust signals.",
+        materials: [
+          "src/components/checkout/**",
+          "https://example.com/logo.svg",
+        ],
+      },
+      body: "Near payment, reduce felt risk.",
+    };
+    const reparsed = parseNode(serializeNode(original));
+    expect(reparsed.report.errors).toBe(0);
+    expect(reparsed.node?.frontmatter).toEqual(original.frontmatter);
+    expect(reparsed.node?.body).toBe(original.body);
+  });
+
   it("round-trips an empty-frontmatter node", () => {
     const original: GhostNodeDocument = {
       frontmatter: {},


### PR DESCRIPTION
**Category:** fix
**User Impact:** Saving a Ghost node no longer silently deletes its `materials` frontmatter.
**Problem:** `serializeNode` emitted only `description` into frontmatter, so any serialize round-trip dropped a node's `materials` locators. A downstream consumer (Ether) verified this against the lib source and had to splice `materials` back in after serializing.
**Solution:** Emit `materials` after `description` in the stable key order, so round-trips are lossless and diffs stay deterministic.

**Validation:**
- `pnpm test`: 175 passed, 1 skipped (run in main checkout with identical diff; this worktree's install was blocked by a registry proxy issue)
- `pnpm check`: green
- Targeted `node-schema.test.ts` run: 13 passed, including the new materials round-trip test

**Changeset:** added (`patch`)

**Ghost Review:**
- `ghost check` / `ghost review`: not run because the change is a pure serialization fix in ghost-core with no UI or fingerprint surface impact

<details>
<summary>File changes</summary>

**packages/ghost/src/ghost-core/node/serialize.ts**
Emit `materials` into ordered frontmatter when defined; update the doc comment to reflect the stable key order.

**packages/ghost/test/ghost-core/node-schema.test.ts**
New round-trip test asserting `materials` (repo glob + HTTPS URL) survives serialize/parse.

**.changeset/serialize-node-materials.md**
Patch changeset for `@design-intelligence/ghost`.

</details>

**Screenshots/Demos:** N/A
