### PR TITLE
Make context the node retrieval field

### DIFF
--- a/.changeset/node-context-retrieval.md
+++ b/.changeset/node-context-retrieval.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": minor
+---
+
+Make `context` the canonical node retrieval field while reading `description` as a deprecated compatibility alias.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ deprecated read alias for one release, and `ghost validate` warns on its use.
 
 ```markdown
 ---
-context: Logo lockups, clearspace, and when the glyph can stand alone.
+context: Placing, sizing, or choosing a logo lockup or glyph.
 materials:
   - brand/logo*.svg
   - https://figma.com/file/example?node-id=logo-lockups

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ working context, the agent can see the shape of the brand without loading the
 whole package.
 
 `gather` and `pull` write a Git-ignored local log. Use `ghost pulse` to inspect
-it and tune node descriptions.
+it and tune node contexts.
 
 Run `ghost --help` for the core workflow and `ghost <command> --help` for
 current flags and command behavior.
@@ -107,12 +107,13 @@ repeatable commands for scaffolding, validation, retrieval, and review.
 The package is a **flat set of nodes**. The optional `cover:` in
 `manifest.yml` may name any node; `ghost gather` inlines it before the menu.
 The default skeleton calls that node `brand`, but the filename is not reserved.
-A node is one markdown file: a `description` in frontmatter, optional
-`materials`, and brand guidance in the prose body.
+A node is one markdown file: a `context` in frontmatter, optional
+`materials`, and brand guidance in the prose body. `description` remains a
+deprecated read alias for one release, and `ghost validate` warns on its use.
 
 ```markdown
 ---
-description: Logo lockups, clearspace, and when the glyph can stand alone.
+context: Logo lockups, clearspace, and when the glyph can stand alone.
 materials:
   - brand/logo*.svg
   - https://figma.com/file/example?node-id=logo-lockups

--- a/apps/docs/.ghost/anti-goal.generic-ai-product.md
+++ b/apps/docs/.ghost/anti-goal.generic-ai-product.md
@@ -1,5 +1,5 @@
 ---
-context: "Replacement for the generic AI-product visual median: spectacle and generic card chrome become an inspectable marked document with a specific flat squircle card language."
+context: Any visual surface at risk of generic AI-product spectacle or card chrome.
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/styles/marked-doc.css

--- a/apps/docs/.ghost/anti-goal.generic-ai-product.md
+++ b/apps/docs/.ghost/anti-goal.generic-ai-product.md
@@ -1,5 +1,5 @@
 ---
-description: "Replacement for the generic AI-product visual median: spectacle and generic card chrome become an inspectable marked document with a specific flat squircle card language."
+context: "Replacement for the generic AI-product visual median: spectacle and generic card chrome become an inspectable marked document with a specific flat squircle card language."
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/styles/marked-doc.css

--- a/apps/docs/.ghost/brand.md
+++ b/apps/docs/.ghost/brand.md
@@ -1,5 +1,5 @@
 ---
-description: "The ghost visual expression in one screen: an exact, quiet, visibly structured document with one meaningful mark."
+context: "The ghost visual expression in one screen: an exact, quiet, visibly structured document with one meaningful mark."
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/app/page.tsx

--- a/apps/docs/.ghost/brand.md
+++ b/apps/docs/.ghost/brand.md
@@ -1,5 +1,5 @@
 ---
-context: "The ghost visual expression in one screen: an exact, quiet, visibly structured document with one meaningful mark."
+context: Any expression of the ghost brand.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/app/page.tsx

--- a/apps/docs/.ghost/composition.md
+++ b/apps/docs/.ghost/composition.md
@@ -1,5 +1,5 @@
 ---
-context: Global composition model for margin, reading column, wider evidence, responsive collapse, and active empty space.
+context: Composing any ghost page or adapting its layout across viewport sizes.
 materials:
   - apps/docs/src/components/docs/docs-page-layout.tsx
   - apps/docs/src/components/docs/wrappers.tsx

--- a/apps/docs/.ghost/composition.md
+++ b/apps/docs/.ghost/composition.md
@@ -1,5 +1,5 @@
 ---
-description: Global composition model for margin, reading column, wider evidence, responsive collapse, and active empty space.
+context: Global composition model for margin, reading column, wider evidence, responsive collapse, and active empty space.
 materials:
   - apps/docs/src/components/docs/docs-page-layout.tsx
   - apps/docs/src/components/docs/wrappers.tsx

--- a/apps/docs/.ghost/exemplar.docs-site.md
+++ b/apps/docs/.ghost/exemplar.docs-site.md
@@ -1,5 +1,5 @@
 ---
-description: Gather when translating the ghost visual expression into another surface or medium and inspect the complete source expression.
+context: Gather when translating the ghost visual expression into another surface or medium and inspect the complete source expression.
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/components/docs/hero.tsx

--- a/apps/docs/.ghost/exemplar.docs-site.md
+++ b/apps/docs/.ghost/exemplar.docs-site.md
@@ -1,5 +1,5 @@
 ---
-context: Translating the ghost visual expression into another surface or medium — the complete source expression to imitate.
+context: Translating the ghost visual expression into another surface or medium.
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/components/docs/hero.tsx

--- a/apps/docs/.ghost/exemplar.docs-site.md
+++ b/apps/docs/.ghost/exemplar.docs-site.md
@@ -1,5 +1,5 @@
 ---
-context: Gather when translating the ghost visual expression into another surface or medium and inspect the complete source expression.
+context: Translating the ghost visual expression into another surface or medium — the complete source expression to imitate.
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/components/docs/hero.tsx

--- a/apps/docs/.ghost/mark.md
+++ b/apps/docs/.ghost/mark.md
@@ -1,5 +1,5 @@
 ---
-context: "Global rule for the yellow mark: it records selection, intervention, or active choice and never acts as general decoration."
+context: Using yellow, selection, intervention, or active-choice states.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/components/docs/gather-demo.tsx

--- a/apps/docs/.ghost/mark.md
+++ b/apps/docs/.ghost/mark.md
@@ -1,5 +1,5 @@
 ---
-description: "Global rule for the yellow mark: it records selection, intervention, or active choice and never acts as general decoration."
+context: "Global rule for the yellow mark: it records selection, intervention, or active choice and never acts as general decoration."
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/components/docs/gather-demo.tsx

--- a/apps/docs/.ghost/pattern.motion.md
+++ b/apps/docs/.ghost/pattern.motion.md
@@ -1,5 +1,5 @@
 ---
-description: Gather when anything moves, transitions, reveals in sequence, or changes position or emphasis.
+context: Gather when anything moves, transitions, reveals in sequence, or changes position or emphasis.
 materials:
   - apps/docs/src/components/docs/gather-demo.tsx
   - apps/docs/src/styles/marked-doc.css

--- a/apps/docs/.ghost/pattern.motion.md
+++ b/apps/docs/.ghost/pattern.motion.md
@@ -1,5 +1,5 @@
 ---
-context: Anything that moves, transitions, reveals in sequence, or changes position or emphasis — the motion vocabulary and when stillness wins.
+context: Anything that moves, transitions, reveals in sequence, or changes position or emphasis.
 materials:
   - apps/docs/src/components/docs/gather-demo.tsx
   - apps/docs/src/styles/marked-doc.css

--- a/apps/docs/.ghost/pattern.motion.md
+++ b/apps/docs/.ghost/pattern.motion.md
@@ -1,5 +1,5 @@
 ---
-context: Gather when anything moves, transitions, reveals in sequence, or changes position or emphasis.
+context: Anything that moves, transitions, reveals in sequence, or changes position or emphasis — the motion vocabulary and when stillness wins.
 materials:
   - apps/docs/src/components/docs/gather-demo.tsx
   - apps/docs/src/styles/marked-doc.css

--- a/apps/docs/.ghost/pattern.specimen.md
+++ b/apps/docs/.ghost/pattern.specimen.md
@@ -1,5 +1,5 @@
 ---
-context: Gather when a reader needs to inspect an example, table, code sample, comparison, palette, diagnostic, or interactive result.
+context: A reader inspecting an example, table, code sample, comparison, palette, diagnostic, or interactive result — the specimen frame that presents it as evidence.
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/components/docs/gather-demo.tsx

--- a/apps/docs/.ghost/pattern.specimen.md
+++ b/apps/docs/.ghost/pattern.specimen.md
@@ -1,5 +1,5 @@
 ---
-description: Gather when a reader needs to inspect an example, table, code sample, comparison, palette, diagnostic, or interactive result.
+context: Gather when a reader needs to inspect an example, table, code sample, comparison, palette, diagnostic, or interactive result.
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/components/docs/gather-demo.tsx

--- a/apps/docs/.ghost/pattern.specimen.md
+++ b/apps/docs/.ghost/pattern.specimen.md
@@ -1,5 +1,5 @@
 ---
-context: A reader inspecting an example, table, code sample, comparison, palette, diagnostic, or interactive result — the specimen frame that presents it as evidence.
+context: A reader needs to inspect an example, table, code sample, comparison, palette, diagnostic, or interactive result.
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/components/docs/gather-demo.tsx

--- a/apps/docs/.ghost/principles.md
+++ b/apps/docs/.ghost/principles.md
@@ -1,5 +1,5 @@
 ---
-description: Global visual principles for every ghost expression, independent of surface, medium, or implementation.
+context: Global visual principles for every ghost expression, independent of surface, medium, or implementation.
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/components/docs/docs-page-layout.tsx

--- a/apps/docs/.ghost/principles.md
+++ b/apps/docs/.ghost/principles.md
@@ -1,5 +1,5 @@
 ---
-context: Global visual principles for every ghost expression, independent of surface, medium, or implementation.
+context: Any ghost visual expression, independent of surface, medium, or implementation.
 materials:
   - apps/docs/src/app/page.tsx
   - apps/docs/src/components/docs/docs-page-layout.tsx

--- a/apps/docs/.ghost/visual-system.md
+++ b/apps/docs/.ghost/visual-system.md
@@ -1,5 +1,5 @@
 ---
-description: Global visual foundation for color, typography, spacing, shape, elevation, interaction, and accessibility.
+context: Global visual foundation for color, typography, spacing, shape, elevation, interaction, and accessibility.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/styles/docs.css

--- a/apps/docs/.ghost/visual-system.md
+++ b/apps/docs/.ghost/visual-system.md
@@ -1,5 +1,5 @@
 ---
-context: Global visual foundation for color, typography, spacing, shape, elevation, interaction, and accessibility.
+context: Choosing or implementing color, typography, spacing, shape, elevation, interaction, or accessibility for ghost.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/styles/docs.css

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -42,7 +42,7 @@ const guidanceExamples = [
     label: "visual decision",
     path: "pattern.crop-with-intent.md",
     body: `---
-context: A composition using photography — crop and focal-point guidance.
+context: A composition uses photography.
 materials:
   - brand/photography/**
 ---
@@ -58,7 +58,7 @@ Reject cautious full-object framing and collages that avoid choosing a focal poi
     label: "product pattern",
     path: "condition.blocked-progress.md",
     body: `---
-context: Someone cannot continue a task — explanation, recovery, and next-action guidance.
+context: Someone cannot continue a task.
 materials:
   - src/components/error-state/**
 ---
@@ -74,7 +74,7 @@ If the person cannot resolve the problem, state what happens next. Do not end on
     label: "exact material",
     path: "asset.color-roles.md",
     body: `---
-context: Assigning color — exact semantic roles and values.
+context: Assigning color.
 materials:
   - src/styles/brand-tokens.css
 ---

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -42,7 +42,7 @@ const guidanceExamples = [
     label: "visual decision",
     path: "pattern.crop-with-intent.md",
     body: `---
-context: Photography. Gather when a composition uses a photo.
+context: A composition using photography — crop and focal-point guidance.
 materials:
   - brand/photography/**
 ---
@@ -58,7 +58,7 @@ Reject cautious full-object framing and collages that avoid choosing a focal poi
     label: "product pattern",
     path: "condition.blocked-progress.md",
     body: `---
-context: Blocked progress. Gather when someone cannot continue a task.
+context: Someone cannot continue a task — explanation, recovery, and next-action guidance.
 materials:
   - src/components/error-state/**
 ---
@@ -74,7 +74,7 @@ If the person cannot resolve the problem, state what happens next. Do not end on
     label: "exact material",
     path: "asset.color-roles.md",
     body: `---
-context: Exact color roles and values. Gather before assigning color.
+context: Assigning color — exact semantic roles and values.
 materials:
   - src/styles/brand-tokens.css
 ---

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -27,8 +27,7 @@ const steeringDiagnoses = [
   {
     signal: "delivery gap",
     read: "the relevant guidance existed but did not reach the task",
-    repair:
-      "add the node, sharpen its description, or inspect why it was skipped",
+    repair: "add the node, sharpen its context, or inspect why it was skipped",
   },
   {
     signal: "correction gap",
@@ -43,7 +42,7 @@ const guidanceExamples = [
     label: "visual decision",
     path: "pattern.crop-with-intent.md",
     body: `---
-description: Photography. Gather when a composition uses a photo.
+context: Photography. Gather when a composition uses a photo.
 materials:
   - brand/photography/**
 ---
@@ -59,7 +58,7 @@ Reject cautious full-object framing and collages that avoid choosing a focal poi
     label: "product pattern",
     path: "condition.blocked-progress.md",
     body: `---
-description: Blocked progress. Gather when someone cannot continue a task.
+context: Blocked progress. Gather when someone cannot continue a task.
 materials:
   - src/components/error-state/**
 ---
@@ -75,7 +74,7 @@ If the person cannot resolve the problem, state what happens next. Do not end on
     label: "exact material",
     path: "asset.color-roles.md",
     body: `---
-description: Exact color roles and values. Gather before assigning color.
+context: Exact color roles and values. Gather before assigning color.
 materials:
   - src/styles/brand-tokens.css
 ---
@@ -247,14 +246,14 @@ export default function Home() {
             <p>
               Gather shows the complete menu before the agent chooses. If useful
               guidance does not reach the work, you can see whether the node was
-              missing, its description was unclear, or the agent skipped it.
+              missing, its context was unclear, or the agent skipped it.
             </p>
 
             <h3 className="pt-4 font-bold lowercase">efficiency</h3>
             <p>
-              Gather represents every node with a compact ID and description.
-              Pull loads the full prose and materials only for the selected
-              nodes. The agent sees the shape of the whole brand while keeping
+              Gather represents every node with a compact ID and context. Pull
+              loads the full prose and materials only for the selected nodes.
+              The agent sees the shape of the whole brand while keeping
               generation context small and free of unrelated instructions.
             </p>
           </div>
@@ -349,7 +348,7 @@ export default function Home() {
             </p>
             <p>
               Volume changes the work too. More instructions can flatten each
-              other until none of them wins. ghost favors compact descriptions,
+              other until none of them wins. ghost favors compact contexts,
               selective pulls, and material-backed detail so the important
               constraints are visible at the moment of making.
             </p>

--- a/apps/docs/src/components/docs/gather-demo.tsx
+++ b/apps/docs/src/components/docs/gather-demo.tsx
@@ -1,21 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const nodes = [
-  { id: "brand", context: "the cover: the whole brand on one page" },
-  { id: "voice", context: "anything with words; voice and tone" },
-  { id: "motion", context: "when and how things move on screen" },
+  { id: "brand", context: "any task that should express this brand" },
+  { id: "voice", context: "anything with words" },
+  { id: "motion", context: "anything that moves on screen" },
   {
     id: "email.transactional",
-    context: "when money moved and the reader is checking",
+    context: "money moved and the reader is checking",
   },
   {
     id: "layout.spacing",
-    context: "laying out a page; spacing logic",
+    context: "laying out a page",
   },
-  { id: "never.ai-defaults", context: "the AI defaults we refuse" },
+  { id: "never.ai-defaults", context: "any first-draft visual surface" },
   {
     id: "logo.usage",
-    context: "the mark, its clearspace, and where it may not appear",
+    context: "placing or sizing the mark",
   },
 ] as const;
 

--- a/apps/docs/src/components/docs/gather-demo.tsx
+++ b/apps/docs/src/components/docs/gather-demo.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 const nodes = [
   { id: "brand", context: "the cover: the whole brand on one page" },
-  { id: "voice", context: "how we talk; grab for anything with words" },
+  { id: "voice", context: "anything with words; voice and tone" },
   { id: "motion", context: "when and how things move on screen" },
   {
     id: "email.transactional",
@@ -10,7 +10,7 @@ const nodes = [
   },
   {
     id: "layout.spacing",
-    context: "spacing logic; grab before laying out a page",
+    context: "laying out a page; spacing logic",
   },
   { id: "never.ai-defaults", context: "the AI defaults we refuse" },
   {

--- a/apps/docs/src/components/docs/gather-demo.tsx
+++ b/apps/docs/src/components/docs/gather-demo.tsx
@@ -1,21 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const nodes = [
-  { id: "brand", description: "the cover: the whole brand on one page" },
-  { id: "voice", description: "how we talk; grab for anything with words" },
-  { id: "motion", description: "when and how things move on screen" },
+  { id: "brand", context: "the cover: the whole brand on one page" },
+  { id: "voice", context: "how we talk; grab for anything with words" },
+  { id: "motion", context: "when and how things move on screen" },
   {
     id: "email.transactional",
-    description: "when money moved and the reader is checking",
+    context: "when money moved and the reader is checking",
   },
   {
     id: "layout.spacing",
-    description: "spacing logic; grab before laying out a page",
+    context: "spacing logic; grab before laying out a page",
   },
-  { id: "never.ai-defaults", description: "the AI defaults we refuse" },
+  { id: "never.ai-defaults", context: "the AI defaults we refuse" },
   {
     id: "logo.usage",
-    description: "the mark, its clearspace, and where it may not appear",
+    context: "the mark, its clearspace, and where it may not appear",
   },
 ] as const;
 
@@ -118,7 +118,7 @@ export function GatherDemo() {
             >
               <div className="font-bold">{node.id}</div>
               <div>
-                {node.description}
+                {node.context}
                 {node.id === "brand" ? (
                   <span className="text-[var(--doc-middle)]">
                     {" "}

--- a/docs/purposes.md
+++ b/docs/purposes.md
@@ -38,13 +38,13 @@ into folders is a browsing convenience only.
 | `manifest.yml` | Schema version and package id; the package's anchor. |
 | `glossary.md` | The author's dictionary: every term with defined meaning in the corpus. ghost ships no fixed vocabulary. |
 | Prose nodes (`<kind>.<slug>.md`, `<slug>.md`) | Durable brand guidance; each body answers why (the stance), with what (the materials), or how it is assembled (the patterns). Altitude lives in prose; narrower guidance names its condition. |
-| Node frontmatter | `description` (retrieval payload) and optional `materials` (repo-relative paths/globs or supported external locators, with optional retrieval notes; see the schema reference for the supported schemes). |
+| Node frontmatter | `context` (retrieval payload) and optional `materials` (repo-relative paths/globs or supported external locators, with optional retrieval notes; see the schema reference for the supported schemes). |
 | `checks/` | Optional review assertions binding to nodes with `references`. Never a node source and never generation input. |
 
 One resolution mechanism, read-only:
 
-- **The menu.** `ghost gather` emits every node's id, kind, description, and
-  material count. The agent reads the ask against descriptions and pulls every
+- **The menu.** `ghost gather` emits every node's id, kind, context, and
+  material count. The agent reads the ask against contexts and pulls every
   node whose stated situation applies. ghost does no NLP and no selection.
 
 The optional `cover` in `manifest.yml` names the human-curated front door.
@@ -69,7 +69,7 @@ Two rules keep the reservation honest:
 | --- | --- | --- | --- | --- |
 | **Authoring** | `ghost init`, `ghost validate`, `ghost checks init` | The raw nodes, checks, and glossary for a human or agent writing the guidance. | the package | **No**, this is the model. |
 | **Generation** | `ghost gather [ask…]`, `ghost pull <ids>` | The flat menu, then selected node bodies and materials. | nodes only | **No** if selection stays with the agent and checks stay invisible. |
-| **Local signal** | `ghost pulse` | The gitignored event tape (`.ghost/.events`) written by `gather` and `pull`, used to tune descriptions and menu ergonomics. | event ids and miss suggestions | **No**, observability must not become ranking, memory, or canonical state. |
+| **Local signal** | `ghost pulse` | The gitignored event tape (`.ghost/.events`) written by `gather` and `pull`, used to tune contexts and menu ergonomics. | event ids and miss suggestions | **No**, observability must not become ranking, memory, or canonical state. |
 | **Diff review** | `ghost review` | Touched files matched to node `materials`, relevant checks, referenced prose, gaps, and the diff. | nodes, checks, diff | **No** if checks bind by `references` and are not gathered. |
 | **Fleet** | (future) | Many ghost packages at once: distances, cohorts, summaries. | many corpora, read-only | **No**, consumes exports read-only. |
 
@@ -78,7 +78,7 @@ Two rules keep the reservation honest:
 1. **Retrieval needs pushed into the shape.** When selection feels imprecise, the
    temptation is to encode routing in data: proliferating filename kinds until
    they become destinations, or turning the glossary into a dispatch table.
-   *Fix: `description` is the retrieval payload; sharpen descriptions, show the
+   *Fix: `context` is the retrieval payload; sharpen contexts, show the
    menu, let the agent pick.*
 
 2. **Filing by destination.** A node authored as `for-emails.md` smuggles a
@@ -109,7 +109,7 @@ Two rules keep the reservation honest:
 
 - **Not** reintroducing a graph: no hierarchy, inheritance, or cross-node edges.
 - **Not** adding a selection engine inside the artifact; the agent selects
-  against descriptions.
+  against contexts.
 - **Not** letting checks become generation input.
 - **Not** letting `materials` become an asset metadata schema.
 - **Not** giving any consumer write access to the shape of the corpus.

--- a/packages/context-control/README.md
+++ b/packages/context-control/README.md
@@ -6,9 +6,9 @@ measures whether the right guidance even makes it into context. Selection is
 the unit. No generation, ever.
 
 `ghost gather` does no filtering: the menu is always the whole catalog, and
-selection happens in the model's head against each node's `description`.
-So what this bench actually tests is whether descriptions are good enough
-retrieval payloads — a node with a vague description is invisible at
+selection happens in the model's head against each node's `context`.
+So what this bench actually tests is whether contexts are good enough
+retrieval payloads — a node with a vague context is invisible at
 selection time no matter how good its body is.
 
 ## Run
@@ -30,15 +30,15 @@ else `ghost` on PATH).
 ## Screens
 
 **package** — the catalog rendered as the selection surface the model
-sees: id, kind, description, material count, coverage line. Click a node to
-see its real `ghost pull` output in a drawer. Review descriptions as
-retrieval payloads, not file contents; a node with no description is flagged
+sees: id, kind, context, material count, coverage line. Click a node to
+see its real `ghost pull` output in a drawer. Review contexts as
+retrieval payloads, not file contents; a node with no context is flagged
 as invisible.
 
 **bench** — type an ask (or run the whole asks suite), fire N single-shot
 selection trials, and read the heatmap: nodes × asks, each cell the
 fraction of trials that selected the node. Solid column = confident
-description. Speckled = coin-flip. Empty row = dead node. Blue outline =
+context. Speckled = coin-flip. Empty row = dead node. Blue outline =
 the ask's expected set. Scores above the map: consistency (mean pairwise
 Jaccard), mean per-trial precision and recall, poison-selection rate, unknown
 ids, and nodes ever selected.

--- a/packages/context-control/lib/model.mjs
+++ b/packages/context-control/lib/model.mjs
@@ -9,7 +9,7 @@
 //   exists to expose. Use it to exercise the UI loop.
 //
 // - openai-compatible: a real LLM behind an OpenAI-compatible chat API.
-//   It sees the ask plus the menu (id, kind, description — exactly the
+//   It sees the ask plus the menu (id, kind, context — exactly the
 //   selection surface `ghost gather` emits) and returns node ids.
 
 const STOPWORDS = new Set([
@@ -60,7 +60,7 @@ export function fakeModel() {
       const selected = [];
       for (const entry of menu) {
         const nodeTokens = tokens(
-          [entry.id.replaceAll(/[.-]/g, " "), entry.kind, entry.description]
+          [entry.id.replaceAll(/[.-]/g, " "), entry.kind, entry.context]
             .filter(Boolean)
             .join(" "),
         );
@@ -85,14 +85,14 @@ const SELECT_SYSTEM = `You are an agent selecting brand guidance nodes for a tas
 following the ghost skill's recall recipe.
 
 You will get an ask, the cover already in context, and the ghost gather menu.
-Select only menu node ids against their descriptions. Do not select the cover.
+Select only menu node ids against their contexts. Do not select the cover.
 
-- Pull every node whose description indicates its stated situation applies and
+- Pull every node whose context indicates its stated situation applies and
   whose guidance, material, structure, or refusal governs the work.
 - Skip inapplicable nodes. Topic overlap alone is not applicability.
 - Do not add nodes for completeness or omit applicable nodes to meet a count.
 - Anti-goal nodes are review-critical negative space; pull each one whose
-  description names territory the ask enters.
+  context names territory the ask enters.
 
 Respond with ONLY a JSON array of node id strings, nothing else.`;
 
@@ -101,7 +101,7 @@ function selectUser(ask, menu, cover) {
     const flags = [entry.materials ? `${entry.materials} materials` : null]
       .filter(Boolean)
       .join(", ");
-    return `- ${entry.id}${entry.kind ? ` [${entry.kind}]` : ""}${flags ? ` (${flags})` : ""}: ${entry.description ?? "(no description)"}`;
+    return `- ${entry.id}${entry.kind ? ` [${entry.kind}]` : ""}${flags ? ` (${flags})` : ""}: ${entry.context ?? "(no context)"}`;
   });
   const coverLine = cover
     ? `Cover already in context: ${cover.id}\n\n${cover.body}\n\n`

--- a/packages/context-control/ui/index.html
+++ b/packages/context-control/ui/index.html
@@ -111,7 +111,7 @@
 <main>
   <section id="viewer">
     <table>
-      <thead><tr><th>id</th><th>kind</th><th>description — the retrieval payload</th></tr></thead>
+      <thead><tr><th>id</th><th>kind</th><th>context — the retrieval payload</th></tr></thead>
       <tbody id="menuRows"></tbody>
     </table>
   </section>
@@ -126,7 +126,7 @@
     </div>
     <div class="legend">
       Each column is one ask; each cell is the fraction of trials that selected the node.
-      Solid = confident description. Speckled = coin-flip. Empty row = invisible node.
+      Solid = confident context. Speckled = coin-flip. Empty row = invisible node.
       Blue outline = in the ask's expected set. The cover is already in context and
       is not part of the menu. Selection runs the ghost skill's recall protocol;
       live agents additionally carry task
@@ -168,12 +168,12 @@ async function loadMenu() {
   const c = data.coverage;
   $("#coverage").textContent =
     `${c.nodes} nodes · ${c.concrete} concrete` +
-    (c.undescribed ? ` · ${c.undescribed} undescribed` : "");
+    (c.withoutContext ? ` · ${c.withoutContext} without context` : "");
   $("#menuRows").innerHTML = state.menu.map((n) => `
     <tr class="node" data-id="${n.id}">
       <td class="id">${n.id}${n.materials ? `<span class="badge mat">${n.materials} mat</span>` : ""}</td>
       <td class="kind">${n.kind ?? ""}</td>
-      <td>${n.description ?? '<span style="color:var(--danger)">no description — invisible at selection time</span>'}</td>
+      <td>${n.context ?? '<span style="color:var(--danger)">no context — invisible at selection time</span>'}</td>
     </tr>`).join("");
   document.querySelectorAll("tr.node").forEach((row) => {
     row.onclick = () => openDrawer(row.dataset.id);
@@ -189,7 +189,7 @@ async function openDrawer(id) {
   const node = data.nodes?.[0];
   drawer.innerHTML = `<button class="close">close ×</button><h2>${id}</h2>` +
     (node
-      ? `<p style="color:var(--dim)">${node.description ?? ""}</p><hr style="border:0;border-top:1px solid var(--line)" />${escapeHtml(node.body)}`
+      ? `<p style="color:var(--dim)">${node.context ?? ""}</p><hr style="border:0;border-top:1px solid var(--line)" />${escapeHtml(node.body)}`
       : `<p class="flag">pull returned nothing (${escapeHtml(JSON.stringify(data))})</p>`);
   drawer.querySelector(".close").onclick = () => drawer.classList.add("hidden");
 }

--- a/packages/ghost/src/commands/gather-command.ts
+++ b/packages/ghost/src/commands/gather-command.ts
@@ -100,8 +100,8 @@ function menuCoverageLine(menu: GhostGatherResult): string {
     `${coverage.nodes} nodes`,
     `${coverage.concrete} carry payloads (${payloadParts.join(", ")})`,
   ];
-  if (coverage.undescribed > 0) {
-    parts.push(`${coverage.undescribed} lack descriptions`);
+  if (coverage.withoutContext > 0) {
+    parts.push(`${coverage.withoutContext} lack context`);
   }
   return parts.join(" · ");
 }
@@ -125,7 +125,7 @@ function formatMenuMarkdown(menu: GhostGatherResult): string {
   if (menu.ask) {
     lines.push(
       "Complete, unfiltered, unranked list from the ghost package. ghost has not selected nodes for this ask.",
-      "Pull every node whose description indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work. Skip inapplicable nodes. Topic overlap alone is not applicability. Do not add nodes for completeness or omit applicable nodes to meet a count.",
+      "Pull every node whose context indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work. Skip inapplicable nodes. Topic overlap alone is not applicability. Do not add nodes for completeness or omit applicable nodes to meet a count.",
       "Next: `ghost pull <id> [<id>…]`.",
       "If nothing applies, name the package's silence, follow the cover silence posture, and do not invent ghost-backed guidance.",
       "",
@@ -147,7 +147,7 @@ function formatMenuMarkdown(menu: GhostGatherResult): string {
   for (const entry of menu.nodes) {
     const kind = entry.kind ? ` _(${entry.kind})_` : "";
     lines.push(`- \`${entry.id}\`${kind}`);
-    if (entry.description) lines.push(`  - ${entry.description}`);
+    if (entry.context) lines.push(`  - ${entry.context}`);
     if (entry.materials !== undefined) {
       lines.push(`  - materials: ${entry.materials}`);
     }

--- a/packages/ghost/src/commands/pull-command.ts
+++ b/packages/ghost/src/commands/pull-command.ts
@@ -108,7 +108,9 @@ function formatPullJson(
     nodes: result.nodes.map((node) => ({
       id: node.id,
       ...(node.kind !== undefined ? { kind: node.kind } : {}),
-      ...(node.description ? { description: node.description } : {}),
+      ...(node.context
+        ? { context: node.context, description: node.context }
+        : {}),
       ...(node.declaredMaterials !== undefined
         ? {
             materials: inlineMaterials
@@ -127,7 +129,7 @@ function formatPullMarkdown(result: GhostPullResult): string {
   for (const node of result.nodes) {
     const kind = node.kind ? ` _(${node.kind})_` : "";
     const lines = [`# \`${node.id}\`${kind}`];
-    if (node.description) lines.push("", `> ${node.description}`);
+    if (node.context) lines.push("", `> ${node.context}`);
     lines.push("", node.body.trim());
     if (node.materials !== undefined && node.materials.length > 0) {
       lines.push("", "Materials:");

--- a/packages/ghost/src/embed/gather.ts
+++ b/packages/ghost/src/embed/gather.ts
@@ -62,7 +62,7 @@ export function gatherContract(ask: string | undefined): GhostGatherContract {
     selection: {
       basis: "applicability",
       instruction: ask
-        ? "Pull every node whose description indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work; skip inapplicable nodes."
+        ? "Pull every node whose context indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work; skip inapplicable nodes."
         : "Bare gather is catalog inspection. Do not treat the menu as task grounding until an ask is supplied; when grounding a task, pull every applicable node and skip inapplicable nodes.",
       topicOverlapAloneIsApplicability: false,
       addForCompleteness: false,
@@ -76,6 +76,9 @@ export function gatherContract(ask: string | undefined): GhostGatherContract {
 export function menuCoverage(
   menu: readonly CatalogMenuEntry[],
 ): GhostGatherCoverage {
+  const withoutContext = menu.filter(
+    (entry) => !entry.context || entry.context.trim().length === 0,
+  ).length;
   return {
     nodes: menu.length,
     concrete: menu.filter((entry) => entry.concrete).length,
@@ -84,9 +87,8 @@ export function menuCoverage(
       fencedExamples: menu.filter((entry) => entry.hasFencedExample).length,
       skeletons: menu.filter((entry) => entry.hasSkeleton).length,
     },
-    undescribed: menu.filter(
-      (entry) => !entry.description || entry.description.trim().length === 0,
-    ).length,
+    withoutContext,
+    undescribed: withoutContext,
   };
 }
 

--- a/packages/ghost/src/embed/pull.ts
+++ b/packages/ghost/src/embed/pull.ts
@@ -66,7 +66,9 @@ export async function pullGhostNodes(
     nodes: pulledNodes.map(({ node, materials }) => ({
       id: node.id,
       ...(node.kind !== undefined ? { kind: node.kind } : {}),
-      ...(node.description ? { description: node.description } : {}),
+      ...(node.context
+        ? { context: node.context, description: node.context }
+        : {}),
       ...(node.materials !== undefined
         ? { declaredMaterials: [...node.materials] }
         : {}),

--- a/packages/ghost/src/embed/types.ts
+++ b/packages/ghost/src/embed/types.ts
@@ -59,6 +59,8 @@ export interface GhostGatherCoverage {
     fencedExamples: number;
     skeletons: number;
   };
+  withoutContext: number;
+  /** @deprecated Use `withoutContext`. */
   undescribed: number;
 }
 
@@ -108,6 +110,8 @@ export interface GhostPulledSkeleton {
 export interface GhostPulledNode {
   id: string;
   kind?: string;
+  context?: string;
+  /** @deprecated Use `context`. Mirrors the resolved context for one release. */
   description?: string;
   declaredMaterials?: readonly GhostMaterial[];
   materials?: readonly TransportedMaterial[];

--- a/packages/ghost/src/ghost-core/catalog/assemble.ts
+++ b/packages/ghost/src/ghost-core/catalog/assemble.ts
@@ -35,6 +35,7 @@ export function assembleCatalog(input: AssembleCatalogInput): GhostCatalog {
 
   for (const placed of input.placedNodes ?? []) {
     const fm = placed.doc.frontmatter;
+    const context = fm.context ?? fm.description;
     const concrete = carriesConcreteMaterial({
       materials: fm.materials,
       body: placed.doc.body,
@@ -43,7 +44,10 @@ export function assembleCatalog(input: AssembleCatalogInput): GhostCatalog {
       id: placed.id,
       ...(placed.kind !== undefined ? { kind: placed.kind } : {}),
       slug: placed.slug ?? placed.id.split("/").pop() ?? placed.id,
-      ...(fm.description !== undefined ? { description: fm.description } : {}),
+      ...(context !== undefined ? { context, description: context } : {}),
+      ...(fm.description !== undefined
+        ? { usesDeprecatedDescription: true as const }
+        : {}),
       ...(fm.materials !== undefined ? { materials: fm.materials } : {}),
       concrete,
       hasFencedExample: hasSubstantialFencedExample(placed.doc.body),

--- a/packages/ghost/src/ghost-core/catalog/closest.ts
+++ b/packages/ghost/src/ghost-core/catalog/closest.ts
@@ -5,7 +5,7 @@
  * routing to nothing. This is that hint: deterministic, LLM-free, bounded.
  *
  * It is not a search engine. An inexact `gather <query>` shows the node menu
- * and lets the agent re-pick by description; this only nominates the few ids a
+ * and lets the agent re-pick by context; this only nominates the few ids a
  * typo most likely meant.
  */
 

--- a/packages/ghost/src/ghost-core/catalog/menu.ts
+++ b/packages/ghost/src/ghost-core/catalog/menu.ts
@@ -1,15 +1,17 @@
 import type { GhostCatalog } from "./types.js";
 
 /**
- * One entry in the gather menu: a node presented as `id` + `kind` +
- * `description`, the retrieval payload the agent selects against. The agent
- * matches a natural-language ask against these and pulls applicable nodes;
- * ghost does no NLP and no selection.
+ * One entry in the gather menu: a node presented as `id` + `kind` + `context`,
+ * the retrieval payload the agent selects against. The agent matches a
+ * natural-language ask against these and pulls applicable nodes; ghost does no
+ * NLP and no selection.
  */
 export interface CatalogMenuEntry {
   id: string;
   /** The node's kind (filename prefix), when it declares one. */
   kind?: string;
+  context?: string;
+  /** @deprecated Use `context`. Mirrors the resolved context for one release. */
   description?: string;
   /** Count of material locators available after pulling this node. */
   materials?: number;
@@ -22,8 +24,8 @@ export interface CatalogMenuEntry {
 }
 
 /**
- * Build the gather menu: every authored node, with its kind and description,
- * sorted by id for stable output. A flat catalog — no anchor, no hierarchy;
+ * Build the gather menu: every authored node, with its kind and context,
+ * sorted by id for stable output. A flat catalog with no anchor or hierarchy;
  * the agent selects from it.
  */
 export function buildCatalogMenu(catalog: GhostCatalog): CatalogMenuEntry[] {
@@ -33,7 +35,9 @@ export function buildCatalogMenu(catalog: GhostCatalog): CatalogMenuEntry[] {
     entries.push({
       id: node.id,
       ...(node.kind !== undefined ? { kind: node.kind } : {}),
-      ...(node.description ? { description: node.description } : {}),
+      ...(node.context
+        ? { context: node.context, description: node.context }
+        : {}),
       ...(node.materials !== undefined && node.materials.length > 0
         ? { materials: node.materials.length }
         : {}),

--- a/packages/ghost/src/ghost-core/catalog/types.ts
+++ b/packages/ghost/src/ghost-core/catalog/types.ts
@@ -13,7 +13,11 @@ export interface GhostCatalogNode {
   /** Filename slug: bare name, or the part after the first dot. */
   slug: string;
   /** Retrieval payload shown in gather: what applies, when, and what it contributes. */
+  context?: string;
+  /** @deprecated Use `context`. Mirrors the resolved context for one release. */
   description?: string;
+  /** Whether the authored frontmatter used the deprecated `description` key. */
+  usesDeprecatedDescription?: true;
   /** Optional bare or annotated material locators carried by the authored node. */
   materials?: GhostMaterial[];
   /** True when the node carries a material locator, substantial fence, or Skeleton. */

--- a/packages/ghost/src/ghost-core/catalog/types.ts
+++ b/packages/ghost/src/ghost-core/catalog/types.ts
@@ -12,7 +12,7 @@ export interface GhostCatalogNode {
   kind?: string;
   /** Filename slug: bare name, or the part after the first dot. */
   slug: string;
-  /** Retrieval payload shown in gather: what applies, when, and what it contributes. */
+  /** Retrieval payload shown in gather: the condition under which this node applies. */
   context?: string;
   /** @deprecated Use `context`. Mirrors the resolved context for one release. */
   description?: string;

--- a/packages/ghost/src/ghost-core/node/schema.ts
+++ b/packages/ghost/src/ghost-core/node/schema.ts
@@ -40,10 +40,12 @@ const AnnotatedMaterialSchema = z
  *
  * Validates a node in isolation. Identity and containment are not here: they
  * come from the node's file path. Kind is the filename prefix, never a
- * frontmatter field.
+ * frontmatter field. `description` is accepted as a deprecated read alias for
+ * `context`; consumers resolve `context` first when both are present.
  */
 export const GhostNodeFrontmatterSchema = z
   .object({
+    context: z.string().min(1).optional(),
     description: z.string().min(1).optional(),
     materials: z
       .array(z.union([MaterialLocatorSchema, AnnotatedMaterialSchema]))
@@ -56,7 +58,7 @@ export const GhostNodeFrontmatterSchema = z
   })
   // Passthrough, not strict: authors may add free-form descriptive keys
   // (e.g. `audience`, `stage`) that describe what the node is. ghost does not
-  // gate on them — they ride along as part of the node's descriptive surface.
+  // gate on them; they ride along as part of the node's descriptive surface.
   .passthrough();
 
 export { NodeIdSchema, NodeRefSchema };

--- a/packages/ghost/src/ghost-core/node/serialize.ts
+++ b/packages/ghost/src/ghost-core/node/serialize.ts
@@ -1,7 +1,7 @@
 import { stringify as stringifyYaml } from "yaml";
 import type { GhostNodeDocument, GhostNodeFrontmatter } from "./types.js";
 
-const FRONTMATTER_KEY_ORDER = ["description", "materials"] as const;
+const FRONTMATTER_KEY_ORDER = ["context", "materials"] as const;
 
 function shouldSerializeFrontmatterValue(value: unknown): boolean {
   return value !== undefined;
@@ -9,28 +9,38 @@ function shouldSerializeFrontmatterValue(value: unknown): boolean {
 
 /**
  * Serialize a node back to its `---\n<yaml>\n---\n<body>` markdown form. Known
- * keys are emitted first in a stable order (description, materials), followed
- * by any free-form descriptive keys in alphabetical order so round-trips and
- * diffs are deterministic. Identity and kind are not serialized — they come
- * from the node's file path and optional filename prefix. Undefined fields are
- * omitted; a node with no frontmatter fields emits an empty block.
+ * keys are emitted first in a stable order (context, materials), followed by
+ * any free-form descriptive keys in alphabetical order so round-trips and
+ * diffs are deterministic. The deprecated `description` alias is written as
+ * `context`, which makes serialize a safe migration boundary. Identity and kind
+ * are not serialized; they come from the node's file path and optional filename
+ * prefix. Undefined fields are omitted; a node with no frontmatter fields emits
+ * an empty block.
  */
 export function serializeNode(node: GhostNodeDocument): string {
   const fm = node.frontmatter as Record<string, unknown>;
+  const normalized: Record<string, unknown> = {
+    ...fm,
+    ...(fm.context === undefined && fm.description !== undefined
+      ? { context: fm.description }
+      : {}),
+  };
+  delete normalized.description;
+
   const ordered: Record<string, unknown> = {};
   const emitted = new Set<string>();
 
   for (const key of FRONTMATTER_KEY_ORDER) {
-    const value = fm[key];
+    const value = normalized[key];
     if (shouldSerializeFrontmatterValue(value)) {
       ordered[key] = value;
       emitted.add(key);
     }
   }
 
-  for (const key of Object.keys(fm).sort()) {
+  for (const key of Object.keys(normalized).sort()) {
     if (emitted.has(key)) continue;
-    const value = fm[key];
+    const value = normalized[key];
     if (shouldSerializeFrontmatterValue(value)) ordered[key] = value;
   }
 

--- a/packages/ghost/src/ghost-core/node/types.ts
+++ b/packages/ghost/src/ghost-core/node/types.ts
@@ -12,10 +12,10 @@ export interface GhostNodeFrontmatter {
   /** Free-form descriptive properties parsed from node frontmatter. */
   [key: string]: unknown;
   /**
-   * Retrieval payload shown by gather: what the node governs, the observable
-   * condition under which it applies, and what it contributes where useful.
-   * Together with the node's id, it is how an agent decides applicability.
-   * Optional, but strongly encouraged on any node worth anchoring a task at.
+   * Retrieval payload shown by gather: the observable condition under which
+   * this node applies. Together with the node's id, it is how an agent decides
+   * applicability. Optional, but strongly encouraged on any node worth
+   * anchoring a task at.
    */
   context?: string;
   /** @deprecated Use `context`. Accepted as a read alias for one release. */

--- a/packages/ghost/src/ghost-core/node/types.ts
+++ b/packages/ghost/src/ghost-core/node/types.ts
@@ -17,6 +17,8 @@ export interface GhostNodeFrontmatter {
    * Together with the node's id, it is how an agent decides applicability.
    * Optional, but strongly encouraged on any node worth anchoring a task at.
    */
+  context?: string;
+  /** @deprecated Use `context`. Accepted as a read alias for one release. */
   description?: string;
   /**
    * Optional locators for the concrete materials this guidance is about:

--- a/packages/ghost/src/init-payloads/median/cliche.median.md
+++ b/packages/ghost/src/init-payloads/median/cliche.median.md
@@ -1,5 +1,5 @@
 ---
-context: "Any greenfield visual surface or first-draft copy — the model's median defaults this package refuses. Each rule is reject→replace; delete lines your brand legitimately violates."
+context: Any greenfield visual surface or first-draft copy.
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/ghost/src/init-payloads/median/cliche.median.md
+++ b/packages/ghost/src/init-payloads/median/cliche.median.md
@@ -1,5 +1,5 @@
 ---
-context: "The model's median defaults this package refuses — gather for any greenfield visual surface or first-draft copy. Each rule is reject→replace; delete lines your brand legitimately violates."
+context: "Any greenfield visual surface or first-draft copy — the model's median defaults this package refuses. Each rule is reject→replace; delete lines your brand legitimately violates."
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/ghost/src/init-payloads/median/cliche.median.md
+++ b/packages/ghost/src/init-payloads/median/cliche.median.md
@@ -1,5 +1,5 @@
 ---
-description: "The model's median defaults this package refuses — gather for any greenfield visual surface or first-draft copy. Each rule is reject→replace; delete lines your brand legitimately violates."
+context: "The model's median defaults this package refuses — gather for any greenfield visual surface or first-draft copy. Each rule is reject→replace; delete lines your brand legitimately violates."
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/ghost/src/init-payloads/skeleton/brand.md
+++ b/packages/ghost/src/init-payloads/skeleton/brand.md
@@ -1,5 +1,5 @@
 ---
-context: "The brand on one page; what this brand is, how it feels, and what only it refuses."
+context: Any task that should express this brand.
 ---
 
 This cover is unwritten. ghost gather always places this page in an agent's

--- a/packages/ghost/src/init-payloads/skeleton/brand.md
+++ b/packages/ghost/src/init-payloads/skeleton/brand.md
@@ -1,5 +1,5 @@
 ---
-description: "The brand on one page; what this brand is, how it feels, and what only it refuses."
+context: "The brand on one page; what this brand is, how it feels, and what only it refuses."
 ---
 
 This cover is unwritten. ghost gather always places this page in an agent's

--- a/packages/ghost/src/init-payloads/skeleton/context.conversation.md
+++ b/packages/ghost/src/init-payloads/skeleton/context.conversation.md
@@ -1,5 +1,5 @@
 ---
-context: "AI conversation threads — assistant text on the page surface, compact user turns, collapsed tool calls, one structured prompt input. Read only for chat threads, agent consoles, and prompt composers."
+context: "Chat threads, agent consoles, and prompt composers — assistant text on the page surface, compact user turns, collapsed tool calls, one structured prompt input."
 ---
 
 In this context: AI conversation threads, agent consoles, review assistants,

--- a/packages/ghost/src/init-payloads/skeleton/context.conversation.md
+++ b/packages/ghost/src/init-payloads/skeleton/context.conversation.md
@@ -1,5 +1,5 @@
 ---
-context: "Chat threads, agent consoles, and prompt composers — assistant text on the page surface, compact user turns, collapsed tool calls, one structured prompt input."
+context: Chat threads, agent consoles, and prompt composers.
 ---
 
 In this context: AI conversation threads, agent consoles, review assistants,

--- a/packages/ghost/src/init-payloads/skeleton/context.conversation.md
+++ b/packages/ghost/src/init-payloads/skeleton/context.conversation.md
@@ -1,5 +1,5 @@
 ---
-description: "AI conversation threads — assistant text on the page surface, compact user turns, collapsed tool calls, one structured prompt input. Read only for chat threads, agent consoles, and prompt composers."
+context: "AI conversation threads — assistant text on the page surface, compact user turns, collapsed tool calls, one structured prompt input. Read only for chat threads, agent consoles, and prompt composers."
 ---
 
 In this context: AI conversation threads, agent consoles, review assistants,

--- a/packages/ghost/src/init-payloads/skeleton/foundation.color.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.color.md
@@ -1,5 +1,5 @@
 ---
-description: "Color — the role system, status meanings, expression rules, and misuse; palette values are an open question. Read before choosing any color."
+context: "Color — the role system, status meanings, expression rules, and misuse; palette values are an open question. Read before choosing any color."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.color.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.color.md
@@ -1,5 +1,5 @@
 ---
-context: "Choosing any color — the role system, status meanings, expression rules, and misuse; palette values are an open question."
+context: Choosing or applying color.
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.color.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.color.md
@@ -1,5 +1,5 @@
 ---
-context: "Color — the role system, status meanings, expression rules, and misuse; palette values are an open question. Read before choosing any color."
+context: "Choosing any color — the role system, status meanings, expression rules, and misuse; palette values are an open question."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
@@ -1,5 +1,5 @@
 ---
-context: "Composition — how a view is assembled: one focal point, one primary action, actions land last, separation escalates. Read before assembling any view."
+context: "Assembling any view — one focal point, one primary action, actions land last, separation escalates."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
@@ -1,5 +1,5 @@
 ---
-context: "Assembling any view — one focal point, one primary action, actions land last, separation escalates."
+context: Assembling any view.
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
@@ -1,5 +1,5 @@
 ---
-description: "Composition — how a view is assembled: one focal point, one primary action, actions land last, separation escalates. Read before assembling any view."
+context: "Composition — how a view is assembled: one focal point, one primary action, actions land last, separation escalates. Read before assembling any view."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
@@ -1,5 +1,5 @@
 ---
-context: "Controls — the five-rung emphasis ladder, quiet fields, and misuse. Read for any view with actions or inputs."
+context: "Any view with actions or inputs — the five-rung emphasis ladder, quiet fields, and misuse."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
@@ -1,5 +1,5 @@
 ---
-context: "Any view with actions or inputs — the five-rung emphasis ladder, quiet fields, and misuse."
+context: Any view with actions or inputs.
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
@@ -1,5 +1,5 @@
 ---
-description: "Controls — the five-rung emphasis ladder, quiet fields, and misuse. Read for any view with actions or inputs."
+context: "Controls — the five-rung emphasis ladder, quiet fields, and misuse. Read for any view with actions or inputs."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
@@ -1,5 +1,5 @@
 ---
-description: "Layout — stacks with five gap steps, surface roles, three elevation tiers, the two radius roles, and misuse; radius values are an open question. Read before laying anything out."
+context: "Layout — stacks with five gap steps, surface roles, three elevation tiers, the two radius roles, and misuse; radius values are an open question. Read before laying anything out."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
@@ -1,5 +1,5 @@
 ---
-context: "Laying out any view — stacks with five gap steps, surface roles, three elevation tiers, the two radius roles, and misuse; radius values are an open question."
+context: Laying out any view.
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
@@ -1,5 +1,5 @@
 ---
-context: "Layout — stacks with five gap steps, surface roles, three elevation tiers, the two radius roles, and misuse; radius values are an open question. Read before laying anything out."
+context: "Laying out any view — stacks with five gap steps, surface roles, three elevation tiers, the two radius roles, and misuse; radius values are an open question."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
@@ -1,5 +1,5 @@
 ---
-context: "Motion — evidence of state change, three durations and one ease, nothing loops, and misuse; the ease's character is an open question shared with voice. Read for any transition or hover treatment."
+context: "Any transition or hover treatment — evidence of state change, three durations and one ease, nothing loops, and misuse; the ease's character is an open question shared with voice."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
@@ -1,5 +1,5 @@
 ---
-context: "Any transition or hover treatment — evidence of state change, three durations and one ease, nothing loops, and misuse; the ease's character is an open question shared with voice."
+context: Any transition, animation, or hover treatment.
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
@@ -1,5 +1,5 @@
 ---
-description: "Motion — evidence of state change, three durations and one ease, nothing loops, and misuse; the ease's character is an open question shared with voice. Read for any transition or hover treatment."
+context: "Motion — evidence of state change, three durations and one ease, nothing loops, and misuse; the ease's character is an open question shared with voice. Read for any transition or hover treatment."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.type.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.type.md
@@ -1,5 +1,5 @@
 ---
-context: "Type — six text variants, seven tones, the one-voice rule, and misuse; the typeface is an open question. Read for any view that contains text."
+context: "Any view containing text — six text variants, seven tones, the one-voice rule, and misuse; the typeface is an open question."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.type.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.type.md
@@ -1,5 +1,5 @@
 ---
-context: "Any view containing text — six text variants, seven tones, the one-voice rule, and misuse; the typeface is an open question."
+context: Any view containing text.
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.type.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.type.md
@@ -1,5 +1,5 @@
 ---
-description: "Type — six text variants, seven tones, the one-voice rule, and misuse; the typeface is an open question. Read for any view that contains text."
+context: "Type — six text variants, seven tones, the one-voice rule, and misuse; the typeface is an open question. Read for any view that contains text."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
@@ -1,5 +1,5 @@
 ---
-context: "Any copy — facts without performed personality, and misuse; warmth is an open question shared with motion."
+context: Writing or editing any copy.
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
@@ -1,5 +1,5 @@
 ---
-description: "Voice and tone — copy states facts, no performed personality, and misuse; warmth is an open question shared with motion. Read for any copy."
+context: "Voice and tone — copy states facts, no performed personality, and misuse; warmth is an open question shared with motion. Read for any copy."
 ---
 
 ## Usage

--- a/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
@@ -1,5 +1,5 @@
 ---
-context: "Voice and tone — copy states facts, no performed personality, and misuse; warmth is an open question shared with motion. Read for any copy."
+context: "Any copy — facts without performed personality, and misuse; warmth is an open question shared with motion."
 ---
 
 ## Usage

--- a/packages/ghost/src/review/baseline.ts
+++ b/packages/ghost/src/review/baseline.ts
@@ -8,7 +8,7 @@ export interface BaselineProse {
   ref: string;
   nodeId: string;
   heading?: string;
-  description?: string;
+  context?: string;
   body: string;
   warning?: string;
 }
@@ -25,9 +25,7 @@ export function resolveBaseline(
     return {
       ref: raw,
       nodeId: ref.nodeId,
-      ...(node.description !== undefined
-        ? { description: node.description }
-        : {}),
+      ...(node.context !== undefined ? { context: node.context } : {}),
       body: node.body,
     };
   }
@@ -36,9 +34,7 @@ export function resolveBaseline(
     ref: raw,
     nodeId: ref.nodeId,
     heading: ref.heading,
-    ...(node.description !== undefined
-      ? { description: node.description }
-      : {}),
+    ...(node.context !== undefined ? { context: node.context } : {}),
     body: section ?? node.body,
     ...(section === null
       ? {

--- a/packages/ghost/src/review/review-packet.ts
+++ b/packages/ghost/src/review/review-packet.ts
@@ -17,7 +17,7 @@ export type { BaselineProse };
 export interface PacketMaterialNode {
   id: string;
   kind?: string;
-  description?: string;
+  context?: string;
   prose: string;
   materials: GhostMaterial[];
   matchedMaterials: string[];
@@ -105,9 +105,7 @@ function materialNodeFromMatch(
   return {
     id: node.id,
     ...(node.kind !== undefined ? { kind: node.kind } : {}),
-    ...(node.description !== undefined
-      ? { description: node.description }
-      : {}),
+    ...(node.context !== undefined ? { context: node.context } : {}),
     prose: node.body,
     materials: node.materials ?? [],
     matchedMaterials: matched.locators,
@@ -137,7 +135,7 @@ export function formatReviewPacket(packet: ReviewPacket): string {
     for (const node of packet.materialNodes) {
       const kind = node.kind ? ` _(${node.kind})_` : "";
       out.push(`### \`${node.id}\`${kind}`);
-      if (node.description) out.push(`_${node.description}_`, "");
+      if (node.context) out.push(`_${node.context}_`, "");
       out.push(node.prose, "");
       out.push("Matched materials:");
       for (const locator of node.matchedMaterials) {

--- a/packages/ghost/src/scan/fingerprint-package-lint.ts
+++ b/packages/ghost/src/scan/fingerprint-package-lint.ts
@@ -80,7 +80,7 @@ export async function lintGhostPackage(
       await lintGlossary(paths.glossary, issues);
       lintCover(manifest.cover, catalog, issues);
       await lintKindPrefixes(paths, catalog, issues);
-      lintNodeDescriptions(catalog, issues);
+      lintNodeContexts(catalog, issues);
       lintSkeletonSections(catalog, issues);
       await lintMaterialLocators(paths, catalog, issues, cwd);
       lintCheckReferences(catalog, checks, issues);
@@ -187,24 +187,28 @@ async function lintKindPrefixes(
 }
 
 /**
- * The `description` is a node's entire retrieval payload: `gather` lists it as
- * the text the agent selects against. A node without one renders as a bare id
- * and cannot show when it applies, so `validate` makes that loud. Warning,
- * not error: an undescribed node is legal, just undiscoverable.
+ * `context` is a node's entire retrieval payload: `gather` lists it as the text
+ * the agent selects against. A node without one renders as a bare id and cannot
+ * show when it applies, so `validate` makes that loud. `description` remains a
+ * read alias for one release and produces a migration warning.
  */
-function lintNodeDescriptions(
-  catalog: GhostCatalog,
-  issues: LintIssue[],
-): void {
+function lintNodeContexts(catalog: GhostCatalog, issues: LintIssue[]): void {
   for (const node of catalog.nodes.values()) {
-    if (node.description !== undefined && node.description.trim().length > 0) {
-      continue;
+    if (node.usesDeprecatedDescription) {
+      issues.push({
+        severity: "warning",
+        rule: "node-description-deprecated",
+        message:
+          "node uses deprecated `description`; rename it to `context` (the retrieval payload shown by `gather`)",
+        path: `${node.id}.md.description`,
+      });
     }
+    if (node.context !== undefined && node.context.trim().length > 0) continue;
     issues.push({
       severity: "warning",
-      rule: "node-description-missing",
+      rule: "node-context-missing",
       message:
-        "node has no `description`, so `gather` lists it as a bare id without applicability context; add a one-line description of what this guidance governs, when it applies, and what it contributes",
+        "node has no `context`, so `gather` lists it as a bare id without applicability context; add one line describing what this guidance governs, when it applies, and what it contributes",
       path: `${node.id}.md`,
     });
   }

--- a/packages/ghost/src/scan/fingerprint-package-lint.ts
+++ b/packages/ghost/src/scan/fingerprint-package-lint.ts
@@ -208,7 +208,7 @@ function lintNodeContexts(catalog: GhostCatalog, issues: LintIssue[]): void {
       severity: "warning",
       rule: "node-context-missing",
       message:
-        "node has no `context`, so `gather` lists it as a bare id without applicability context; add one line describing what this guidance governs, when it applies, and what it contributes",
+        "node has no `context`, so `gather` lists it as a bare id without applicability context; add one line naming the observable condition under which this node applies",
       path: `${node.id}.md`,
     });
   }

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -26,7 +26,7 @@ it applies, and an agent reads the relevant guidance before building.
 
 ## The model in one breath
 
-- A **node** is a markdown file: `description`, optional `materials`, and prose brand guidance.
+- A **node** is a markdown file: `context`, optional `materials`, and prose brand guidance. `description` is a deprecated compatibility alias for one release.
 - `materials` is one list of locators for the concrete stuff the guidance is about:
   repo-relative paths/globs or supported external locators (see
   [schema.md](references/schema.md)). A bare locator is enough
@@ -62,7 +62,7 @@ ghost pulse         # summarize local gather/pull events while tuning
 ```
 
 `gather` does no selection. It emits the complete, unfiltered, unranked menu
-from the ghost package. You read the ask against descriptions, then
+from the ghost package. You read the ask against contexts, then
 pull every applicable node and skip inapplicable nodes. Topic overlap alone is
 not applicability. Its header includes a coverage line: total nodes and nodes
 carrying concrete material. `gather` labels materials, substantial fenced

--- a/packages/ghost/src/skill-bundle/references/authoring-scenarios.md
+++ b/packages/ghost/src/skill-bundle/references/authoring-scenarios.md
@@ -89,7 +89,7 @@ and enforced in review, not repeated as the model's main example.
 ## 4. Draft The Nodes
 
 Write the smallest useful set of nodes, each carrying purpose-coherent prose guidance with
-a one-line `description`, named `<kind>.<slug>.md` (or a bare slug when no kind is present). Ask three questions of each node body: why (the stance), with what
+a one-line `context`, named `<kind>.<slug>.md` (or a bare slug when no kind is present). Ask three questions of each node body: why (the stance), with what
 (the materials), and how it is assembled (the patterns). These are drafting
 prompts, not fields.
 

--- a/packages/ghost/src/skill-bundle/references/blocks.md
+++ b/packages/ghost/src/skill-bundle/references/blocks.md
@@ -64,9 +64,9 @@ primitive.
 
 ## The shape of a block node
 
-A node like any other. Frontmatter carries `context` (the retrieval payload —
-write one on every block worth matching); the body is prose the agent reasons
-over.
+A node like any other. Frontmatter carries `context`, the direct applicability
+payload; write one on every block worth matching. The body is prose the agent
+reasons over.
 
 **Body:** one short paragraph in a consistent rhythm, *for / reach when / not
 when (use X instead) / never*:

--- a/packages/ghost/src/skill-bundle/references/blocks.md
+++ b/packages/ghost/src/skill-bundle/references/blocks.md
@@ -18,7 +18,7 @@ This is opinionated method, not new schema. **"Block node" is shorthand in this
 recipe, not a ghost concept**: it means any node whose guidance is a reusable
 building block, whatever kind the author's glossary declares for it (`block`,
 `asset`, `pattern`, …). A block node is a node like any other: a markdown file
-with a `description` and a prose body, named `<kind>.<slug>.md` (or a bare
+with a `context` and a prose body, named `<kind>.<slug>.md` (or a bare
 slug). See [capture.md](capture.md) for the node shape. Block prose can be one
 paragraph inside a broader node, or split across many nodes, one per block,
 whatever keeps each node purpose-coherent.
@@ -46,7 +46,7 @@ Neither is correct. A concrete block node is a deliberate trade, not a leak.
 
 - **Primitives** (button, input, badge, avatar, spinner…) get **no prose body**
   when the generic form serves. They are shared vocabulary, not stance. If you
-  record one at all, give it only a `description` so `gather` can surface it;
+  record one at all, give it only a `context` so `gather` can surface it;
   the absence of a body is the signal that training priors are acceptable here.
   When a primitive is itself brand-distinctive (a button whose shape, weight, or
   focus treatment is a recognizable brand move), its *divergence from the
@@ -64,7 +64,7 @@ primitive.
 
 ## The shape of a block node
 
-A node like any other. Frontmatter carries `description` (the retrieval payload —
+A node like any other. Frontmatter carries `context` (the retrieval payload —
 write one on every block worth matching); the body is prose the agent reasons
 over.
 
@@ -90,7 +90,7 @@ not a swappable implementation detail.
 ## How a match runs
 
 The agent reads the package's stance, `gather`s the menu, pulls block nodes
-whose descriptions apply, separates near-neighbors on *not when* and *never*,
+whose contexts apply, separates near-neighbors on *not when* and *never*,
 and assembles. The realizing surface authors the chosen blocks in its medium.
 The guidance never named a component; the agent bridged via documented
 purpose.
@@ -118,7 +118,7 @@ kinds:
 
 ```markdown
 ---
-description: Gate a consequential action behind explicit user approval.
+context: Gate a consequential action behind explicit user approval.
 ---
 Gates a tool action behind explicit user approval. Reach for it when the user's
 first question is "do I allow this?", when a consequential action needs a human
@@ -131,7 +131,7 @@ with no decision to make, it only manufactures friction.
 
 ```markdown
 ---
-description: Present many records across shared, comparable columns.
+context: Present many records across shared, comparable columns.
 ---
 Presents many records across shared, comparable columns. Reach for it when the
 user's first question is "how do these compare across the same attributes?" Not
@@ -144,11 +144,11 @@ record's detail view.
 
 ```markdown
 ---
-description: A primitive action trigger.
+context: A primitive action trigger.
 ---
 ```
 
-(A primitive the generic form serves: a `description` so `gather` can surface
+(A primitive the generic form serves: a `context` so `gather` can surface
 it, no body. If this brand's button were itself a recognizable brand move, its
 divergence from the generic form would earn a short body.)
 

--- a/packages/ghost/src/skill-bundle/references/blocks.md
+++ b/packages/ghost/src/skill-bundle/references/blocks.md
@@ -118,7 +118,7 @@ kinds:
 
 ```markdown
 ---
-context: Gate a consequential action behind explicit user approval.
+context: A consequential action needs explicit user approval before it runs.
 ---
 Gates a tool action behind explicit user approval. Reach for it when the user's
 first question is "do I allow this?", when a consequential action needs a human
@@ -131,7 +131,7 @@ with no decision to make, it only manufactures friction.
 
 ```markdown
 ---
-context: Present many records across shared, comparable columns.
+context: Many records need comparison across shared columns.
 ---
 Presents many records across shared, comparable columns. Reach for it when the
 user's first question is "how do these compare across the same attributes?" Not
@@ -144,7 +144,7 @@ record's detail view.
 
 ```markdown
 ---
-context: A primitive action trigger.
+context: A person can trigger an action.
 ---
 ```
 

--- a/packages/ghost/src/skill-bundle/references/brief.md
+++ b/packages/ghost/src/skill-bundle/references/brief.md
@@ -8,7 +8,7 @@ description: Build a compact pre-generation packet from pulled ghost guidance.
 A brief is an ephemeral steering packet for the generating pass. It is not a new
 schema and is never written back into `.ghost/`.
 
-1. Run `ghost gather <ask> --format json` and select against descriptions.
+1. Run `ghost gather <ask> --format json` and select against contexts.
 2. The cover is already in context and outside selection. Pull every applicable
    node with `ghost pull <id> [<id>…]`; skip nodes whose stated situation does
    not apply. Topic overlap alone is not applicability.

--- a/packages/ghost/src/skill-bundle/references/capture.md
+++ b/packages/ghost/src/skill-bundle/references/capture.md
@@ -201,11 +201,13 @@ Near the moment of payment, reduce felt risk. Proximity of reassurance to the
 action beats completeness...
 ```
 
-- **`context`** is how an agent finds the node: a compact retrieval payload
-  naming what the node governs, the observable condition under which it applies,
-  and what it contributes when useful. `ghost gather` emits id, kind,
-  context, concrete coverage, payload labels, and material count; the agent matches the ask
-  against applicability.
+- **`context`** tells the agent when to gather the node: a compact retrieval
+  payload naming what the node governs, the observable condition under which it
+  applies, and what it contributes when useful. Usually state that information
+  directly. Use an explicit retrieval instruction such as “gather when” only
+  when the direct condition cannot carry a necessary routing constraint.
+  `ghost gather` emits id, kind, context, concrete coverage, payload labels, and
+  material count; the agent matches the ask against applicability.
 - **Kind is the filename prefix** and must be a kind the glossary declares. A
   bare name (`voice.md`) has no kind.
 - **Altitude lives in the prose.** State universal guidance plainly; give a

--- a/packages/ghost/src/skill-bundle/references/capture.md
+++ b/packages/ghost/src/skill-bundle/references/capture.md
@@ -37,7 +37,7 @@ should preserve and what is incidental.
 
 ````markdown
 ---
-context: Complete status card exemplar — normative for density, evidence placement, and action language.
+context: Building or reviewing a status card.
 materials:
   - src/components/status-card.tsx
 ---
@@ -99,7 +99,7 @@ out-steers a paragraph about error-message voice:
 
 ```markdown
 ---
-context: A verbatim on-brand error message — the voice at failure moments.
+context: Writing or reviewing an error message.
 ---
 
 Normative for rhythm and stance at failure moments; match its form, not its words.
@@ -170,7 +170,7 @@ thing.
 
 ```markdown
 ---
-context: Review-critical replacement for the generic AI dashboard default.
+context: Building or reviewing an AI dashboard.
 ---
 
 Not: rounded-xl cards on gray-50, indigo primary buttons, gradient hero text,
@@ -193,7 +193,7 @@ A node at `principle.trust.md` (id `principle.trust`, kind `principle`):
 
 ```markdown
 ---
-context: Trust at the payment moment.  # the retrieval payload
+context: A person is about to pay.  # the retrieval payload
 # optional: materials, audience, stage, or other free-form keys
 ---
 
@@ -201,13 +201,12 @@ Near the moment of payment, reduce felt risk. Proximity of reassurance to the
 action beats completeness...
 ```
 
-- **`context`** tells the agent when to gather the node: a compact retrieval
-  payload naming what the node governs, the observable condition under which it
-  applies, and what it contributes when useful. Usually state that information
-  directly. Use an explicit retrieval instruction such as “gather when” only
-  when the direct condition cannot carry a necessary routing constraint.
-  `ghost gather` emits id, kind, context, concrete coverage, payload labels, and
-  material count; the agent matches the ask against applicability.
+- **`context`** tells the agent when to gather the node. Name the observable
+  condition under which it applies, and nothing else. Put the guidance and what
+  the node contributes in the body. State the condition directly; use “gather
+  when” only when the direct condition cannot carry a necessary routing
+  constraint. `ghost gather` emits id, kind, context, concrete coverage, payload
+  labels, and material count; the agent matches the ask against applicability.
 - **Kind is the filename prefix** and must be a kind the glossary declares. A
   bare name (`voice.md`) has no kind.
 - **Altitude lives in the prose.** State universal guidance plainly; give a

--- a/packages/ghost/src/skill-bundle/references/capture.md
+++ b/packages/ghost/src/skill-bundle/references/capture.md
@@ -23,7 +23,7 @@ ghost treats the `.ghost/` package as canonical.
   voice.md              # guidance without a kind
 ```
 
-A **node** is a markdown file: a `description`, optional `materials`, and a
+A **node** is a markdown file: a `context`, optional `materials`, and a
 prose body. The package is **flat** — no hierarchy, no inheritance, no edges. A
 node's kind comes from its filename prefix; the glossary declares the kinds.
 
@@ -37,7 +37,7 @@ should preserve and what is incidental.
 
 ````markdown
 ---
-description: Complete status card exemplar — normative for density, evidence placement, and action language.
+context: Complete status card exemplar — normative for density, evidence placement, and action language.
 materials:
   - src/components/status-card.tsx
 ---
@@ -99,7 +99,7 @@ out-steers a paragraph about error-message voice:
 
 ```markdown
 ---
-description: A verbatim on-brand error message — the voice at failure moments.
+context: A verbatim on-brand error message — the voice at failure moments.
 ---
 
 Normative for rhythm and stance at failure moments; match its form, not its words.
@@ -170,7 +170,7 @@ thing.
 
 ```markdown
 ---
-description: Review-critical replacement for the generic AI dashboard default.
+context: Review-critical replacement for the generic AI dashboard default.
 ---
 
 Not: rounded-xl cards on gray-50, indigo primary buttons, gradient hero text,
@@ -193,7 +193,7 @@ A node at `principle.trust.md` (id `principle.trust`, kind `principle`):
 
 ```markdown
 ---
-description: Trust at the payment moment.  # the retrieval payload
+context: Trust at the payment moment.  # the retrieval payload
 # optional: materials, audience, stage, or other free-form keys
 ---
 
@@ -201,16 +201,16 @@ Near the moment of payment, reduce felt risk. Proximity of reassurance to the
 action beats completeness...
 ```
 
-- **`description`** is how an agent finds the node: a compact retrieval payload
+- **`context`** is how an agent finds the node: a compact retrieval payload
   naming what the node governs, the observable condition under which it applies,
   and what it contributes when useful. `ghost gather` emits id, kind,
-  description, concrete coverage, payload labels, and material count; the agent matches the ask
+  context, concrete coverage, payload labels, and material count; the agent matches the ask
   against applicability.
 - **Kind is the filename prefix** and must be a kind the glossary declares. A
   bare name (`voice.md`) has no kind.
 - **Altitude lives in the prose.** State universal guidance plainly; give a
   narrower guidance a **condition** — the situation it applies in — in the prose
-  and usually in the description. Do not use broad universal imperatives unless
+  and usually in the context. Do not use broad universal imperatives unless
   universal retrieval is intended. Never file a node by destination
   (`for-emails.md`).
 - **Concreteness is derived.** A node carries concrete material when it has
@@ -258,7 +258,7 @@ Everywhere else:
 - **No aspirational abstractions.** "We value clarity and trust" steers
   nothing. Name the decision the guidance forces: what gets picked when two goods
   compete, and what gets given up.
-- **Descriptions must discriminate.** Read the description alone. If it also
+- **Contexts must discriminate.** Read the context alone. If it also
   fits a competitor's brand, it is retrieval-dead; rewrite it until it could
   belong to no one else.
 - **Cut unratified hedges.** "Generally," "where possible," and "consider" in a
@@ -279,7 +279,7 @@ dimension:
 | Dimension | Question |
 | --- | --- |
 | Testimony | Can you quote the human words or artifact this node came from? |
-| Discrimination | Does the description fit only this brand? |
+| Discrimination | Does the context fit only this brand? |
 | Force | Does the node body decide something, or merely describe something? |
 | Altitude | Is it universal on purpose, or given its condition? |
 | Residue | Is it free of starter-demo prose and brand-deck filler? |
@@ -295,7 +295,7 @@ strongest form that fixes the observed failure.
 
 | If the agent keeps... | Author... |
 | --- | --- |
-| missing the guidance | sharper `description`; move universal guidance to the cover |
+| missing the guidance | sharper `context`; move universal guidance to the cover |
 | inventing values | `asset.*` node with materials and exact names |
 | producing generic output | `anti-goal.*` replacement plus annotated `exemplar.*` |
 | choosing the wrong structure | `pattern.*` with bound/open and a `## Skeleton` |

--- a/packages/ghost/src/skill-bundle/references/distill.md
+++ b/packages/ghost/src/skill-bundle/references/distill.md
@@ -51,7 +51,7 @@ ghost pull <potentially-affected-node-ids>
 Treat the gathered menu as a reconciliation index. Read affected node bodies
 before proposing edits.
 
-Pull nodes whose descriptions or materials touch the evidence, the situation,
+Pull nodes whose contexts or materials touch the evidence, the situation,
 the medium, or the likely contradiction. If no node applies, say so and continue
 with a new-node proposal only after inspection and human ratification.
 

--- a/packages/ghost/src/skill-bundle/references/making.md
+++ b/packages/ghost/src/skill-bundle/references/making.md
@@ -23,7 +23,7 @@ selects, inspects, makes, renders, judges, and repairs in the same session.
 
 1. **Gather for the actual ask.** Follow [recall.md](recall.md): run
    `ghost gather <ask>` with the user's real task, not a generic label.
-2. **Select applicable nodes.** Read descriptions against the situation. Pull
+2. **Select applicable nodes.** Read contexts against the situation. Pull
    guidance whose stated condition, material, structure, refusal, or decision
    governs the work. Topic overlap alone is not applicability.
 3. **Pull selected nodes.** Run `ghost pull <id> [<id>…]`. Prefer the pulled
@@ -38,7 +38,7 @@ selects, inspects, makes, renders, judges, and repairs in the same session.
    - read inlined text materials;
    - open referenced source, token, or component files;
    - view image inspect-pointers instead of relying on filenames;
-   - inspect rendered exemplars, not just their descriptions;
+   - inspect rendered exemplars, not just their contexts;
    - use an available host connection for an external locator only when inspecting
      it could materially affect the task;
    - let the host run its normal authentication and permission flow;

--- a/packages/ghost/src/skill-bundle/references/recall.md
+++ b/packages/ghost/src/skill-bundle/references/recall.md
@@ -8,7 +8,7 @@ description: Gather and pull the applicable ghost brand guidance for a task.
 1. Run `ghost gather <ask>` for the actual task. The cover is inlined by gather;
    do not pull it separately. Read the coverage line: all-prose packages are
    weak steering.
-2. Select against `description`; ghost never selects for you. Pull every node
+2. Select against `context`; ghost never selects for you. Pull every node
    whose stated situation applies and whose guidance, material, structure, or
    refusal governs the work. Skip inapplicable nodes. Topic overlap alone is not
    applicability.

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -37,7 +37,7 @@ A node is markdown with frontmatter and a prose body:
 
 ```markdown
 ---
-context: Logo lockups, clearspace, and when the glyph can stand alone.
+context: Placing, sizing, or choosing a logo lockup or glyph.
 materials:
   - brand/logo*.svg
   - https://figma.com/file/example?node-id=logo-lockups
@@ -50,13 +50,13 @@ Use the full lockup when recognition matters.
 
 - Identity is the filename minus `.md`.
 - Kind is the first dotted segment of the filename.
-- `context` is the retrieval payload shown by `ghost gather`: what the node
-  governs, the observable condition under which it applies, and what it
-  contributes where useful. Its job is to tell the agent when to gather the
-  node. State the condition directly; say “gather when” only when an explicit
-  routing instruction is necessary. Avoid broad universal wording unless
-  universal retrieval is intended. `description` remains a deprecated read
-  alias for one release; `ghost validate` warns until it is renamed.
+- `context` is the retrieval payload shown by `ghost gather`. Its only job is
+  to tell the agent when to gather the node. Name the observable applicability
+  condition directly; put guidance and contribution in the body. Say “gather
+  when” only when an explicit routing instruction is necessary. Avoid broad
+  universal wording unless universal retrieval is intended. `description`
+  remains a deprecated read alias for one release; `ghost validate` warns until
+  it is renamed.
 - `materials` accepts repo-relative paths/globs plus supported external locators using `https:`, `mcp:`,
   `figma:`, or `github:`. Items may be bare locator strings or
   `{ locator, note }` objects. Use a short `note` only when an opaque locator

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -37,7 +37,7 @@ A node is markdown with frontmatter and a prose body:
 
 ```markdown
 ---
-description: Logo lockups, clearspace, and when the glyph can stand alone.
+context: Logo lockups, clearspace, and when the glyph can stand alone.
 materials:
   - brand/logo*.svg
   - https://figma.com/file/example?node-id=logo-lockups
@@ -50,10 +50,11 @@ Use the full lockup when recognition matters.
 
 - Identity is the filename minus `.md`.
 - Kind is the first dotted segment of the filename.
-- `description` is the retrieval payload shown by `ghost gather`: what the node
+- `context` is the retrieval payload shown by `ghost gather`: what the node
   governs, the observable condition under which it applies, and what it
   contributes where useful. Avoid broad universal wording unless universal
-  retrieval is intended.
+  retrieval is intended. `description` remains a deprecated read alias for one
+  release; `ghost validate` warns until it is renamed.
 - `materials` accepts repo-relative paths/globs plus supported external locators using `https:`, `mcp:`,
   `figma:`, or `github:`. Items may be bare locator strings or
   `{ locator, note }` objects. Use a short `note` only when an opaque locator

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -52,9 +52,11 @@ Use the full lockup when recognition matters.
 - Kind is the first dotted segment of the filename.
 - `context` is the retrieval payload shown by `ghost gather`: what the node
   governs, the observable condition under which it applies, and what it
-  contributes where useful. Avoid broad universal wording unless universal
-  retrieval is intended. `description` remains a deprecated read alias for one
-  release; `ghost validate` warns until it is renamed.
+  contributes where useful. Its job is to tell the agent when to gather the
+  node. State the condition directly; say “gather when” only when an explicit
+  routing instruction is necessary. Avoid broad universal wording unless
+  universal retrieval is intended. `description` remains a deprecated read
+  alias for one release; `ghost validate` warns until it is renamed.
 - `materials` accepts repo-relative paths/globs plus supported external locators using `https:`, `mcp:`,
   `figma:`, or `github:`. Items may be bare locator strings or
   `{ locator, note }` objects. Use a short `note` only when an opaque locator

--- a/packages/ghost/src/skill-bundle/references/self-check.md
+++ b/packages/ghost/src/skill-bundle/references/self-check.md
@@ -55,7 +55,7 @@ Classify readiness:
 When you cannot answer the grounding questions:
 
 1. Run `ghost gather <ask>` to emit the menu for the actual task, then match the
-   work to nodes by their descriptions.
+   work to nodes by their contexts.
 2. Read the selected nodes' bodies and re-ask the questions, citing node ids.
 
 A genuinely silent package is an expected state, not a blocker. When it does

--- a/packages/ghost/src/skill-bundle/references/steering-audit.md
+++ b/packages/ghost/src/skill-bundle/references/steering-audit.md
@@ -30,13 +30,13 @@ Report first:
 - **Pulse by concreteness:** concrete-material exposure/pull rate vs prose-only
   exposure/pull rate. In markdown this is the `Concrete material` row. This is
   the tuning instrument: if concrete nodes are not pulled when applicable,
-  descriptions or task selection are failing.
+  contexts or task selection are failing.
 
 ## Corpus-level table
 
 | Row | Status | Evidence | Next move |
 | --- | --- | --- | --- |
-| Retrieval | strong / weak | descriptions, ids, cover | sharpen descriptions or move universal guidance to the cover |
+| Retrieval | strong / weak | contexts, ids, cover | sharpen contexts or move universal guidance to the cover |
 | Concreteness | strong / thin | materials, fenced examples, Skeletons | add concrete locators, exemplars, or opening structures |
 | Anti-goals | present / missing / vague | `anti-goal.*`, review packet | write not-X-instead-Y replacements and material locators |
 | Consistency | clean / conflicting | concrete bodies vs rules | update stale examples; examples average with rules |

--- a/packages/ghost/test/cli-exit.test.ts
+++ b/packages/ghost/test/cli-exit.test.ts
@@ -156,15 +156,12 @@ async function writeLargePullFixture(dir: string): Promise<void> {
         "",
       ].join("\n"),
     ),
-    writeFile(
-      join(ghost, "index.md"),
-      "---\ndescription: Cover.\n---\n\nCover.\n",
-    ),
+    writeFile(join(ghost, "index.md"), "---\ncontext: Cover.\n---\n\nCover.\n"),
     writeFile(
       join(ghost, "principle.long.md"),
       [
         "---",
-        "description: Large pull body.",
+        "context: Large pull body.",
         "---",
         "",
         "x".repeat(2 * 1024 * 1024),

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -124,11 +124,11 @@ async function writeBareTestPackage(dir: string): Promise<void> {
     ),
     writeFile(
       join(packageDir, "index.md"),
-      "---\ndescription: Test package cover.\n---\n\nTest package.\n",
+      "---\ncontext: Test package cover.\n---\n\nTest package.\n",
     ),
     writeFile(
       join(packageDir, "cliche.median.md"),
-      "---\ndescription: Test cliche floor.\n---\n\nAvoid generic defaults.\n",
+      "---\ncontext: Test cliche floor.\n---\n\nAvoid generic defaults.\n",
     ),
   ]);
 }
@@ -676,6 +676,7 @@ describe("ghost CLI", () => {
       nodes: 9,
       concrete: 0,
       payloads: { materials: 0, fencedExamples: 0, skeletons: 0 },
+      withoutContext: 0,
       undescribed: 0,
     });
   });
@@ -826,15 +827,15 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - missing.css\n---\n\nUse exact tokens.\n",
+      "---\ncontext: Tokens.\nmaterials:\n  - missing.css\n---\n\nUse exact tokens.\n",
     );
     await writeFile(
       join(dir, ".ghost", "principle.rule.md"),
-      "---\ndescription: Rule.\n---\n\nPlain rule.\n",
+      "---\ncontext: Rule.\n---\n\nPlain rule.\n",
     );
     await writeFile(
       join(dir, ".ghost", "anti-goal.generic.md"),
-      "---\ndescription: Generic replacement.\n---\n\nNot vague; instead exact.\n",
+      "---\ncontext: Generic replacement.\n---\n\nNot vague; instead exact.\n",
     );
 
     // The seeded cover (`index`) is inlined above the menu, not counted in it.
@@ -844,26 +845,28 @@ describe("ghost CLI", () => {
       nodes: 4,
       concrete: 1,
       payloads: { materials: 1, fencedExamples: 0, skeletons: 0 },
+      withoutContext: 0,
       undescribed: 0,
     });
     const markdown = await runCli(["gather"], dir);
     expect(markdown.stdout).toContain(
       "4 nodes · 1 carry payloads (1 with materials, 0 with substantial fenced examples, 0 with Skeletons)",
     );
-    // No undescribed nodes: the coverage line stays quiet about them.
-    expect(markdown.stdout).not.toContain("lack descriptions");
+    // No withoutContext nodes: the coverage line stays quiet about them.
+    expect(markdown.stdout).not.toContain("lack context");
 
-    // A node without a description is invisible to selection — the coverage
+    // A node without context is invisible to selection — the coverage
     // line says so, and validate warns on it.
     await writeFile(
       join(dir, ".ghost", "principle.mute.md"),
-      "---\n{}\n---\n\nUndescribed guidance.\n",
+      "---\n{}\n---\n\nContext-free guidance.\n",
     );
     const gatherMute = await runCli(["gather"], dir);
     expect(gatherMute.stdout).toContain(
-      "5 nodes · 1 carry payloads (1 with materials, 0 with substantial fenced examples, 0 with Skeletons) · 1 lack descriptions",
+      "5 nodes · 1 carry payloads (1 with materials, 0 with substantial fenced examples, 0 with Skeletons) · 1 lack context",
     );
     const gatherMuteJson = await runCli(["gather", "--format", "json"], dir);
+    expect(JSON.parse(gatherMuteJson.stdout).coverage.withoutContext).toBe(1);
     expect(JSON.parse(gatherMuteJson.stdout).coverage.undescribed).toBe(1);
 
     const steering = await runCli(
@@ -890,7 +893,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "asset.tokens.md"),
       [
         "---",
-        "description: Token material.",
+        "context: Token material.",
         "materials:",
         "  - materials/tokens.css",
         "---",
@@ -903,7 +906,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "exemplar.copy.md"),
       [
         "---",
-        "description: Copy exemplar.",
+        "context: Copy exemplar.",
         "---",
         "",
         "```txt",
@@ -918,7 +921,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "pattern.card.md"),
       [
         "---",
-        "description: Card pattern.",
+        "context: Card pattern.",
         "---",
         "",
         "## Skeleton",
@@ -969,11 +972,11 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "pattern.card.md"),
-      "---\ndescription: Card pattern.\n---\n\nPattern prose.\n\n## Skeleton\n\n```tsx\n<section>{children}</section>\n```\n\nAfter skeleton should be stripped.\n",
+      "---\ncontext: Card pattern.\n---\n\nPattern prose.\n\n## Skeleton\n\n```tsx\n<section>{children}</section>\n```\n\nAfter skeleton should be stripped.\n",
     );
     await writeFile(
       join(dir, ".ghost", "pattern.bad.md"),
-      "---\ndescription: Bad skeleton.\n---\n\n## Skeleton\n\nNo fence here.\n",
+      "---\ncontext: Bad skeleton.\n---\n\n## Skeleton\n\nNo fence here.\n",
     );
 
     const pull = await runCli(["pull", "pattern.card"], dir);
@@ -1014,7 +1017,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "pattern.safe.md"),
       [
         "---",
-        "description: Fence safety.",
+        "context: Fence safety.",
         "materials:",
         "  - brand/example.md",
         "---",
@@ -1048,7 +1051,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "mark.png"), Buffer.from([0, 1, 2]));
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - brand/mark.png\n---\n\nInspect the blessed mark.\n",
+      "---\ncontext: Logo.\nmaterials:\n  - brand/mark.png\n---\n\nInspect the blessed mark.\n",
     );
 
     const md = await runCli(["pull", "asset.logo"], dir);
@@ -1070,11 +1073,11 @@ describe("ghost CLI", () => {
     await runCli(["init"], dir);
     await writeFile(
       join(dir, ".ghost", "principle.trust.md"),
-      "---\ndescription: Trust at the payment moment.\n---\n\nNear payment, reduce felt risk.\n",
+      "---\ncontext: Trust at the payment moment.\n---\n\nNear payment, reduce felt risk.\n",
     );
     await writeFile(
       join(dir, ".ghost", "voice.md"),
-      "---\ndescription: The brand voice.\n---\n\nPlain words. No hype.\n",
+      "---\ncontext: The brand voice.\n---\n\nPlain words. No hype.\n",
     );
 
     const gather = await runCli(
@@ -1118,7 +1121,7 @@ describe("ghost CLI", () => {
     expect(pull.stdout).toContain("Near payment, reduce felt risk.");
     expect(pull.stdout).toContain("Plain words. No hype.");
 
-    // JSON format carries id, kind, description, and body.
+    // JSON format carries id, kind, context, and body.
     const json = await runCli(
       ["pull", "principle.trust", "--format", "json"],
       dir,
@@ -1129,7 +1132,7 @@ describe("ghost CLI", () => {
     expect(payload.nodes[0]).toMatchObject({
       id: "principle.trust",
       kind: "principle",
-      description: "Trust at the payment moment.",
+      context: "Trust at the payment moment.",
     });
     expect(payload.nodes[0].body).toContain("reduce felt risk");
 
@@ -1213,7 +1216,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "large.txt"), "x".repeat(8 * 1024 + 1));
     await writeFile(
       join(dir, ".ghost", "asset.materials.md"),
-      "---\ndescription: Materials.\nmaterials:\n  - locator: materials/tokens.css\n    note: Canonical token values\n  - brand/voice.txt\n  - brand/mark.bin\n  - brand/large.txt\n  - https://example.com/brand-kit\n  - locator: mcp://brand-assets/brand-kit\n    note: Approved source artwork\n---\n\nRead these materials.\n",
+      "---\ncontext: Materials.\nmaterials:\n  - locator: materials/tokens.css\n    note: Canonical token values\n  - brand/voice.txt\n  - brand/mark.bin\n  - brand/large.txt\n  - https://example.com/brand-kit\n  - locator: mcp://brand-assets/brand-kit\n    note: Approved source artwork\n---\n\nRead these materials.\n",
     );
 
     const md = await runCli(["pull", "asset.materials"], dir);
@@ -1264,7 +1267,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
+      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
     );
 
     const md = await runCli(["pull", "asset.tokens", "--no-materials"], dir);
@@ -1295,7 +1298,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "voice.txt"), "Plain.\n");
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - locator: mcp://brand-assets/tokens\n    note: Canonical token source\n---\n\nToken prose.\n",
+      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - locator: mcp://brand-assets/tokens\n    note: Canonical token source\n---\n\nToken prose.\n",
     );
 
     const json = await runCli(
@@ -1338,7 +1341,7 @@ describe("ghost CLI", () => {
     }
     await writeFile(
       join(dir, ".ghost", "asset.samples.md"),
-      "---\ndescription: Samples.\nmaterials:\n  - brand/samples/*.txt\n---\n\nSample prose.\n",
+      "---\ncontext: Samples.\nmaterials:\n  - brand/samples/*.txt\n---\n\nSample prose.\n",
     );
 
     const json = await runCli(
@@ -1370,7 +1373,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n\n## Skeleton\n\n```css\n:root { }\n```\n\nStrip me.\n",
+      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n\n## Skeleton\n\n```css\n:root { }\n```\n\nStrip me.\n",
     );
 
     const snapshot = await loadGhostSnapshot(
@@ -1395,7 +1398,7 @@ describe("ghost CLI", () => {
     );
     expect(cliPull.nodes[0]).toMatchObject({
       id: embedPull.nodes[0].id,
-      description: embedPull.nodes[0].description,
+      context: embedPull.nodes[0].context,
       body: embedPull.nodes[0].body,
     });
     expect(cliPull.nodes[0].materials).toEqual(
@@ -1415,7 +1418,7 @@ describe("ghost CLI", () => {
     await runCli(["init"], dir);
     await writeFile(
       join(dir, ".ghost", "principle.trust.md"),
-      "---\ndescription: Trust.\n---\n\nBody.\n",
+      "---\ncontext: Trust.\n---\n\nBody.\n",
     );
 
     const partial = await runCli(
@@ -1453,11 +1456,11 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "principle.trust.md"),
-      "---\ndescription: Trust.\n---\n\nBody.\n",
+      "---\ncontext: Trust.\n---\n\nBody.\n",
     );
     await writeFile(
       join(dir, ".ghost", "voice.md"),
-      "---\ndescription: Voice.\n---\n\nPlain.\n",
+      "---\ncontext: Voice.\n---\n\nPlain.\n",
     );
 
     await runCli(["gather", "checkout"], dir);
@@ -1687,7 +1690,7 @@ describe("ghost CLI", () => {
     await mkdir(checksDir, { recursive: true });
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
+      "---\ncontext: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
     );
     await writeFile(
       join(checksDir, "secret-check.md"),
@@ -1749,7 +1752,7 @@ describe("ghost CLI", () => {
     await runCli(["init", "--with", "checks"], dir);
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - locator: brand/logo*.svg\n    note: Use the approved clearspace source\n  - brand/icon*.svg\n---\n\nLogo prose.\n",
+      "---\ncontext: Logo.\nmaterials:\n  - locator: brand/logo*.svg\n    note: Use the approved clearspace source\n  - brand/icon*.svg\n---\n\nLogo prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "checks", "logo-clearspace.md"),
@@ -1814,7 +1817,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, packageDir, "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nTokens prose.\n",
+      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nTokens prose.\n",
     );
     await mkdir(join(dir, packageDir, "checks"), { recursive: true });
     await writeFile(
@@ -1856,7 +1859,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "anti-goal.generic-logo.md"),
-      "---\ndescription: Replace generic marks.\nmaterials:\n  - brand/logo.svg\n---\n\nNot a stock spark; instead use the wordmark and measured clearspace.\n",
+      "---\ncontext: Replace generic marks.\nmaterials:\n  - brand/logo.svg\n---\n\nNot a stock spark; instead use the wordmark and measured clearspace.\n",
     );
     await writeFile(
       join(dir, ".ghost", "checks", "unrelated.md"),
@@ -1890,7 +1893,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n  - https://example.com/tokens\n  - mcp://brand-assets/tokens\n---\n\nToken prose.\n",
+      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n  - https://example.com/tokens\n  - mcp://brand-assets/tokens\n---\n\nToken prose.\n",
     );
 
     const out = join(dir, "brand.tgz");
@@ -1949,7 +1952,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "voice.txt"), "Plain.\n");
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - https://example.com/tokens\n  - figma://file/abc\n---\n\nToken prose.\n",
+      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - https://example.com/tokens\n  - figma://file/abc\n---\n\nToken prose.\n",
     );
 
     const result = await runCli(["export", "--format", "json"], dir);
@@ -1989,7 +1992,7 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "asset.remote.md"),
-      "---\ndescription: Remote material.\nmaterials:\n  - mcp://brand-assets/tokens\n  - figma://file/abc\n  - github:acme/brand-assets\n---\n\nRemote prose.\n",
+      "---\ncontext: Remote material.\nmaterials:\n  - mcp://brand-assets/tokens\n  - figma://file/abc\n  - github:acme/brand-assets\n---\n\nRemote prose.\n",
     );
 
     const result = await runCli(["export", "--strict"], dir);
@@ -2013,7 +2016,7 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "asset.voice.md"),
-      "---\ndescription: Voice.\nmaterials:\n  - brand/voice.txt\n---\n\nVoice prose.\n",
+      "---\ncontext: Voice.\nmaterials:\n  - brand/voice.txt\n---\n\nVoice prose.\n",
     );
 
     const result = await runCli(["export", "--strict"], dir);
@@ -2032,7 +2035,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
+      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
     );
     const out = join(dir, "portable.tgz");
     await runCli(["export", "--out", out], dir);
@@ -2218,15 +2221,15 @@ async function writeGatherPackage(dir: string): Promise<void> {
   // Directories are a browsing convenience only; ids are paths minus .md.
   await writeFile(
     join(ghost, "index.md"),
-    "---\ndescription: Brand voice.\n---\n\nWarm and concise.\n",
+    "---\ncontext: Brand voice.\n---\n\nWarm and concise.\n",
   );
   await writeFile(
     join(ghost, "email", "index.md"),
-    "---\ndescription: Email surface.\n---\n\nEmail.\n",
+    "---\ncontext: Email surface.\n---\n\nEmail.\n",
   );
   await writeFile(
     join(ghost, "email", "marketing", "index.md"),
-    "---\ndescription: Marketing email.\n---\n\nMarketing may use urgency.\n",
+    "---\ncontext: Marketing email.\n---\n\nMarketing may use urgency.\n",
   );
   await writeFile(
     join(ghost, "checkout", "clarity.md"),

--- a/packages/ghost/test/embed.test.ts
+++ b/packages/ghost/test/embed.test.ts
@@ -45,7 +45,7 @@ async function writePackage(dir: string): Promise<void> {
   );
   await writeFile(
     join(dir, ".ghost", "cover.md"),
-    "---\ndescription: Cover.\n---\n\nSilence posture.\n",
+    "---\ncontext: Cover.\n---\n\nSilence posture.\n",
   );
   await writeFile(join(dir, ".ghost", "materials", "tokens.css"), ":root{}\n");
   await writeFile(join(dir, "brand", "voice.txt"), "Plain.\n");
@@ -57,7 +57,7 @@ async function writePackage(dir: string): Promise<void> {
     join(dir, ".ghost", "asset.tokens.md"),
     [
       "---",
-      "description: Tokens.",
+      "context: Tokens.",
       "materials:",
       "  - materials/tokens.css",
       "  - brand/voice.txt",
@@ -80,7 +80,7 @@ async function writePackage(dir: string): Promise<void> {
   );
   await writeFile(
     join(dir, ".ghost", "principle.rule.md"),
-    "---\ndescription: Rule.\n---\n\nRule prose.\n",
+    "---\ncontext: Rule.\n---\n\nRule prose.\n",
   );
   await mkdir(join(dir, ".ghost", "checks"), { recursive: true });
   await writeFile(
@@ -149,6 +149,7 @@ describe("embed contract", () => {
       nodes: 2,
       concrete: 1,
       payloads: { materials: 1, fencedExamples: 0, skeletons: 1 },
+      withoutContext: 0,
       undescribed: 0,
     });
     expect(result.kinds).toContainEqual({
@@ -417,11 +418,11 @@ describe("embed contract", () => {
     await writePackage(dir);
     await writeFile(
       join(dir, ".ghost", "asset.traversal.md"),
-      "---\ndescription: Traversal.\nmaterials:\n  - ../outside.txt\n---\n\nTraversal prose.\n",
+      "---\ncontext: Traversal.\nmaterials:\n  - ../outside.txt\n---\n\nTraversal prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "asset.absolute.md"),
-      `---\ndescription: Absolute.\nmaterials:\n  - ${join(dir, "brand", "voice.txt")}\n---\n\nAbsolute prose.\n`,
+      `---\ncontext: Absolute.\nmaterials:\n  - ${join(dir, "brand", "voice.txt")}\n---\n\nAbsolute prose.\n`,
     );
     const baseSnapshot = await loadGhostSnapshot(
       resolveGhostPackage(undefined, dir),
@@ -492,7 +493,7 @@ describe("embed contract", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.escape.md"),
-      "---\ndescription: Escape.\nmaterials:\n  - brand/escape.txt\n---\n\nEscape prose.\n",
+      "---\ncontext: Escape.\nmaterials:\n  - brand/escape.txt\n---\n\nEscape prose.\n",
     );
     try {
       const snapshot = await loadGhostSnapshot(

--- a/packages/ghost/test/fingerprint-package.test.ts
+++ b/packages/ghost/test/fingerprint-package.test.ts
@@ -421,7 +421,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "index.md"),
-      "---\ncontext: Start here.\n---\n\nFront door prose.\n",
+      "---\ncontext: The package cover and coverage map.\n---\n\nFront door prose.\n",
     );
     await mkdir(join(dir, "email"), { recursive: true });
     await writeFile(

--- a/packages/ghost/test/fingerprint-package.test.ts
+++ b/packages/ghost/test/fingerprint-package.test.ts
@@ -58,7 +58,7 @@ describe("ghost package", () => {
     await mkdir(join(dir, "checkout"), { recursive: true });
     await writeFile(
       join(dir, "checkout", "principle.trust.md"),
-      "---\ndescription: Trust at the payment moment.\n---\n\nReduce felt risk near payment.\n",
+      "---\ncontext: Trust at the payment moment.\n---\n\nReduce felt risk near payment.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));
@@ -66,7 +66,7 @@ describe("ghost package", () => {
     // id is the path; kind/slug come from the filename.
     const authored = loaded.catalog.nodes.get("checkout/principle.trust");
     expect(authored?.body).toBe("Reduce felt risk near payment.");
-    expect(authored?.description).toBe("Trust at the payment moment.");
+    expect(authored?.context).toBe("Trust at the payment moment.");
     expect(authored?.kind).toBe("principle");
     expect(authored?.slug).toBe("trust");
   });
@@ -78,7 +78,7 @@ describe("ghost package", () => {
     // while loading, but must not vanish silently.
     await writeFile(
       join(dir, "features", "index.md"),
-      "---\ndescription: All feature UI.\nrelates:\n  - to: core\n---\n\nFeature prose.\n",
+      "---\ncontext: All feature UI.\nrelates:\n  - to: core\n---\n\nFeature prose.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));
@@ -131,7 +131,7 @@ Replacement rule.
     await writeGlossary(dir, ["principle"]);
     await writeFile(
       join(dir, "principle.density.md"),
-      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
+      "---\ncontext: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -149,7 +149,7 @@ Replacement rule.
     await writeGlossary(dir, ["principle"]);
     await writeFile(
       join(dir, "voice.md"),
-      "---\ndescription: Voice.\n---\n\nSpeak plainly.\n",
+      "---\ncontext: Voice.\n---\n\nSpeak plainly.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -162,7 +162,7 @@ Replacement rule.
     );
   });
 
-  it("warns when a node has no description", async () => {
+  it("warns when a node has no context", async () => {
     await writeManifest(dir);
     await writeGlossary(dir, ["principle"]);
     await writeFile(
@@ -173,18 +173,18 @@ Replacement rule.
     const report = await lintGhostPackage(dir);
 
     expect(report.errors).toBe(0);
-    // Undeclared cover + missing description.
+    // Undeclared cover + missing context.
     expect(report.warnings).toBe(2);
     expect(report.issues).toContainEqual(
       expect.objectContaining({
         severity: "warning",
-        rule: "node-description-missing",
+        rule: "node-context-missing",
         path: "principle.density.md",
       }),
     );
   });
 
-  it("does not warn about descriptions when every node has one", async () => {
+  it("reads deprecated description as context and warns to migrate", async () => {
     await writeManifest(dir);
     await writeGlossary(dir, ["principle"]);
     await writeFile(
@@ -192,11 +192,52 @@ Replacement rule.
       "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
+    const loaded = await loadGhostPackage(resolveGhostPackage(dir));
+    expect(loaded.catalog.nodes.get("principle.density")?.context).toBe(
+      "Density stance.",
+    );
+
+    const report = await lintGhostPackage(dir);
+    expect(report.errors).toBe(0);
+    expect(report.issues).toContainEqual(
+      expect.objectContaining({
+        severity: "warning",
+        rule: "node-description-deprecated",
+        path: "principle.density.md.description",
+      }),
+    );
+    expect(report.issues).not.toContainEqual(
+      expect.objectContaining({ rule: "node-context-missing" }),
+    );
+  });
+
+  it("prefers context when context and deprecated description coexist", async () => {
+    await writeManifest(dir);
+    await writeGlossary(dir, ["principle"]);
+    await writeFile(
+      join(dir, "principle.density.md"),
+      "---\ncontext: Canonical context.\ndescription: Legacy context.\n---\n\nUse density deliberately.\n",
+    );
+
+    const loaded = await loadGhostPackage(resolveGhostPackage(dir));
+    expect(loaded.catalog.nodes.get("principle.density")?.context).toBe(
+      "Canonical context.",
+    );
+  });
+
+  it("does not warn about context when every node has one", async () => {
+    await writeManifest(dir);
+    await writeGlossary(dir, ["principle"]);
+    await writeFile(
+      join(dir, "principle.density.md"),
+      "---\ncontext: Density stance.\n---\n\nUse density deliberately.\n",
+    );
+
     const report = await lintGhostPackage(dir);
 
     expect(report.errors).toBe(0);
     expect(report.issues).not.toContainEqual(
-      expect.objectContaining({ rule: "node-description-missing" }),
+      expect.objectContaining({ rule: "node-context-missing" }),
     );
   });
 
@@ -205,7 +246,7 @@ Replacement rule.
     await writeGlossary(dir, ["principle"]);
     await writeFile(
       join(dir, "principles.density.md"),
-      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
+      "---\ncontext: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -229,7 +270,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "principles.density.md"),
-      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
+      "---\ncontext: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -246,7 +287,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - brand/logo*.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
+      "---\ncontext: Logo.\nmaterials:\n  - brand/logo*.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));
@@ -262,7 +303,7 @@ Replacement rule.
     await mkdir(join(dir, "materials"), { recursive: true });
     await writeFile(
       join(dir, "materials", "asset.logo.md"),
-      "---\ndescription: Bundled material.\n---\n\nNot a node.\n",
+      "---\ncontext: Bundled material.\n---\n\nNot a node.\n",
     );
 
     const loadedFiles = await loadNodeFiles(dir);
@@ -287,7 +328,7 @@ Replacement rule.
     await writeFile(join(dir, "materials", "orphan.txt"), "orphan\n");
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - materials/claimed.txt\n  - missing/logo.svg\n  - https://example.com/logo.svg\n---\n\nLogo prose.\n",
+      "---\ncontext: Logo.\nmaterials:\n  - materials/claimed.txt\n  - missing/logo.svg\n  - https://example.com/logo.svg\n---\n\nLogo prose.\n",
     );
 
     const report = await lintGhostPackage(dir, dir);
@@ -319,7 +360,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - /absolute/logo.svg\n---\n\nLogo prose.\n",
+      "---\ncontext: Logo.\nmaterials:\n  - /absolute/logo.svg\n---\n\nLogo prose.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -335,7 +376,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
+      "---\ncontext: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
     );
     await writeChecks(dir, [
       [
@@ -380,12 +421,12 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "index.md"),
-      "---\ndescription: Start here.\n---\n\nFront door prose.\n",
+      "---\ncontext: Start here.\n---\n\nFront door prose.\n",
     );
     await mkdir(join(dir, "email"), { recursive: true });
     await writeFile(
       join(dir, "email", "index.md"),
-      "---\ndescription: Email surface.\n---\n\nEmail.\n",
+      "---\ncontext: Email surface.\n---\n\nEmail.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));

--- a/packages/ghost/test/ghost-core/node-schema.test.ts
+++ b/packages/ghost/test/ghost-core/node-schema.test.ts
@@ -43,14 +43,41 @@ describe("ghost.node/v1 schema", () => {
     expect(lintGhostNode(node("audience: enterprise")).errors).toBe(0);
   });
 
-  it("accepts a description (the retrieval payload)", () => {
-    expect(lintGhostNode(node("description: Lifecycle email.")).errors).toBe(0);
+  it("accepts context (the retrieval payload)", () => {
+    expect(lintGhostNode(node("context: Lifecycle email.")).errors).toBe(0);
+  });
+
+  it("accepts description as a deprecated read alias", () => {
+    const parsed = parseNode(node("description: Lifecycle email."));
+    expect(parsed.report.errors).toBe(0);
+    expect(parsed.node?.frontmatter.description).toBe("Lifecycle email.");
+  });
+
+  it("serializes the deprecated description alias as context", () => {
+    const serialized = serializeNode({
+      frontmatter: { description: "Lifecycle email." },
+      body: "Send only when useful.",
+    });
+    expect(serialized).toContain("context: Lifecycle email.");
+    expect(serialized).not.toContain("description:");
+  });
+
+  it("prefers context when both keys are present", () => {
+    const serialized = serializeNode({
+      frontmatter: {
+        context: "Canonical retrieval payload.",
+        description: "Legacy retrieval payload.",
+      },
+      body: "Body.",
+    });
+    expect(serialized).toContain("context: Canonical retrieval payload.");
+    expect(serialized).not.toContain("Legacy retrieval payload.");
   });
 
   it("round-trips through serialize/parse (frontmatter is properties only)", () => {
     const original: GhostNodeDocument = {
       frontmatter: {
-        description: "Near payment, reduce felt risk.",
+        context: "Near payment, reduce felt risk.",
       },
       body: "Near payment, reduce felt risk.",
     };
@@ -63,7 +90,7 @@ describe("ghost.node/v1 schema", () => {
   it("round-trips complete frontmatter through serialize/parse", () => {
     const original = {
       frontmatter: {
-        description: "Checkout trust signals.",
+        context: "Checkout trust signals.",
         materials: [
           "src/components/checkout/**",
           "https://example.com/logo.svg",
@@ -154,7 +181,7 @@ describe("ghost.node/v1 schema", () => {
     const serialized = serializeNode({
       frontmatter: {
         stage: "purchase",
-        description: "Checkout trust signals.",
+        context: "Checkout trust signals.",
         audience: "enterprise",
         materials: ["src/components/checkout/**"],
       },
@@ -163,7 +190,7 @@ describe("ghost.node/v1 schema", () => {
 
     expect(serialized).toMatchInlineSnapshot(`
       "---
-      description: Checkout trust signals.
+      context: Checkout trust signals.
       materials:
         - src/components/checkout/**
       audience: enterprise

--- a/packages/vessel-light/.ghost/anti-goal.median.md
+++ b/packages/vessel-light/.ghost/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-description: "The model's median defaults this ghost package refuses — gather for any greenfield visual surface or first-draft copy. Each rule is reject→replace; delete lines your brand legitimately violates."
+context: "The model's median defaults this ghost package refuses — gather for any greenfield visual surface or first-draft copy. Each rule is reject→replace; delete lines your brand legitimately violates."
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/vessel-light/.ghost/anti-goal.median.md
+++ b/packages/vessel-light/.ghost/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-context: "Any greenfield visual surface or first-draft copy — the model's median defaults this ghost package refuses. Each rule is reject→replace; delete lines your brand legitimately violates."
+context: Any greenfield visual surface or first-draft copy.
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/vessel-light/.ghost/anti-goal.median.md
+++ b/packages/vessel-light/.ghost/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-context: "The model's median defaults this ghost package refuses — gather for any greenfield visual surface or first-draft copy. Each rule is reject→replace; delete lines your brand legitimately violates."
+context: "Any greenfield visual surface or first-draft copy — the model's median defaults this ghost package refuses. Each rule is reject→replace; delete lines your brand legitimately violates."
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/vessel-light/.ghost/anti-goal.tells.md
+++ b/packages/vessel-light/.ghost/anti-goal.tells.md
@@ -1,5 +1,5 @@
 ---
-description: "Failure modes specific to this brand's own signature — gather alongside any signature node you pull."
+context: "Failure modes specific to this brand's own signature — gather alongside any signature node you pull."
 ---
 
 These are the near-misses of Vessel's own signature: outputs that got close

--- a/packages/vessel-light/.ghost/anti-goal.tells.md
+++ b/packages/vessel-light/.ghost/anti-goal.tells.md
@@ -1,5 +1,5 @@
 ---
-context: "Failure modes specific to this brand's own signature — gather alongside any signature node you pull."
+context: "Any work applying this brand's signature — the signature's own failure modes and model tells."
 ---
 
 These are the near-misses of Vessel's own signature: outputs that got close

--- a/packages/vessel-light/.ghost/anti-goal.tells.md
+++ b/packages/vessel-light/.ghost/anti-goal.tells.md
@@ -1,5 +1,5 @@
 ---
-context: "Any work applying this brand's signature — the signature's own failure modes and model tells."
+context: Any work applying this brand's signature.
 ---
 
 These are the near-misses of Vessel's own signature: outputs that got close

--- a/packages/vessel-light/.ghost/grammar.color-roles.md
+++ b/packages/vessel-light/.ghost/grammar.color-roles.md
@@ -1,5 +1,5 @@
 ---
-context: "Choosing any color — semantic roles, not raw values; status is meaning, expression is register-gated and never on controls."
+context: Choosing or applying color.
 materials:
   - materials/tokens.css
   - "**/*.css"

--- a/packages/vessel-light/.ghost/grammar.color-roles.md
+++ b/packages/vessel-light/.ghost/grammar.color-roles.md
@@ -1,5 +1,5 @@
 ---
-description: "Semantic color roles and the rules that govern them — gather before choosing any color; roles not raw values, status is meaning, expression is register-gated and never on controls."
+context: "Semantic color roles and the rules that govern them — gather before choosing any color; roles not raw values, status is meaning, expression is register-gated and never on controls."
 materials:
   - materials/tokens.css
   - "**/*.css"

--- a/packages/vessel-light/.ghost/grammar.color-roles.md
+++ b/packages/vessel-light/.ghost/grammar.color-roles.md
@@ -1,5 +1,5 @@
 ---
-context: "Semantic color roles and the rules that govern them — gather before choosing any color; roles not raw values, status is meaning, expression is register-gated and never on controls."
+context: "Choosing any color — semantic roles, not raw values; status is meaning, expression is register-gated and never on controls."
 materials:
   - materials/tokens.css
   - "**/*.css"

--- a/packages/vessel-light/.ghost/grammar.conversation.md
+++ b/packages/vessel-light/.ghost/grammar.conversation.md
@@ -1,5 +1,5 @@
 ---
-description: "Conversation grammar — plain assistant text, compact user surfaces, collapsed tool calls, one structured prompt input; gather for any AI thread, agent console, review assistant, or prompt composer."
+context: "Conversation grammar — plain assistant text, compact user surfaces, collapsed tool calls, one structured prompt input; gather for any AI thread, agent console, review assistant, or prompt composer."
 materials:
   - materials/ref/composition.conversation.html
   - "**/*.html"

--- a/packages/vessel-light/.ghost/grammar.conversation.md
+++ b/packages/vessel-light/.ghost/grammar.conversation.md
@@ -1,5 +1,5 @@
 ---
-context: "Any AI thread, agent console, review assistant, or prompt composer — plain assistant text, compact user surfaces, collapsed tool calls, one structured prompt input."
+context: Any AI thread, agent console, review assistant, or prompt composer.
 materials:
   - materials/ref/composition.conversation.html
   - "**/*.html"

--- a/packages/vessel-light/.ghost/grammar.conversation.md
+++ b/packages/vessel-light/.ghost/grammar.conversation.md
@@ -1,5 +1,5 @@
 ---
-context: "Conversation grammar — plain assistant text, compact user surfaces, collapsed tool calls, one structured prompt input; gather for any AI thread, agent console, review assistant, or prompt composer."
+context: "Any AI thread, agent console, review assistant, or prompt composer — plain assistant text, compact user surfaces, collapsed tool calls, one structured prompt input."
 materials:
   - materials/ref/composition.conversation.html
   - "**/*.html"

--- a/packages/vessel-light/.ghost/grammar.deletion.md
+++ b/packages/vessel-light/.ghost/grammar.deletion.md
@@ -1,5 +1,5 @@
 ---
-context: "The final pass over any composition, or whenever a view feels crowded, busy, or dressed up — every element must name what breaks if it goes; demote or delete, never add emphasis."
+context: The final pass over any composition, or whenever a view feels crowded, busy, or dressed up.
 ---
 
 Restraint is not a mood; it is a test every element has to pass. Before a

--- a/packages/vessel-light/.ghost/grammar.deletion.md
+++ b/packages/vessel-light/.ghost/grammar.deletion.md
@@ -1,5 +1,5 @@
 ---
-description: "The deletion pass — every element must name what breaks if it goes; the fix for a crowded view is always demotion or deletion, never more emphasis; surfaces arrive settled, with no skeleton theater. Gather as the final pass over any composition, and whenever a view feels crowded, busy, or dressed up."
+context: "The deletion pass — every element must name what breaks if it goes; the fix for a crowded view is always demotion or deletion, never more emphasis; surfaces arrive settled, with no skeleton theater. Gather as the final pass over any composition, and whenever a view feels crowded, busy, or dressed up."
 ---
 
 Restraint is not a mood; it is a test every element has to pass. Before a

--- a/packages/vessel-light/.ghost/grammar.deletion.md
+++ b/packages/vessel-light/.ghost/grammar.deletion.md
@@ -1,5 +1,5 @@
 ---
-context: "The deletion pass — every element must name what breaks if it goes; the fix for a crowded view is always demotion or deletion, never more emphasis; surfaces arrive settled, with no skeleton theater. Gather as the final pass over any composition, and whenever a view feels crowded, busy, or dressed up."
+context: "The final pass over any composition, or whenever a view feels crowded, busy, or dressed up — every element must name what breaks if it goes; demote or delete, never add emphasis."
 ---
 
 Restraint is not a mood; it is a test every element has to pass. Before a

--- a/packages/vessel-light/.ghost/grammar.hierarchy.md
+++ b/packages/vessel-light/.ghost/grammar.hierarchy.md
@@ -1,5 +1,5 @@
 ---
-context: "The closed hierarchy vocabulary — six text variants, seven tones, a five-rung control emphasis ladder, one primary per view — gather for any view that contains text or actions."
+context: "Any view containing text or actions — six text variants, seven tones, a five-rung control emphasis ladder, one primary per view."
 materials:
   - materials/primitives.css
   - materials/ref/composition.form.html

--- a/packages/vessel-light/.ghost/grammar.hierarchy.md
+++ b/packages/vessel-light/.ghost/grammar.hierarchy.md
@@ -1,5 +1,5 @@
 ---
-context: "Any view containing text or actions — six text variants, seven tones, a five-rung control emphasis ladder, one primary per view."
+context: Any view containing text or actions.
 materials:
   - materials/primitives.css
   - materials/ref/composition.form.html

--- a/packages/vessel-light/.ghost/grammar.hierarchy.md
+++ b/packages/vessel-light/.ghost/grammar.hierarchy.md
@@ -1,5 +1,5 @@
 ---
-description: "The closed hierarchy vocabulary — six text variants, seven tones, a five-rung control emphasis ladder, one primary per view — gather for any view that contains text or actions."
+context: "The closed hierarchy vocabulary — six text variants, seven tones, a five-rung control emphasis ladder, one primary per view — gather for any view that contains text or actions."
 materials:
   - materials/primitives.css
   - materials/ref/composition.form.html

--- a/packages/vessel-light/.ghost/grammar.job.md
+++ b/packages/vessel-light/.ghost/grammar.job.md
@@ -1,5 +1,5 @@
 ---
-context: "Any new view before structure exists — the reader's job picks the ref to imitate and the register that applies, never the topic."
+context: Any new view before its structure or register is chosen.
 materials:
   - materials/ref/composition.form.html
   - materials/ref/composition.table.html

--- a/packages/vessel-light/.ghost/grammar.job.md
+++ b/packages/vessel-light/.ghost/grammar.job.md
@@ -1,5 +1,5 @@
 ---
-context: "The routing rule — name the reader's job before composing anything; the job picks the ref to imitate and the register that applies, never the topic. Gather first for any new view, before structure exists."
+context: "Any new view before structure exists — the reader's job picks the ref to imitate and the register that applies, never the topic."
 materials:
   - materials/ref/composition.form.html
   - materials/ref/composition.table.html

--- a/packages/vessel-light/.ghost/grammar.job.md
+++ b/packages/vessel-light/.ghost/grammar.job.md
@@ -1,5 +1,5 @@
 ---
-description: "The routing rule — name the reader's job before composing anything; the job picks the ref to imitate and the register that applies, never the topic. Gather first for any new view, before structure exists."
+context: "The routing rule — name the reader's job before composing anything; the job picks the ref to imitate and the register that applies, never the topic. Gather first for any new view, before structure exists."
 materials:
   - materials/ref/composition.form.html
   - materials/ref/composition.table.html

--- a/packages/vessel-light/.ghost/grammar.motion.md
+++ b/packages/vessel-light/.ghost/grammar.motion.md
@@ -1,5 +1,5 @@
 ---
-description: "Motion doctrine — motion is evidence of state change, never decoration; a closed vocabulary of three duration roles and one ease; gather for any transition, animation, or hover treatment."
+context: "Motion doctrine — motion is evidence of state change, never decoration; a closed vocabulary of three duration roles and one ease; gather for any transition, animation, or hover treatment."
 materials:
   - materials/tokens.css
   - "**/*.css"

--- a/packages/vessel-light/.ghost/grammar.motion.md
+++ b/packages/vessel-light/.ghost/grammar.motion.md
@@ -1,5 +1,5 @@
 ---
-context: "Any transition, animation, or hover treatment — motion is evidence of state change, never decoration; three duration roles and one ease form the closed vocabulary."
+context: Any transition, animation, or hover treatment.
 materials:
   - materials/tokens.css
   - "**/*.css"

--- a/packages/vessel-light/.ghost/grammar.motion.md
+++ b/packages/vessel-light/.ghost/grammar.motion.md
@@ -1,5 +1,5 @@
 ---
-context: "Motion doctrine — motion is evidence of state change, never decoration; a closed vocabulary of three duration roles and one ease; gather for any transition, animation, or hover treatment."
+context: "Any transition, animation, or hover treatment — motion is evidence of state change, never decoration; three duration roles and one ease form the closed vocabulary."
 materials:
   - materials/tokens.css
   - "**/*.css"

--- a/packages/vessel-light/.ghost/grammar.rhythm.md
+++ b/packages/vessel-light/.ghost/grammar.rhythm.md
@@ -1,5 +1,5 @@
 ---
-context: "Layout rhythm — all layout is stacks with a closed gap step set; gather before laying anything out; never ad-hoc sibling margins."
+context: "Laying out any view — all layout is stacks with a closed gap step set; never ad-hoc sibling margins."
 materials:
   - materials/primitives.css
   - "**/*.html"

--- a/packages/vessel-light/.ghost/grammar.rhythm.md
+++ b/packages/vessel-light/.ghost/grammar.rhythm.md
@@ -1,5 +1,5 @@
 ---
-description: "Layout rhythm — all layout is stacks with a closed gap step set; gather before laying anything out; never ad-hoc sibling margins."
+context: "Layout rhythm — all layout is stacks with a closed gap step set; gather before laying anything out; never ad-hoc sibling margins."
 materials:
   - materials/primitives.css
   - "**/*.html"

--- a/packages/vessel-light/.ghost/grammar.rhythm.md
+++ b/packages/vessel-light/.ghost/grammar.rhythm.md
@@ -1,5 +1,5 @@
 ---
-context: "Laying out any view — all layout is stacks with a closed gap step set; never ad-hoc sibling margins."
+context: Laying out any view.
 materials:
   - materials/primitives.css
   - "**/*.html"

--- a/packages/vessel-light/.ghost/grammar.surfaces.md
+++ b/packages/vessel-light/.ghost/grammar.surfaces.md
@@ -1,5 +1,5 @@
 ---
-context: "Any card, popover, modal, dialog, scrim, or bordered container — flat is the default, borders are structural, exactly three elevation tiers."
+context: Any card, popover, modal, dialog, scrim, or bordered container.
 materials:
   - materials/primitives.css
   - materials/ref/composition.overlay.html

--- a/packages/vessel-light/.ghost/grammar.surfaces.md
+++ b/packages/vessel-light/.ghost/grammar.surfaces.md
@@ -1,5 +1,5 @@
 ---
-context: "Surface roles and the closed elevation set — gather for any card, popover, modal, dialog, scrim, or bordered container; flat is the default, borders are structural, exactly three elevation tiers."
+context: "Any card, popover, modal, dialog, scrim, or bordered container — flat is the default, borders are structural, exactly three elevation tiers."
 materials:
   - materials/primitives.css
   - materials/ref/composition.overlay.html

--- a/packages/vessel-light/.ghost/grammar.surfaces.md
+++ b/packages/vessel-light/.ghost/grammar.surfaces.md
@@ -1,5 +1,5 @@
 ---
-description: "Surface roles and the closed elevation set — gather for any card, popover, modal, dialog, scrim, or bordered container; flat is the default, borders are structural, exactly three elevation tiers."
+context: "Surface roles and the closed elevation set — gather for any card, popover, modal, dialog, scrim, or bordered container; flat is the default, borders are structural, exactly three elevation tiers."
 materials:
   - materials/primitives.css
   - materials/ref/composition.overlay.html

--- a/packages/vessel-light/.ghost/index.md
+++ b/packages/vessel-light/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-context: "Vessel's complete design language as a raw HTML/CSS steering packet for agents."
+context: Any task using the complete Vessel design language.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/index.md
+++ b/packages/vessel-light/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-context: "Always read first: Vessel's design language as a raw HTML/CSS steering packet for agents."
+context: "Vessel's complete design language as a raw HTML/CSS steering packet for agents."
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/index.md
+++ b/packages/vessel-light/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Always read first: Vessel's design language as a raw HTML/CSS steering packet for agents."
+context: "Always read first: Vessel's design language as a raw HTML/CSS steering packet for agents."
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/register.data-density.md
+++ b/packages/vessel-light/.ghost/register.data-density.md
@@ -1,5 +1,5 @@
 ---
-description: "Data-dense consoles — gather for tables, dashboards, logs, and monitoring; compresses product rhythm to the two smallest gap steps, mono numerals, muted-first."
+context: "Data-dense consoles — gather for tables, dashboards, logs, and monitoring; compresses product rhythm to the two smallest gap steps, mono numerals, muted-first."
 materials:
   - materials/ref/composition.table.html
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/register.data-density.md
+++ b/packages/vessel-light/.ghost/register.data-density.md
@@ -1,5 +1,5 @@
 ---
-context: "Data-dense consoles — gather for tables, dashboards, logs, and monitoring; compresses product rhythm to the two smallest gap steps, mono numerals, muted-first."
+context: "Tables, dashboards, logs, and monitoring — data-dense consoles compress product rhythm to the two smallest gap steps, mono numerals, muted-first."
 materials:
   - materials/ref/composition.table.html
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/register.data-density.md
+++ b/packages/vessel-light/.ghost/register.data-density.md
@@ -1,5 +1,5 @@
 ---
-context: "Tables, dashboards, logs, and monitoring — data-dense consoles compress product rhythm to the two smallest gap steps, mono numerals, muted-first."
+context: Tables, dashboards, logs, monitoring, or other data-dense consoles.
 materials:
   - materials/ref/composition.table.html
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/register.editorial.md
+++ b/packages/vessel-light/.ghost/register.editorial.md
@@ -1,5 +1,5 @@
 ---
-context: "Heroes, marketing pages, pull quotes, and full-bleed dark moments — editorial and landing surfaces invert product type restraint."
+context: Heroes, marketing pages, pull quotes, or full-bleed dark moments.
 materials:
   - materials/ref/composition.editorial.html
   - materials/tokens.css

--- a/packages/vessel-light/.ghost/register.editorial.md
+++ b/packages/vessel-light/.ghost/register.editorial.md
@@ -1,5 +1,5 @@
 ---
-description: "Editorial and landing surfaces — gather for heroes, marketing pages, pull quotes, and full-bleed dark moments; inverts product type restraint."
+context: "Editorial and landing surfaces — gather for heroes, marketing pages, pull quotes, and full-bleed dark moments; inverts product type restraint."
 materials:
   - materials/ref/composition.editorial.html
   - materials/tokens.css

--- a/packages/vessel-light/.ghost/register.editorial.md
+++ b/packages/vessel-light/.ghost/register.editorial.md
@@ -1,5 +1,5 @@
 ---
-context: "Editorial and landing surfaces — gather for heroes, marketing pages, pull quotes, and full-bleed dark moments; inverts product type restraint."
+context: "Heroes, marketing pages, pull quotes, and full-bleed dark moments — editorial and landing surfaces invert product type restraint."
 materials:
   - materials/ref/composition.editorial.html
   - materials/tokens.css

--- a/packages/vessel-light/.ghost/register.email.md
+++ b/packages/vessel-light/.ghost/register.email.md
@@ -1,5 +1,5 @@
 ---
-description: "Transactional email — gather ONLY for email; inverts the token contract: inline styles, hardcoded hex transcribed from tokens.css, table layout, system fonts."
+context: "Transactional email — gather ONLY for email; inverts the token contract: inline styles, hardcoded hex transcribed from tokens.css, table layout, system fonts."
 materials:
   - materials/ref/email.html
 ---

--- a/packages/vessel-light/.ghost/register.email.md
+++ b/packages/vessel-light/.ghost/register.email.md
@@ -1,5 +1,5 @@
 ---
-context: "Transactional email — gather ONLY for email; inverts the token contract: inline styles, hardcoded hex transcribed from tokens.css, table layout, system fonts."
+context: "Transactional email only — inline styles, hardcoded hex transcribed from tokens.css, table layout, and system fonts invert the token contract."
 materials:
   - materials/ref/email.html
 ---

--- a/packages/vessel-light/.ghost/register.email.md
+++ b/packages/vessel-light/.ghost/register.email.md
@@ -1,5 +1,5 @@
 ---
-context: "Transactional email only — inline styles, hardcoded hex transcribed from tokens.css, table layout, and system fonts invert the token contract."
+context: Transactional email only.
 materials:
   - materials/ref/email.html
 ---

--- a/packages/vessel-light/.ghost/signature.palette.md
+++ b/packages/vessel-light/.ghost/signature.palette.md
@@ -1,5 +1,5 @@
 ---
-context: "Gather whenever color beyond the base roles is in question, in any register. The palette dial: a monochrome spine plus a closed expression set whose volume rises with the register — this brand's current answer is gray plus five named hues."
+context: "Color beyond the base roles in any register — a monochrome spine plus a closed expression set whose volume rises with the register; this brand's current answer is gray plus five named hues."
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.palette.md
+++ b/packages/vessel-light/.ghost/signature.palette.md
@@ -1,5 +1,5 @@
 ---
-context: "Color beyond the base roles in any register — a monochrome spine plus a closed expression set whose volume rises with the register; this brand's current answer is gray plus five named hues."
+context: Color beyond the base roles, in any register.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.palette.md
+++ b/packages/vessel-light/.ghost/signature.palette.md
@@ -1,5 +1,5 @@
 ---
-description: "Gather whenever color beyond the base roles is in question, in any register. The palette dial: a monochrome spine plus a closed expression set whose volume rises with the register — this brand's current answer is gray plus five named hues."
+context: "Gather whenever color beyond the base roles is in question, in any register. The palette dial: a monochrome spine plus a closed expression set whose volume rises with the register — this brand's current answer is gray plus five named hues."
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.shape.md
+++ b/packages/vessel-light/.ghost/signature.shape.md
@@ -1,5 +1,5 @@
 ---
-description: "Gather before setting any radius or corner treatment. The shape dial: controls take --radius-control, surfaces take --radius-surface — this brand's current answer is pills on controls and a 20px signature radius on surfaces."
+context: "Gather before setting any radius or corner treatment. The shape dial: controls take --radius-control, surfaces take --radius-surface — this brand's current answer is pills on controls and a 20px signature radius on surfaces."
 materials:
   - materials/tokens.css
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/signature.shape.md
+++ b/packages/vessel-light/.ghost/signature.shape.md
@@ -1,5 +1,5 @@
 ---
-context: "Gather before setting any radius or corner treatment. The shape dial: controls take --radius-control, surfaces take --radius-surface — this brand's current answer is pills on controls and a 20px signature radius on surfaces."
+context: "Any radius or corner treatment — controls take --radius-control and surfaces take --radius-surface; this brand's current answer is pills on controls and a 20px signature radius on surfaces."
 materials:
   - materials/tokens.css
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/signature.shape.md
+++ b/packages/vessel-light/.ghost/signature.shape.md
@@ -1,5 +1,5 @@
 ---
-context: "Any radius or corner treatment — controls take --radius-control and surfaces take --radius-surface; this brand's current answer is pills on controls and a 20px signature radius on surfaces."
+context: Choosing or implementing any radius or corner treatment.
 materials:
   - materials/tokens.css
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/signature.temperature.md
+++ b/packages/vessel-light/.ghost/signature.temperature.md
@@ -1,5 +1,5 @@
 ---
-context: "Gather for any copy and for motion character. The temperature dial: how the brand sounds and how it moves — this brand's current answer is factual, quiet, never celebratory, with resolved spring motion."
+context: "Any copy, and the character of any motion — factual, quiet, never celebratory, with resolved spring motion."
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.temperature.md
+++ b/packages/vessel-light/.ghost/signature.temperature.md
@@ -1,5 +1,5 @@
 ---
-description: "Gather for any copy and for motion character. The temperature dial: how the brand sounds and how it moves — this brand's current answer is factual, quiet, never celebratory, with resolved spring motion."
+context: "Gather for any copy and for motion character. The temperature dial: how the brand sounds and how it moves — this brand's current answer is factual, quiet, never celebratory, with resolved spring motion."
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.temperature.md
+++ b/packages/vessel-light/.ghost/signature.temperature.md
@@ -1,5 +1,5 @@
 ---
-context: "Any copy, and the character of any motion — factual, quiet, never celebratory, with resolved spring motion."
+context: Writing any copy or choosing the character of motion.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.type.md
+++ b/packages/vessel-light/.ghost/signature.type.md
@@ -1,5 +1,5 @@
 ---
-description: "Gather for any text, and for heroes, landing pages, and editorial moments. The type dial: one voice typeface plus a mono for machine detail, with an editorial heading scale kept separate from product text — this brand's current answer is HK Grotesk."
+context: "Gather for any text, and for heroes, landing pages, and editorial moments. The type dial: one voice typeface plus a mono for machine detail, with an editorial heading scale kept separate from product text — this brand's current answer is HK Grotesk."
 materials:
   - materials/tokens.css
   - materials/fonts/*.woff2

--- a/packages/vessel-light/.ghost/signature.type.md
+++ b/packages/vessel-light/.ghost/signature.type.md
@@ -1,5 +1,5 @@
 ---
-context: "Any text, hero, landing page, or editorial moment — one voice typeface plus mono for machine detail, with an editorial heading scale separate from product text; this brand's current answer is HK Grotesk."
+context: Any text, hero, landing page, or editorial moment.
 materials:
   - materials/tokens.css
   - materials/fonts/*.woff2

--- a/packages/vessel-light/.ghost/signature.type.md
+++ b/packages/vessel-light/.ghost/signature.type.md
@@ -1,5 +1,5 @@
 ---
-context: "Gather for any text, and for heroes, landing pages, and editorial moments. The type dial: one voice typeface plus a mono for machine detail, with an editorial heading scale kept separate from product text — this brand's current answer is HK Grotesk."
+context: "Any text, hero, landing page, or editorial moment — one voice typeface plus mono for machine detail, with an editorial heading scale separate from product text; this brand's current answer is HK Grotesk."
 materials:
   - materials/tokens.css
   - materials/fonts/*.woff2

--- a/packages/vessel-react/.ghost/asset.registry.md
+++ b/packages/vessel-react/.ghost/asset.registry.md
@@ -1,5 +1,5 @@
 ---
-context: The shadcn registry is the distribution surface — copy-and-own, with decision metadata as part of the API.
+context: Changing registry distribution, registry metadata, or copy-and-own component delivery.
 materials:
   - packages/vessel-react/registry.json
   - packages/vessel-react/public/r/**

--- a/packages/vessel-react/.ghost/asset.registry.md
+++ b/packages/vessel-react/.ghost/asset.registry.md
@@ -1,5 +1,5 @@
 ---
-description: The shadcn registry is the distribution surface — copy-and-own, with decision metadata as part of the API.
+context: The shadcn registry is the distribution surface — copy-and-own, with decision metadata as part of the API.
 materials:
   - packages/vessel-react/registry.json
   - packages/vessel-react/public/r/**

--- a/packages/vessel-react/.ghost/asset.tokens.md
+++ b/packages/vessel-react/.ghost/asset.tokens.md
@@ -1,5 +1,5 @@
 ---
-context: The token contract — primitives feed semantic roles, extensions stay narrow and job-named, no broad alias sprawl.
+context: Changing tokens, semantic roles, or the Tailwind utility bridge.
 materials:
   - packages/vessel-react/src/styles/main.css
   - packages/vessel-react/src/styles/*.css

--- a/packages/vessel-react/.ghost/asset.tokens.md
+++ b/packages/vessel-react/.ghost/asset.tokens.md
@@ -1,5 +1,5 @@
 ---
-description: The token contract — primitives feed semantic roles, extensions stay narrow and job-named, no broad alias sprawl.
+context: The token contract — primitives feed semantic roles, extensions stay narrow and job-named, no broad alias sprawl.
 materials:
   - packages/vessel-react/src/styles/main.css
   - packages/vessel-react/src/styles/*.css

--- a/packages/vessel-react/.ghost/condition.escape-hatches.md
+++ b/packages/vessel-react/.ghost/condition.escape-hatches.md
@@ -1,5 +1,5 @@
 ---
-description: When component work needs className, inline style, or arbitrary values — the governed escape-hatch path.
+context: When component work needs className, inline style, or arbitrary values — the governed escape-hatch path.
 materials:
   - packages/vessel-react/scripts/audit-agent-safety.mjs
 ---

--- a/packages/vessel-react/.ghost/condition.escape-hatches.md
+++ b/packages/vessel-react/.ghost/condition.escape-hatches.md
@@ -1,5 +1,5 @@
 ---
-context: When component work needs className, inline style, or arbitrary values — the governed escape-hatch path.
+context: Component work needs className, inline style, arbitrary values, or a local primitive fork.
 materials:
   - packages/vessel-react/scripts/audit-agent-safety.mjs
 ---

--- a/packages/vessel-react/.ghost/condition.upstream-sync.md
+++ b/packages/vessel-react/.ghost/condition.upstream-sync.md
@@ -1,5 +1,5 @@
 ---
-context: When reconciling with latest upstream shadcn — adopt mechanics, adapt anatomy, reject generic visual decisions.
+context: Reconciling Vessel with upstream shadcn or evaluating an upstream change.
 ---
 
 Condition: you are syncing Vessel components against newer upstream shadcn

--- a/packages/vessel-react/.ghost/condition.upstream-sync.md
+++ b/packages/vessel-react/.ghost/condition.upstream-sync.md
@@ -1,5 +1,5 @@
 ---
-description: When reconciling with latest upstream shadcn — adopt mechanics, adapt anatomy, reject generic visual decisions.
+context: When reconciling with latest upstream shadcn — adopt mechanics, adapt anatomy, reject generic visual decisions.
 ---
 
 Condition: you are syncing Vessel components against newer upstream shadcn

--- a/packages/vessel-react/.ghost/index.md
+++ b/packages/vessel-react/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-context: The Vessel fingerprint’s coverage map — what each node kind governs and how the pieces fit together.
+context: Any task changing the Vessel workspace.
 ---
 
 Vessel is ghost's reference body: an agnostic, agent-safe shadcn-compatible

--- a/packages/vessel-react/.ghost/index.md
+++ b/packages/vessel-react/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-description: Start here — what the Vessel fingerprint covers and how to read it.
+context: Start here — what the Vessel fingerprint covers and how to read it.
 ---
 
 Vessel is ghost's reference body: an agnostic, agent-safe shadcn-compatible

--- a/packages/vessel-react/.ghost/index.md
+++ b/packages/vessel-react/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-context: Start here — what the Vessel fingerprint covers and how to read it.
+context: The Vessel fingerprint’s coverage map — what each node kind governs and how the pieces fit together.
 ---
 
 Vessel is ghost's reference body: an agnostic, agent-safe shadcn-compatible

--- a/packages/vessel-react/.ghost/principle.named-decisions.md
+++ b/packages/vessel-react/.ghost/principle.named-decisions.md
@@ -1,5 +1,5 @@
 ---
-description: Make off-system output hard to express — decision names beat raw values, checks beat prose.
+context: Make off-system output hard to express — decision names beat raw values, checks beat prose.
 materials:
   - packages/vessel-react/src/components/**
   - packages/vessel-react/scripts/audit-agent-safety.mjs

--- a/packages/vessel-react/.ghost/principle.named-decisions.md
+++ b/packages/vessel-react/.ghost/principle.named-decisions.md
@@ -1,5 +1,5 @@
 ---
-context: Make off-system output hard to express — decision names beat raw values, checks beat prose.
+context: Authoring or reviewing components and tokens — make off-system output hard to express; decision names beat raw values, checks beat prose.
 materials:
   - packages/vessel-react/src/components/**
   - packages/vessel-react/scripts/audit-agent-safety.mjs

--- a/packages/vessel-react/.ghost/principle.named-decisions.md
+++ b/packages/vessel-react/.ghost/principle.named-decisions.md
@@ -1,5 +1,5 @@
 ---
-context: Authoring or reviewing components and tokens — make off-system output hard to express; decision names beat raw values, checks beat prose.
+context: Authoring or reviewing components, tokens, variants, or agent-safety checks.
 materials:
   - packages/vessel-react/src/components/**
   - packages/vessel-react/scripts/audit-agent-safety.mjs

--- a/packages/vessel-react/.ghost/principle.reference-not-brand.md
+++ b/packages/vessel-react/.ghost/principle.reference-not-brand.md
@@ -1,5 +1,5 @@
 ---
-description: Vessel is an agnostic reference body a product fingerprint inhabits — never the brand truth for any consumer.
+context: Vessel is an agnostic reference body a product fingerprint inhabits — never the brand truth for any consumer.
 ---
 
 Vessel provides a coherent implementation vocabulary — tokens, primitives, AI

--- a/packages/vessel-react/.ghost/principle.reference-not-brand.md
+++ b/packages/vessel-react/.ghost/principle.reference-not-brand.md
@@ -1,5 +1,5 @@
 ---
-context: Vessel is an agnostic reference body a product fingerprint inhabits — never the brand truth for any consumer.
+context: Any Vessel change that could encode product-specific brand truth.
 ---
 
 Vessel provides a coherent implementation vocabulary — tokens, primitives, AI

--- a/packages/vessel-react/fingerprint/anti-goal.median.md
+++ b/packages/vessel-react/fingerprint/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-context: "The measured defaults of unsteered generation — gather before any build to know what the model will reach for on its own, and veer."
+context: "Any build — the measured defaults the model reaches for unsteered, each paired with the veer away."
 ---
 
 These are not aesthetic opinions. They are the measured convergence of 300

--- a/packages/vessel-react/fingerprint/anti-goal.median.md
+++ b/packages/vessel-react/fingerprint/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-context: "Any build — the measured defaults the model reaches for unsteered, each paired with the veer away."
+context: Any build using the vendored component set.
 ---
 
 These are not aesthetic opinions. They are the measured convergence of 300

--- a/packages/vessel-react/fingerprint/anti-goal.median.md
+++ b/packages/vessel-react/fingerprint/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-description: "The measured defaults of unsteered generation — gather before any build to know what the model will reach for on its own, and veer."
+context: "The measured defaults of unsteered generation — gather before any build to know what the model will reach for on its own, and veer."
 ---
 
 These are not aesthetic opinions. They are the measured convergence of 300

--- a/packages/vessel-react/fingerprint/contract.theming.md
+++ b/packages/vessel-react/fingerprint/contract.theming.md
@@ -1,5 +1,5 @@
 ---
-description: "The theming seams — which token bindings a theme may rebind freely, and which relationships must hold in every theme."
+context: "The theming seams — which token bindings a theme may rebind freely, and which relationships must hold in every theme."
 materials:
   - "**/styles/main.css"
 ---

--- a/packages/vessel-react/fingerprint/contract.theming.md
+++ b/packages/vessel-react/fingerprint/contract.theming.md
@@ -1,5 +1,5 @@
 ---
-context: "The theming seams — which token bindings a theme may rebind freely, and which relationships must hold in every theme."
+context: Creating or changing a theme, token binding, font stack, radius, shadow, or gray ramp.
 materials:
   - "**/styles/main.css"
 ---

--- a/packages/vessel-react/fingerprint/contract.tokens.md
+++ b/packages/vessel-react/fingerprint/contract.tokens.md
@@ -1,5 +1,5 @@
 ---
-description: The token pipeline — primitive values feed semantic roles, components author role-first, extensions stay narrow and job-named.
+context: The token pipeline — primitive values feed semantic roles, components author role-first, extensions stay narrow and job-named.
 materials:
   - "**/styles/main.css"
   - "**/components/ui/**/*.tsx"

--- a/packages/vessel-react/fingerprint/contract.tokens.md
+++ b/packages/vessel-react/fingerprint/contract.tokens.md
@@ -1,5 +1,5 @@
 ---
-context: The token pipeline — primitive values feed semantic roles, components author role-first, extensions stay narrow and job-named.
+context: Changing tokens, component styles, semantic roles, or the Tailwind utility bridge.
 materials:
   - "**/styles/main.css"
   - "**/components/ui/**/*.tsx"

--- a/packages/vessel-react/fingerprint/index.md
+++ b/packages/vessel-react/fingerprint/index.md
@@ -1,5 +1,5 @@
 ---
-context: "This vendored ghost package, what it governs, and the rule that this repo's own nodes always win."
+context: Any task using or changing the vendored component set.
 materials:
   - "**/styles/main.css"
 ---

--- a/packages/vessel-react/fingerprint/index.md
+++ b/packages/vessel-react/fingerprint/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Always read first: what this vendored ghost package is, what it governs, and that this repo's own nodes always win."
+context: "Always read first: what this vendored ghost package is, what it governs, and that this repo's own nodes always win."
 materials:
   - "**/styles/main.css"
 ---

--- a/packages/vessel-react/fingerprint/index.md
+++ b/packages/vessel-react/fingerprint/index.md
@@ -1,5 +1,5 @@
 ---
-context: "Always read first: what this vendored ghost package is, what it governs, and that this repo's own nodes always win."
+context: "This vendored ghost package, what it governs, and the rule that this repo's own nodes always win."
 materials:
   - "**/styles/main.css"
 ---

--- a/packages/vessel-react/fingerprint/pattern.conversation.md
+++ b/packages/vessel-react/fingerprint/pattern.conversation.md
@@ -1,5 +1,5 @@
 ---
-context: Conversation grammar for AI surfaces — assistant prose on the page surface, quiet user containment, tools and reasoning as collapsed affordances.
+context: Any AI conversation, prompt input, reasoning display, or tool output.
 materials:
   - "**/components/ai-elements/conversation.tsx"
   - "**/components/ai-elements/message.tsx"

--- a/packages/vessel-react/fingerprint/pattern.conversation.md
+++ b/packages/vessel-react/fingerprint/pattern.conversation.md
@@ -1,5 +1,5 @@
 ---
-description: Conversation grammar for AI surfaces — assistant prose on the page surface, quiet user containment, tools and reasoning as collapsed affordances.
+context: Conversation grammar for AI surfaces — assistant prose on the page surface, quiet user containment, tools and reasoning as collapsed affordances.
 materials:
   - "**/components/ai-elements/conversation.tsx"
   - "**/components/ai-elements/message.tsx"

--- a/packages/vessel-react/fingerprint/primitive.composition.md
+++ b/packages/vessel-react/fingerprint/primitive.composition.md
@@ -1,5 +1,5 @@
 ---
-description: Stack, Surface, and Text — rhythm from the gap scale, elevation as interaction tiers, type from the variant vocabulary.
+context: Stack, Surface, and Text — rhythm from the gap scale, elevation as interaction tiers, type from the variant vocabulary.
 materials:
   - "**/components/ui/stack.tsx"
   - "**/components/ui/surface.tsx"

--- a/packages/vessel-react/fingerprint/primitive.composition.md
+++ b/packages/vessel-react/fingerprint/primitive.composition.md
@@ -1,5 +1,5 @@
 ---
-context: Stack, Surface, and Text — rhythm from the gap scale, elevation as interaction tiers, type from the variant vocabulary.
+context: Composing layout, surfaces, text hierarchy, spacing, cards, separators, or loading states.
 materials:
   - "**/components/ui/stack.tsx"
   - "**/components/ui/surface.tsx"

--- a/packages/vessel-react/fingerprint/primitive.controls.md
+++ b/packages/vessel-react/fingerprint/primitive.controls.md
@@ -1,5 +1,5 @@
 ---
-description: Buttons, inputs, and forms — one primary action per view, quiet fields, focus rings as guidance, errors as facts at the field.
+context: Buttons, inputs, and forms — one primary action per view, quiet fields, focus rings as guidance, errors as facts at the field.
 materials:
   - "**/components/ui/button.tsx"
   - "**/components/ui/button-group.tsx"

--- a/packages/vessel-react/fingerprint/primitive.controls.md
+++ b/packages/vessel-react/fingerprint/primitive.controls.md
@@ -1,5 +1,5 @@
 ---
-context: Buttons, inputs, and forms — one primary action per view, quiet fields, focus rings as guidance, errors as facts at the field.
+context: Any view with buttons, inputs, forms, labels, or field errors.
 materials:
   - "**/components/ui/button.tsx"
   - "**/components/ui/button-group.tsx"


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Agents can use clearer `context` frontmatter to decide which brand guidance applies without silently losing retrieval coverage.
**Problem:** Node retrieval currently reads `description`, so authors cannot rename the field to `context` without producing blank gather menus. A fingerprint-only migration would validate successfully while quietly making nodes undiscoverable.
**Solution:** Make `context` canonical throughout schema, catalog, gather, pull, review, serialization, validation, docs, and repo-owned packages. Keep `description` as a deprecated compatibility alias for one release, warn on its use, and serialize it back as `context` so existing packages remain retrievable during migration.

**Validation:**
- `pnpm check`: passed
- `pnpm exec vitest run packages/ghost/test packages/context-control/test`: passed, 180 passed and 1 skipped
- `pnpm test`: 203 passed and 1 skipped; one unrelated local environment failure in `steering-control` because `process.execPath` contains a space and `ghostBin.split()` attempts to execute `/Users/chai/Library/Application`
- `ghost validate` for `apps/docs/.ghost` and `packages/vessel-light/.ghost`: passed with no warnings
- `ghost validate` for `packages/vessel-react/.ghost`: passed with its existing `cover-undeclared` warning

**Changeset:** added as a minor release because this introduces the public `context` retrieval capability.

**ghost Review:**
- `ghost check --base main`: not available in the current CLI; deterministic package and repository checks ran through `pnpm check`
- `ghost review --base main --include-memory`: not available in the current CLI shape; review packet behavior is covered by the Ghost test suite

<details>
<summary>File changes</summary>

**`.changeset/node-context-retrieval.md`**
Records the new public node retrieval capability as a minor release.

**`packages/ghost/src/ghost-core/node/`**
Adds canonical `context` schema and types, accepts deprecated `description`, and migrates the alias during serialization.

**`packages/ghost/src/ghost-core/catalog/`**
Resolves node context with canonical precedence and emits it through gather menu entries while retaining transition aliases.

**`packages/ghost/src/embed/` and `packages/ghost/src/commands/`**
Uses context in gather selection instructions, coverage, menu output, and pull packets; keeps deprecated JSON compatibility fields for one release.

**`packages/ghost/src/scan/fingerprint-package-lint.ts`**
Warns when context is missing and when deprecated description frontmatter needs migration.

**`packages/ghost/src/review/`**
Carries context through review baselines and material-backed review nodes.

**`packages/ghost/src/init-payloads/`, `packages/vessel-light/.ghost/`, `packages/vessel-react/{.ghost,fingerprint}/`, and `apps/docs/.ghost/`**
Migrates repo-owned node frontmatter to `context`; check documents retain their separate `description` schema.

**`packages/ghost/src/skill-bundle/`, `README.md`, and `docs/purposes.md`**
Documents context as the retrieval payload and the one-release compatibility window.

**`packages/context-control/`**
Updates the retrieval benchmark, model prompt, and viewer to evaluate node context.

**`apps/docs/src/`**
Updates public examples and gather demonstrations to show context.

**`packages/ghost/test/`**
Covers canonical context, deprecated alias reads, precedence, migration serialization, lint warnings, coverage, gather, pull, and embed output.

</details>

**Screenshots/Demos:** N/A; this changes framework terminology and output contracts without changing the rendered design.
