### PR TITLE
Rename node retrieval frontmatter field to for

### DIFF
--- a/.changeset/rename-context-to-description.md
+++ b/.changeset/rename-context-to-description.md
@@ -1,5 +1,0 @@
----
-"@design-intelligence/ghost": minor
----
-
-Rename the node retrieval frontmatter field from `context` back to `description`. `context` is now rejected at validation with a rename message; gather/pull output, the embed API, coverage reporting, and the lint rules (`node-description-missing`) all use `description`.

--- a/.changeset/rename-context-to-description.md
+++ b/.changeset/rename-context-to-description.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": minor
+---
+
+Rename the node retrieval frontmatter field from `context` back to `description`. `context` is now rejected at validation with a rename message; gather/pull output, the embed API, coverage reporting, and the lint rules (`node-description-missing`) all use `description`.

--- a/.changeset/rename-retrieval-field-to-for.md
+++ b/.changeset/rename-retrieval-field-to-for.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": minor
+---
+
+Rename the node retrieval frontmatter field to `for`: the situation or activity the guidance is for. Both prior names are rejected at validation with rename messages (`context`, `description`); gather/pull output, the embed API, coverage reporting (`withoutFor`), and the lint rule (`node-for-missing`) all use `for`.

--- a/.changeset/rename-retrieval-field-to-for.md
+++ b/.changeset/rename-retrieval-field-to-for.md
@@ -2,4 +2,4 @@
 "@design-intelligence/ghost": minor
 ---
 
-Rename the node retrieval frontmatter field to `for`: the situation or activity the guidance is for. Both prior names are rejected at validation with rename messages (`context`, `description`); gather/pull output, the embed API, coverage reporting (`withoutFor`), and the lint rule (`node-for-missing`) all use `for`.
+The node retrieval frontmatter field is `for`: the situation or activity the guidance is for. `context` and `description` are rejected at validation with a pointer to `for`; gather/pull output, the embed API, coverage reporting (`withoutFor`), and the lint rule (`node-for-missing`) all use `for`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ glossary.md           # the author's category vocabulary + what each kind means
 checks/               # optional review assertions; never a node source
 ```
 
-The **corpus is flat**. A node is a markdown file: a `context` in
+The **corpus is flat**. A node is a markdown file: a `description` in
 frontmatter (the retrieval payload), optional `materials`, and brand guidance in
 the prose body. A node's identity is its filename minus `.md`; its kind is the
 filename prefix before the first dot, declared in the glossary. There is no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,9 @@ glossary.md           # the author's category vocabulary + what each kind means
 checks/               # optional review assertions; never a node source
 ```
 
-The **corpus is flat**. A node is a markdown file: a `description` in
-frontmatter (the retrieval payload), optional `materials`, and brand guidance in
-the prose body. A node's identity is its filename minus `.md`; its kind is the
+The **corpus is flat**. A node is a markdown file: a `for` payload in
+frontmatter (the retrieval payload: the situation or activity the guidance is
+for), optional `materials`, and brand guidance in the prose body. A node's identity is its filename minus `.md`; its kind is the
 filename prefix before the first dot, declared in the glossary. There is no
 hierarchy, no inheritance, no edges; nesting into folders is a browsing
 convenience only.

--- a/README.md
+++ b/README.md
@@ -107,13 +107,12 @@ repeatable commands for scaffolding, validation, retrieval, and review.
 The package is a **flat set of nodes**. The optional `cover:` in
 `manifest.yml` may name any node; `ghost gather` inlines it before the menu.
 The default skeleton calls that node `brand`, but the filename is not reserved.
-A node is one markdown file: a `context` in frontmatter, optional
-`materials`, and brand guidance in the prose body. `description` remains a
-deprecated read alias for one release, and `ghost validate` warns on its use.
+A node is one markdown file: a `description` in frontmatter, optional
+`materials`, and brand guidance in the prose body.
 
 ```markdown
 ---
-context: Placing, sizing, or choosing a logo lockup or glyph.
+description: Placing, sizing, or choosing a logo lockup or glyph.
 materials:
   - brand/logo-lockup.svg
   - brand/logo-glyph.svg

--- a/README.md
+++ b/README.md
@@ -107,12 +107,13 @@ repeatable commands for scaffolding, validation, retrieval, and review.
 The package is a **flat set of nodes**. The optional `cover:` in
 `manifest.yml` may name any node; `ghost gather` inlines it before the menu.
 The default skeleton calls that node `brand`, but the filename is not reserved.
-A node is one markdown file: a `description` in frontmatter, optional
-`materials`, and brand guidance in the prose body.
+A node is one markdown file: a `for` payload in frontmatter (the situation or
+activity the guidance is for), optional `materials`, and brand guidance in the
+prose body.
 
 ```markdown
 ---
-description: Placing, sizing, or choosing a logo lockup or glyph.
+for: Placing, sizing, or choosing a logo lockup or glyph.
 materials:
   - brand/logo-lockup.svg
   - brand/logo-glyph.svg

--- a/apps/docs/.ghost/anti-goal.generic-ai-product.md
+++ b/apps/docs/.ghost/anti-goal.generic-ai-product.md
@@ -1,5 +1,5 @@
 ---
-context: Any visual surface at risk of generic AI-product spectacle or card chrome.
+description: Any visual surface at risk of generic AI-product spectacle or card chrome.
 materials:
   - apps/docs/src/pages/index.astro
   - apps/docs/src/styles/marked-doc.css

--- a/apps/docs/.ghost/anti-goal.generic-ai-product.md
+++ b/apps/docs/.ghost/anti-goal.generic-ai-product.md
@@ -1,5 +1,5 @@
 ---
-description: Any visual surface at risk of generic AI-product spectacle or card chrome.
+for: Any visual surface at risk of generic AI-product spectacle or card chrome.
 materials:
   - apps/docs/src/pages/index.astro
   - apps/docs/src/styles/marked-doc.css

--- a/apps/docs/.ghost/brand.md
+++ b/apps/docs/.ghost/brand.md
@@ -1,5 +1,5 @@
 ---
-description: Any expression of the ghost brand.
+for: Any expression of the ghost brand.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/pages/index.astro

--- a/apps/docs/.ghost/brand.md
+++ b/apps/docs/.ghost/brand.md
@@ -1,5 +1,5 @@
 ---
-context: Any expression of the ghost brand.
+description: Any expression of the ghost brand.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/pages/index.astro

--- a/apps/docs/.ghost/composition.md
+++ b/apps/docs/.ghost/composition.md
@@ -1,5 +1,5 @@
 ---
-context: Composing any ghost page or adapting its layout across viewport sizes.
+description: Composing any ghost page or adapting its layout across viewport sizes.
 materials:
   - apps/docs/src/components/DocSection.astro
   - apps/docs/src/components/SectionWrapper.astro

--- a/apps/docs/.ghost/composition.md
+++ b/apps/docs/.ghost/composition.md
@@ -1,5 +1,5 @@
 ---
-description: Composing any ghost page or adapting its layout across viewport sizes.
+for: Composing any ghost page or adapting its layout across viewport sizes.
 materials:
   - apps/docs/src/components/DocSection.astro
   - apps/docs/src/components/SectionWrapper.astro

--- a/apps/docs/.ghost/docs-site.md
+++ b/apps/docs/.ghost/docs-site.md
@@ -1,5 +1,5 @@
 ---
-description: Translating the ghost visual expression into another surface or medium.
+for: Translating the ghost visual expression into another surface or medium.
 materials:
   - apps/docs/src/pages/index.astro
   - apps/docs/src/components/Hero.astro

--- a/apps/docs/.ghost/docs-site.md
+++ b/apps/docs/.ghost/docs-site.md
@@ -1,5 +1,5 @@
 ---
-context: Translating the ghost visual expression into another surface or medium.
+description: Translating the ghost visual expression into another surface or medium.
 materials:
   - apps/docs/src/pages/index.astro
   - apps/docs/src/components/Hero.astro

--- a/apps/docs/.ghost/mark.md
+++ b/apps/docs/.ghost/mark.md
@@ -1,5 +1,5 @@
 ---
-description: Using yellow, selection, intervention, or active-choice states.
+for: Using yellow, selection, intervention, or active-choice states.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/components/docs/gather-demo.tsx

--- a/apps/docs/.ghost/mark.md
+++ b/apps/docs/.ghost/mark.md
@@ -1,5 +1,5 @@
 ---
-context: Using yellow, selection, intervention, or active-choice states.
+description: Using yellow, selection, intervention, or active-choice states.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/components/docs/gather-demo.tsx

--- a/apps/docs/.ghost/pattern.motion.md
+++ b/apps/docs/.ghost/pattern.motion.md
@@ -1,5 +1,5 @@
 ---
-context: Anything that moves, transitions, reveals in sequence, or changes position or emphasis.
+description: Anything that moves, transitions, reveals in sequence, or changes position or emphasis.
 materials:
   - apps/docs/src/components/docs/gather-demo.tsx
   - apps/docs/src/styles/marked-doc.css

--- a/apps/docs/.ghost/pattern.motion.md
+++ b/apps/docs/.ghost/pattern.motion.md
@@ -1,5 +1,5 @@
 ---
-description: Anything that moves, transitions, reveals in sequence, or changes position or emphasis.
+for: Anything that moves, transitions, reveals in sequence, or changes position or emphasis.
 materials:
   - apps/docs/src/components/docs/gather-demo.tsx
   - apps/docs/src/styles/marked-doc.css

--- a/apps/docs/.ghost/pattern.specimen.md
+++ b/apps/docs/.ghost/pattern.specimen.md
@@ -1,5 +1,5 @@
 ---
-description: A reader needs to inspect an example, table, code sample, comparison, palette, diagnostic, or interactive result.
+for: A reader needs to inspect an example, table, code sample, comparison, palette, diagnostic, or interactive result.
 materials:
   - apps/docs/src/pages/index.astro
   - apps/docs/src/components/docs/gather-demo.tsx

--- a/apps/docs/.ghost/pattern.specimen.md
+++ b/apps/docs/.ghost/pattern.specimen.md
@@ -1,5 +1,5 @@
 ---
-context: A reader needs to inspect an example, table, code sample, comparison, palette, diagnostic, or interactive result.
+description: A reader needs to inspect an example, table, code sample, comparison, palette, diagnostic, or interactive result.
 materials:
   - apps/docs/src/pages/index.astro
   - apps/docs/src/components/docs/gather-demo.tsx

--- a/apps/docs/.ghost/principles.md
+++ b/apps/docs/.ghost/principles.md
@@ -1,5 +1,5 @@
 ---
-context: Any ghost visual expression, independent of surface, medium, or implementation.
+description: Any ghost visual expression, independent of surface, medium, or implementation.
 materials:
   - apps/docs/src/pages/index.astro
   - apps/docs/src/components/DocSection.astro

--- a/apps/docs/.ghost/principles.md
+++ b/apps/docs/.ghost/principles.md
@@ -1,5 +1,5 @@
 ---
-description: Any ghost visual expression, independent of surface, medium, or implementation.
+for: Any ghost visual expression, independent of surface, medium, or implementation.
 materials:
   - apps/docs/src/pages/index.astro
   - apps/docs/src/components/DocSection.astro

--- a/apps/docs/.ghost/visual-system.md
+++ b/apps/docs/.ghost/visual-system.md
@@ -1,5 +1,5 @@
 ---
-description: Choosing or implementing color, typography, spacing, shape, elevation, interaction, or accessibility for ghost.
+for: Choosing or implementing color, typography, spacing, shape, elevation, interaction, or accessibility for ghost.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/styles/docs.css

--- a/apps/docs/.ghost/visual-system.md
+++ b/apps/docs/.ghost/visual-system.md
@@ -1,5 +1,5 @@
 ---
-context: Choosing or implementing color, typography, spacing, shape, elevation, interaction, or accessibility for ghost.
+description: Choosing or implementing color, typography, spacing, shape, elevation, interaction, or accessibility for ghost.
 materials:
   - apps/docs/src/styles/marked-doc.css
   - apps/docs/src/styles/docs.css

--- a/apps/docs/src/components/docs/gather-demo.tsx
+++ b/apps/docs/src/components/docs/gather-demo.tsx
@@ -1,21 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const nodes = [
-  { id: "brand", context: "any task that should express this brand" },
-  { id: "voice", context: "anything with words" },
-  { id: "motion", context: "anything that moves on screen" },
+  { id: "brand", description: "any task that should express this brand" },
+  { id: "voice", description: "anything with words" },
+  { id: "motion", description: "anything that moves on screen" },
   {
     id: "email.transactional",
-    context: "money moved and the reader is checking",
+    description: "money moved and the reader is checking",
   },
   {
     id: "layout.spacing",
-    context: "laying out a page",
+    description: "laying out a page",
   },
-  { id: "never.ai-defaults", context: "any first-draft visual surface" },
+  { id: "never.ai-defaults", description: "any first-draft visual surface" },
   {
     id: "logo.usage",
-    context: "placing or sizing the mark",
+    description: "placing or sizing the mark",
   },
 ] as const;
 
@@ -118,7 +118,7 @@ export function GatherDemo() {
             >
               <div className="font-bold">{node.id}</div>
               <div>
-                {node.context}
+                {node.description}
                 {node.id === "brand" ? (
                   <span className="text-[var(--doc-middle)]">
                     {" "}

--- a/apps/docs/src/components/docs/gather-demo.tsx
+++ b/apps/docs/src/components/docs/gather-demo.tsx
@@ -1,21 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const nodes = [
-  { id: "brand", description: "any task that should express this brand" },
-  { id: "voice", description: "anything with words" },
-  { id: "motion", description: "anything that moves on screen" },
+  { id: "brand", for: "any task that should express this brand" },
+  { id: "voice", for: "anything with words" },
+  { id: "motion", for: "anything that moves on screen" },
   {
     id: "email.transactional",
-    description: "money moved and the reader is checking",
+    for: "money moved and the reader is checking",
   },
   {
     id: "layout.spacing",
-    description: "laying out a page",
+    for: "laying out a page",
   },
-  { id: "never.ai-defaults", description: "any first-draft visual surface" },
+  { id: "never.ai-defaults", for: "any first-draft visual surface" },
   {
     id: "logo.usage",
-    description: "placing or sizing the mark",
+    for: "placing or sizing the mark",
   },
 ] as const;
 
@@ -118,7 +118,7 @@ export function GatherDemo() {
             >
               <div className="font-bold">{node.id}</div>
               <div>
-                {node.description}
+                {node.for}
                 {node.id === "brand" ? (
                   <span className="text-[var(--doc-middle)]">
                     {" "}

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -29,7 +29,7 @@ const steeringDiagnoses = [
     signal: "delivery gap",
     read: "the relevant guidance existed but did not reach the task",
     repair:
-      "add the node, sharpen its description, or inspect why it was skipped",
+      "add the node, sharpen its for payload, or inspect why it was skipped",
   },
   {
     signal: "correction gap",
@@ -44,7 +44,7 @@ const guidanceExamples = [
     label: "visual decision",
     path: "pattern.crop-with-intent.md",
     body: `---
-description: Photography. Gather when a composition uses a photo.
+for: Photography. Gather when a composition uses a photo.
 materials:
   - brand/photography/**
 ---
@@ -60,7 +60,7 @@ Reject cautious full-object framing and collages that avoid choosing a focal poi
     label: "product pattern",
     path: "condition.blocked-progress.md",
     body: `---
-description: Blocked progress. Gather when someone cannot continue a task.
+for: Blocked progress. Gather when someone cannot continue a task.
 materials:
   - src/components/error-state/**
 ---
@@ -76,7 +76,7 @@ If the person cannot resolve the problem, state what happens next. Do not end on
     label: "exact material",
     path: "asset.color-roles.md",
     body: `---
-description: Exact color roles and values. Gather before assigning color.
+for: Exact color roles and values. Gather before assigning color.
 materials:
   - src/styles/brand-tokens.css
 ---
@@ -245,12 +245,12 @@ Ink carries content. Signal marks selection. Correction marks review.
                 <p>
                   Gather shows the complete menu before the agent chooses. If useful
                   guidance does not reach the work, you can see whether the node was
-                  missing, its description was unclear, or the agent skipped it.
+                  missing, its <code>for</code> payload was unclear, or the agent skipped it.
                 </p>
 
                 <h3 class="pt-4 font-bold lowercase">efficiency</h3>
                 <p>
-                  Gather represents every node with a compact ID and description.
+                  Gather represents every node with a compact ID and <code>for</code> payload.
                   Pull loads the full prose and materials only for the selected
                   nodes. The agent sees the shape of the whole brand while keeping
                   generation context small and free of unrelated instructions.

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -29,7 +29,7 @@ const steeringDiagnoses = [
     signal: "delivery gap",
     read: "the relevant guidance existed but did not reach the task",
     repair:
-      "add the node, sharpen its for payload, or inspect why it was skipped",
+      "add the node, sharpen its `for` payload, or inspect why it was skipped",
   },
   {
     signal: "correction gap",

--- a/docs/purposes.md
+++ b/docs/purposes.md
@@ -38,7 +38,7 @@ into folders is a browsing convenience only.
 | `manifest.yml` | Schema version and package id; the package's anchor. |
 | `glossary.md` | The author's dictionary: every term with defined meaning in the corpus. ghost ships no fixed vocabulary. |
 | Prose nodes (`<kind>.<slug>.md`, `<slug>.md`) | Durable brand guidance; each body answers why (the stance), with what (the materials), or how it is assembled (the patterns). Altitude lives in prose; narrower guidance names its condition. |
-| Node frontmatter | `description` (retrieval payload) and optional `materials` (explicit repo-relative file paths or supported external locators, with optional retrieval notes; see the schema reference for the supported schemes). |
+| Node frontmatter | `for` (retrieval payload) and optional `materials` (explicit repo-relative file paths or supported external locators, with optional retrieval notes; see the schema reference for the supported schemes). |
 | `checks/` | Optional review assertions binding to nodes with `references`. Never a node source and never generation input. |
 
 One resolution mechanism, read-only:
@@ -78,7 +78,7 @@ Two rules keep the reservation honest:
 1. **Retrieval needs pushed into the shape.** When selection feels imprecise, the
    temptation is to encode routing in data: proliferating filename kinds until
    they become destinations, or turning the glossary into a dispatch table.
-   *Fix: `description` is the retrieval payload; sharpen descriptions, show the
+   *Fix: `for` is the retrieval payload; sharpen `for` payloads, show the
    menu, let the agent pick.*
 
 2. **Filing by destination.** A node authored as `for-emails.md` smuggles a

--- a/docs/purposes.md
+++ b/docs/purposes.md
@@ -38,7 +38,7 @@ into folders is a browsing convenience only.
 | `manifest.yml` | Schema version and package id; the package's anchor. |
 | `glossary.md` | The author's dictionary: every term with defined meaning in the corpus. ghost ships no fixed vocabulary. |
 | Prose nodes (`<kind>.<slug>.md`, `<slug>.md`) | Durable brand guidance; each body answers why (the stance), with what (the materials), or how it is assembled (the patterns). Altitude lives in prose; narrower guidance names its condition. |
-| Node frontmatter | `context` (retrieval payload) and optional `materials` (explicit repo-relative file paths or supported external locators, with optional retrieval notes; see the schema reference for the supported schemes). |
+| Node frontmatter | `description` (retrieval payload) and optional `materials` (explicit repo-relative file paths or supported external locators, with optional retrieval notes; see the schema reference for the supported schemes). |
 | `checks/` | Optional review assertions binding to nodes with `references`. Never a node source and never generation input. |
 
 One resolution mechanism, read-only:
@@ -78,7 +78,7 @@ Two rules keep the reservation honest:
 1. **Retrieval needs pushed into the shape.** When selection feels imprecise, the
    temptation is to encode routing in data: proliferating filename kinds until
    they become destinations, or turning the glossary into a dispatch table.
-   *Fix: `context` is the retrieval payload; sharpen contexts, show the
+   *Fix: `description` is the retrieval payload; sharpen descriptions, show the
    menu, let the agent pick.*
 
 2. **Filing by destination.** A node authored as `for-emails.md` smuggles a

--- a/packages/context-control/README.md
+++ b/packages/context-control/README.md
@@ -6,9 +6,9 @@ measures whether the right guidance even makes it into context. Selection is
 the unit. No generation, ever.
 
 `ghost gather` does no filtering: the menu is always the whole catalog, and
-selection happens in the model's head against each node's `context`.
-So what this bench actually tests is whether contexts are good enough
-retrieval payloads — a node with a vague context is invisible at
+selection happens in the model's head against each node's `description`.
+So what this bench actually tests is whether descriptions are good enough
+retrieval payloads — a node with a vague description is invisible at
 selection time no matter how good its body is.
 
 ## Run
@@ -30,15 +30,15 @@ else `ghost` on PATH).
 ## Screens
 
 **package** — the catalog rendered as the selection surface the model
-sees: id, kind, context, material count, coverage line. Click a node to
-see its real `ghost pull` output in a drawer. Review contexts as
-retrieval payloads, not file contents; a node with no context is flagged
+sees: id, kind, description, material count, coverage line. Click a node to
+see its real `ghost pull` output in a drawer. Review descriptions as
+retrieval payloads, not file contents; a node with no description is flagged
 as invisible.
 
 **bench** — type an ask (or run the whole asks suite), fire N single-shot
 selection trials, and read the heatmap: nodes × asks, each cell the
 fraction of trials that selected the node. Solid column = confident
-context. Speckled = coin-flip. Empty row = dead node. Blue outline =
+description. Speckled = coin-flip. Empty row = dead node. Blue outline =
 the ask's expected set. Scores above the map: consistency (mean pairwise
 Jaccard), mean per-trial precision and recall, poison-selection rate, unknown
 ids, and nodes ever selected.

--- a/packages/context-control/README.md
+++ b/packages/context-control/README.md
@@ -6,9 +6,9 @@ measures whether the right guidance even makes it into context. Selection is
 the unit. No generation, ever.
 
 `ghost gather` does no filtering: the menu is always the whole catalog, and
-selection happens in the model's head against each node's `description`.
-So what this bench actually tests is whether descriptions are good enough
-retrieval payloads — a node with a vague description is invisible at
+selection happens in the model's head against each node's `for` payload.
+So what this bench actually tests is whether `for` payloads are good enough
+retrieval payloads — a node with a vague `for` is invisible at
 selection time no matter how good its body is.
 
 ## Run
@@ -30,15 +30,15 @@ else `ghost` on PATH).
 ## Screens
 
 **package** — the catalog rendered as the selection surface the model
-sees: id, kind, description, material count, coverage line. Click a node to
-see its real `ghost pull` output in a drawer. Review descriptions as
-retrieval payloads, not file contents; a node with no description is flagged
+sees: id, kind, `for` payload, material count, coverage line. Click a node to
+see its real `ghost pull` output in a drawer. Review `for` payloads as
+retrieval payloads, not file contents; a node with no `for` is flagged
 as invisible.
 
 **bench** — type an ask (or run the whole asks suite), fire N single-shot
 selection trials, and read the heatmap: nodes × asks, each cell the
 fraction of trials that selected the node. Solid column = confident
-description. Speckled = coin-flip. Empty row = dead node. Blue outline =
+`for` payload. Speckled = coin-flip. Empty row = dead node. Blue outline =
 the ask's expected set. Scores above the map: consistency (mean pairwise
 Jaccard), mean per-trial precision and recall, poison-selection rate, unknown
 ids, and nodes ever selected.

--- a/packages/context-control/lib/model.mjs
+++ b/packages/context-control/lib/model.mjs
@@ -60,7 +60,7 @@ export function fakeModel() {
       const selected = [];
       for (const entry of menu) {
         const nodeTokens = tokens(
-          [entry.id.replaceAll(/[.-]/g, " "), entry.kind, entry.description]
+          [entry.id.replaceAll(/[.-]/g, " "), entry.kind, entry.for]
             .filter(Boolean)
             .join(" "),
         );
@@ -101,7 +101,7 @@ function selectUser(ask, menu, cover) {
     const flags = [entry.materials ? `${entry.materials} materials` : null]
       .filter(Boolean)
       .join(", ");
-    return `- ${entry.id}${entry.kind ? ` [${entry.kind}]` : ""}${flags ? ` (${flags})` : ""}: ${entry.description ?? "(no description)"}`;
+    return `- ${entry.id}${entry.kind ? ` [${entry.kind}]` : ""}${flags ? ` (${flags})` : ""}: ${entry.for ?? "(no for payload)"}`;
   });
   const coverLine = cover
     ? `Cover already in context: ${cover.id}\n\n${cover.body}\n\n`

--- a/packages/context-control/lib/model.mjs
+++ b/packages/context-control/lib/model.mjs
@@ -60,7 +60,7 @@ export function fakeModel() {
       const selected = [];
       for (const entry of menu) {
         const nodeTokens = tokens(
-          [entry.id.replaceAll(/[.-]/g, " "), entry.kind, entry.context]
+          [entry.id.replaceAll(/[.-]/g, " "), entry.kind, entry.description]
             .filter(Boolean)
             .join(" "),
         );
@@ -101,7 +101,7 @@ function selectUser(ask, menu, cover) {
     const flags = [entry.materials ? `${entry.materials} materials` : null]
       .filter(Boolean)
       .join(", ");
-    return `- ${entry.id}${entry.kind ? ` [${entry.kind}]` : ""}${flags ? ` (${flags})` : ""}: ${entry.context ?? "(no context)"}`;
+    return `- ${entry.id}${entry.kind ? ` [${entry.kind}]` : ""}${flags ? ` (${flags})` : ""}: ${entry.description ?? "(no description)"}`;
   });
   const coverLine = cover
     ? `Cover already in context: ${cover.id}\n\n${cover.body}\n\n`

--- a/packages/context-control/ui/index.html
+++ b/packages/context-control/ui/index.html
@@ -126,7 +126,7 @@
     </div>
     <div class="legend">
       Each column is one ask; each cell is the fraction of trials that selected the node.
-      Solid = confident description. Speckled = coin-flip. Empty row = invisible node.
+      Solid = confident `for` payload. Speckled = coin-flip. Empty row = invisible node.
       Blue outline = in the ask's expected set. The cover is already in context and
       is not part of the menu. Selection runs the ghost skill's recall protocol;
       live agents additionally carry task
@@ -168,12 +168,12 @@ async function loadMenu() {
   const c = data.coverage;
   $("#coverage").textContent =
     `${c.nodes} nodes · ${c.concrete} concrete` +
-    (c.undescribed ? ` · ${c.undescribed} undescribed` : "");
+    (c.withoutFor ? ` · ${c.withoutFor} lack for` : "");
   $("#menuRows").innerHTML = state.menu.map((n) => `
     <tr class="node" data-id="${n.id}">
       <td class="id">${n.id}${n.materials ? `<span class="badge mat">${n.materials} mat</span>` : ""}</td>
       <td class="kind">${n.kind ?? ""}</td>
-      <td>${n.description ?? '<span style="color:var(--danger)">no description — invisible at selection time</span>'}</td>
+      <td>${n.for ?? '<span style="color:var(--danger)">no for payload — invisible at selection time</span>'}</td>
     </tr>`).join("");
   document.querySelectorAll("tr.node").forEach((row) => {
     row.onclick = () => openDrawer(row.dataset.id);
@@ -189,7 +189,7 @@ async function openDrawer(id) {
   const node = data.nodes?.[0];
   drawer.innerHTML = `<button class="close">close ×</button><h2>${id}</h2>` +
     (node
-      ? `<p style="color:var(--dim)">${node.description ?? ""}</p><hr style="border:0;border-top:1px solid var(--line)" />${escapeHtml(node.body)}`
+      ? `<p style="color:var(--dim)">${node.for ?? ""}</p><hr style="border:0;border-top:1px solid var(--line)" />${escapeHtml(node.body)}`
       : `<p class="flag">pull returned nothing (${escapeHtml(JSON.stringify(data))})</p>`);
   drawer.querySelector(".close").onclick = () => drawer.classList.add("hidden");
 }

--- a/packages/context-control/ui/index.html
+++ b/packages/context-control/ui/index.html
@@ -126,7 +126,7 @@
     </div>
     <div class="legend">
       Each column is one ask; each cell is the fraction of trials that selected the node.
-      Solid = confident context. Speckled = coin-flip. Empty row = invisible node.
+      Solid = confident description. Speckled = coin-flip. Empty row = invisible node.
       Blue outline = in the ask's expected set. The cover is already in context and
       is not part of the menu. Selection runs the ghost skill's recall protocol;
       live agents additionally carry task
@@ -173,7 +173,7 @@ async function loadMenu() {
     <tr class="node" data-id="${n.id}">
       <td class="id">${n.id}${n.materials ? `<span class="badge mat">${n.materials} mat</span>` : ""}</td>
       <td class="kind">${n.kind ?? ""}</td>
-      <td>${n.context ?? '<span style="color:var(--danger)">no context — invisible at selection time</span>'}</td>
+      <td>${n.description ?? '<span style="color:var(--danger)">no description — invisible at selection time</span>'}</td>
     </tr>`).join("");
   document.querySelectorAll("tr.node").forEach((row) => {
     row.onclick = () => openDrawer(row.dataset.id);
@@ -189,7 +189,7 @@ async function openDrawer(id) {
   const node = data.nodes?.[0];
   drawer.innerHTML = `<button class="close">close ×</button><h2>${id}</h2>` +
     (node
-      ? `<p style="color:var(--dim)">${node.context ?? ""}</p><hr style="border:0;border-top:1px solid var(--line)" />${escapeHtml(node.body)}`
+      ? `<p style="color:var(--dim)">${node.description ?? ""}</p><hr style="border:0;border-top:1px solid var(--line)" />${escapeHtml(node.body)}`
       : `<p class="flag">pull returned nothing (${escapeHtml(JSON.stringify(data))})</p>`);
   drawer.querySelector(".close").onclick = () => drawer.classList.add("hidden");
 }

--- a/packages/context-control/ui/index.html
+++ b/packages/context-control/ui/index.html
@@ -168,7 +168,7 @@ async function loadMenu() {
   const c = data.coverage;
   $("#coverage").textContent =
     `${c.nodes} nodes · ${c.concrete} concrete` +
-    (c.withoutContext ? ` · ${c.withoutContext} without context` : "");
+    (c.undescribed ? ` · ${c.undescribed} undescribed` : "");
   $("#menuRows").innerHTML = state.menu.map((n) => `
     <tr class="node" data-id="${n.id}">
       <td class="id">${n.id}${n.materials ? `<span class="badge mat">${n.materials} mat</span>` : ""}</td>

--- a/packages/ghost/src/commands/gather-command.ts
+++ b/packages/ghost/src/commands/gather-command.ts
@@ -100,8 +100,8 @@ function menuCoverageLine(menu: GhostGatherResult): string {
     `${coverage.nodes} nodes`,
     `${coverage.concrete} carry payloads (${payloadParts.join(", ")})`,
   ];
-  if (coverage.withoutContext > 0) {
-    parts.push(`${coverage.withoutContext} lack context`);
+  if (coverage.undescribed > 0) {
+    parts.push(`${coverage.undescribed} lack descriptions`);
   }
   return parts.join(" · ");
 }
@@ -125,7 +125,7 @@ function formatMenuMarkdown(menu: GhostGatherResult): string {
   if (menu.ask) {
     lines.push(
       "Complete, unfiltered, unranked list from the ghost package. ghost has not selected nodes for this ask.",
-      "Pull every node whose context indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work. Skip inapplicable nodes. Topic overlap alone is not applicability. Do not add nodes for completeness or omit applicable nodes to meet a count.",
+      "Pull every node whose description indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work. Skip inapplicable nodes. Topic overlap alone is not applicability. Do not add nodes for completeness or omit applicable nodes to meet a count.",
       "Next: `ghost pull <id> [<id>…]`.",
       "If nothing applies, name the package's silence, follow the cover silence posture, and do not invent ghost-backed guidance.",
       "",
@@ -147,7 +147,7 @@ function formatMenuMarkdown(menu: GhostGatherResult): string {
   for (const entry of menu.nodes) {
     const kind = entry.kind ? ` _(${entry.kind})_` : "";
     lines.push(`- \`${entry.id}\`${kind}`);
-    if (entry.context) lines.push(`  - ${entry.context}`);
+    if (entry.description) lines.push(`  - ${entry.description}`);
     if (entry.materials !== undefined) {
       lines.push(`  - materials: ${entry.materials}`);
     }

--- a/packages/ghost/src/commands/gather-command.ts
+++ b/packages/ghost/src/commands/gather-command.ts
@@ -100,8 +100,8 @@ function menuCoverageLine(menu: GhostGatherResult): string {
     `${coverage.nodes} nodes`,
     `${coverage.concrete} carry payloads (${payloadParts.join(", ")})`,
   ];
-  if (coverage.undescribed > 0) {
-    parts.push(`${coverage.undescribed} lack descriptions`);
+  if (coverage.withoutFor > 0) {
+    parts.push(`${coverage.withoutFor} lack \`for\` payloads`);
   }
   return parts.join(" · ");
 }
@@ -125,7 +125,7 @@ function formatMenuMarkdown(menu: GhostGatherResult): string {
   if (menu.ask) {
     lines.push(
       "Complete, unfiltered, unranked list from the ghost package. ghost has not selected nodes for this ask.",
-      "Pull every node whose description indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work. Skip inapplicable nodes. Topic overlap alone is not applicability. Do not add nodes for completeness or omit applicable nodes to meet a count.",
+      "Pull every node whose `for` payload indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work. Skip inapplicable nodes. Topic overlap alone is not applicability. Do not add nodes for completeness or omit applicable nodes to meet a count.",
       "Next: `ghost pull <id> [<id>…]`.",
       "If nothing applies, name the package's silence, follow the cover silence posture, and do not invent ghost-backed guidance.",
       "",
@@ -147,7 +147,7 @@ function formatMenuMarkdown(menu: GhostGatherResult): string {
   for (const entry of menu.nodes) {
     const kind = entry.kind ? ` _(${entry.kind})_` : "";
     lines.push(`- \`${entry.id}\`${kind}`);
-    if (entry.description) lines.push(`  - ${entry.description}`);
+    if (entry.for) lines.push(`  - ${entry.for}`);
     if (entry.materials !== undefined) {
       lines.push(`  - materials: ${entry.materials}`);
     }

--- a/packages/ghost/src/commands/pull-command.ts
+++ b/packages/ghost/src/commands/pull-command.ts
@@ -113,9 +113,7 @@ function formatPullJson(
     nodes: result.nodes.map((node) => ({
       id: node.id,
       ...(node.kind !== undefined ? { kind: node.kind } : {}),
-      ...(node.context
-        ? { context: node.context, description: node.context }
-        : {}),
+      ...(node.description ? { description: node.description } : {}),
       ...(node.declaredMaterials !== undefined
         ? {
             materials: inlineMaterials
@@ -134,7 +132,7 @@ function formatPullMarkdown(result: GhostPullResult): string {
   for (const node of result.nodes) {
     const kind = node.kind ? ` _(${node.kind})_` : "";
     const lines = [`# \`${node.id}\`${kind}`];
-    if (node.context) lines.push("", `> ${node.context}`);
+    if (node.description) lines.push("", `> ${node.description}`);
     lines.push("", node.body.trim());
     if (node.materials !== undefined && node.materials.length > 0) {
       lines.push("", "Materials:");

--- a/packages/ghost/src/commands/pull-command.ts
+++ b/packages/ghost/src/commands/pull-command.ts
@@ -113,7 +113,7 @@ function formatPullJson(
     nodes: result.nodes.map((node) => ({
       id: node.id,
       ...(node.kind !== undefined ? { kind: node.kind } : {}),
-      ...(node.description ? { description: node.description } : {}),
+      ...(node.for ? { for: node.for } : {}),
       ...(node.declaredMaterials !== undefined
         ? {
             materials: inlineMaterials
@@ -132,7 +132,7 @@ function formatPullMarkdown(result: GhostPullResult): string {
   for (const node of result.nodes) {
     const kind = node.kind ? ` _(${node.kind})_` : "";
     const lines = [`# \`${node.id}\`${kind}`];
-    if (node.description) lines.push("", `> ${node.description}`);
+    if (node.for) lines.push("", `> ${node.for}`);
     lines.push("", node.body.trim());
     if (node.materials !== undefined && node.materials.length > 0) {
       lines.push("", "Materials:");

--- a/packages/ghost/src/embed/gather.ts
+++ b/packages/ghost/src/embed/gather.ts
@@ -62,7 +62,7 @@ export function gatherContract(ask: string | undefined): GhostGatherContract {
     selection: {
       basis: "applicability",
       instruction: ask
-        ? "Pull every node whose description indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work; skip inapplicable nodes."
+        ? "Pull every node whose `for` payload indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work; skip inapplicable nodes."
         : "Bare gather is catalog inspection. Do not treat the menu as task grounding until an ask is supplied; when grounding a task, pull every applicable node and skip inapplicable nodes.",
       topicOverlapAloneIsApplicability: false,
       addForCompleteness: false,
@@ -76,8 +76,8 @@ export function gatherContract(ask: string | undefined): GhostGatherContract {
 export function menuCoverage(
   menu: readonly CatalogMenuEntry[],
 ): GhostGatherCoverage {
-  const undescribed = menu.filter(
-    (entry) => !entry.description || entry.description.trim().length === 0,
+  const withoutFor = menu.filter(
+    (entry) => !entry.for || entry.for.trim().length === 0,
   ).length;
   return {
     nodes: menu.length,
@@ -87,7 +87,7 @@ export function menuCoverage(
       fencedExamples: menu.filter((entry) => entry.hasFencedExample).length,
       skeletons: menu.filter((entry) => entry.hasSkeleton).length,
     },
-    undescribed,
+    withoutFor,
   };
 }
 

--- a/packages/ghost/src/embed/gather.ts
+++ b/packages/ghost/src/embed/gather.ts
@@ -62,7 +62,7 @@ export function gatherContract(ask: string | undefined): GhostGatherContract {
     selection: {
       basis: "applicability",
       instruction: ask
-        ? "Pull every node whose context indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work; skip inapplicable nodes."
+        ? "Pull every node whose description indicates its stated situation applies and whose guidance, material, structure, or refusal governs the work; skip inapplicable nodes."
         : "Bare gather is catalog inspection. Do not treat the menu as task grounding until an ask is supplied; when grounding a task, pull every applicable node and skip inapplicable nodes.",
       topicOverlapAloneIsApplicability: false,
       addForCompleteness: false,
@@ -76,8 +76,8 @@ export function gatherContract(ask: string | undefined): GhostGatherContract {
 export function menuCoverage(
   menu: readonly CatalogMenuEntry[],
 ): GhostGatherCoverage {
-  const withoutContext = menu.filter(
-    (entry) => !entry.context || entry.context.trim().length === 0,
+  const undescribed = menu.filter(
+    (entry) => !entry.description || entry.description.trim().length === 0,
   ).length;
   return {
     nodes: menu.length,
@@ -87,8 +87,7 @@ export function menuCoverage(
       fencedExamples: menu.filter((entry) => entry.hasFencedExample).length,
       skeletons: menu.filter((entry) => entry.hasSkeleton).length,
     },
-    withoutContext,
-    undescribed: withoutContext,
+    undescribed,
   };
 }
 

--- a/packages/ghost/src/embed/pull.ts
+++ b/packages/ghost/src/embed/pull.ts
@@ -67,9 +67,7 @@ export async function pullGhostNodes(
     nodes: pulledNodes.map(({ node, materials }) => ({
       id: node.id,
       ...(node.kind !== undefined ? { kind: node.kind } : {}),
-      ...(node.context
-        ? { context: node.context, description: node.context }
-        : {}),
+      ...(node.description ? { description: node.description } : {}),
       ...(node.materials !== undefined
         ? { declaredMaterials: [...node.materials] }
         : {}),

--- a/packages/ghost/src/embed/pull.ts
+++ b/packages/ghost/src/embed/pull.ts
@@ -67,7 +67,7 @@ export async function pullGhostNodes(
     nodes: pulledNodes.map(({ node, materials }) => ({
       id: node.id,
       ...(node.kind !== undefined ? { kind: node.kind } : {}),
-      ...(node.description ? { description: node.description } : {}),
+      ...(node.for ? { for: node.for } : {}),
       ...(node.materials !== undefined
         ? { declaredMaterials: [...node.materials] }
         : {}),

--- a/packages/ghost/src/embed/types.ts
+++ b/packages/ghost/src/embed/types.ts
@@ -59,8 +59,6 @@ export interface GhostGatherCoverage {
     fencedExamples: number;
     skeletons: number;
   };
-  withoutContext: number;
-  /** @deprecated Use `withoutContext`. */
   undescribed: number;
 }
 
@@ -110,8 +108,6 @@ export interface GhostPulledSkeleton {
 export interface GhostPulledNode {
   id: string;
   kind?: string;
-  context?: string;
-  /** @deprecated Use `context`. Mirrors the resolved context for one release. */
   description?: string;
   declaredMaterials?: readonly GhostMaterial[];
   materials?: readonly TransportedMaterial[];

--- a/packages/ghost/src/embed/types.ts
+++ b/packages/ghost/src/embed/types.ts
@@ -59,7 +59,7 @@ export interface GhostGatherCoverage {
     fencedExamples: number;
     skeletons: number;
   };
-  undescribed: number;
+  withoutFor: number;
 }
 
 export interface GhostGatherContract {
@@ -108,7 +108,7 @@ export interface GhostPulledSkeleton {
 export interface GhostPulledNode {
   id: string;
   kind?: string;
-  description?: string;
+  for?: string;
   declaredMaterials?: readonly GhostMaterial[];
   materials?: readonly TransportedMaterial[];
   body: string;

--- a/packages/ghost/src/ghost-core/catalog/assemble.ts
+++ b/packages/ghost/src/ghost-core/catalog/assemble.ts
@@ -35,7 +35,6 @@ export function assembleCatalog(input: AssembleCatalogInput): GhostCatalog {
 
   for (const placed of input.placedNodes ?? []) {
     const fm = placed.doc.frontmatter;
-    const context = fm.context ?? fm.description;
     const concrete = carriesConcreteMaterial({
       materials: fm.materials,
       body: placed.doc.body,
@@ -44,10 +43,7 @@ export function assembleCatalog(input: AssembleCatalogInput): GhostCatalog {
       id: placed.id,
       ...(placed.kind !== undefined ? { kind: placed.kind } : {}),
       slug: placed.slug ?? placed.id.split("/").pop() ?? placed.id,
-      ...(context !== undefined ? { context, description: context } : {}),
-      ...(fm.description !== undefined
-        ? { usesDeprecatedDescription: true as const }
-        : {}),
+      ...(fm.description !== undefined ? { description: fm.description } : {}),
       ...(fm.materials !== undefined ? { materials: fm.materials } : {}),
       concrete,
       hasFencedExample: hasSubstantialFencedExample(placed.doc.body),

--- a/packages/ghost/src/ghost-core/catalog/assemble.ts
+++ b/packages/ghost/src/ghost-core/catalog/assemble.ts
@@ -43,7 +43,7 @@ export function assembleCatalog(input: AssembleCatalogInput): GhostCatalog {
       id: placed.id,
       ...(placed.kind !== undefined ? { kind: placed.kind } : {}),
       slug: placed.slug ?? placed.id.split("/").pop() ?? placed.id,
-      ...(fm.description !== undefined ? { description: fm.description } : {}),
+      ...(fm.for !== undefined ? { for: fm.for } : {}),
       ...(fm.materials !== undefined ? { materials: fm.materials } : {}),
       concrete,
       hasFencedExample: hasSubstantialFencedExample(placed.doc.body),

--- a/packages/ghost/src/ghost-core/catalog/closest.ts
+++ b/packages/ghost/src/ghost-core/catalog/closest.ts
@@ -5,7 +5,7 @@
  * routing to nothing. This is that hint: deterministic, LLM-free, bounded.
  *
  * It is not a search engine. An inexact `gather <query>` shows the node menu
- * and lets the agent re-pick by context; this only nominates the few ids a
+ * and lets the agent re-pick by description; this only nominates the few ids a
  * typo most likely meant.
  */
 

--- a/packages/ghost/src/ghost-core/catalog/closest.ts
+++ b/packages/ghost/src/ghost-core/catalog/closest.ts
@@ -5,7 +5,7 @@
  * routing to nothing. This is that hint: deterministic, LLM-free, bounded.
  *
  * It is not a search engine. An inexact `gather <query>` shows the node menu
- * and lets the agent re-pick by description; this only nominates the few ids a
+ * and lets the agent re-pick by `for` payload; this only nominates the few ids a
  * typo most likely meant.
  */
 

--- a/packages/ghost/src/ghost-core/catalog/menu.ts
+++ b/packages/ghost/src/ghost-core/catalog/menu.ts
@@ -1,17 +1,15 @@
 import type { GhostCatalog } from "./types.js";
 
 /**
- * One entry in the gather menu: a node presented as `id` + `kind` + `context`,
- * the retrieval payload the agent selects against. The agent matches a
- * natural-language ask against these and pulls applicable nodes; ghost does no
- * NLP and no selection.
+ * One entry in the gather menu: a node presented as `id` + `kind` +
+ * `description`, the retrieval payload the agent selects against. The agent
+ * matches a natural-language ask against these and pulls applicable nodes;
+ * ghost does no NLP and no selection.
  */
 export interface CatalogMenuEntry {
   id: string;
   /** The node's kind (filename prefix), when it declares one. */
   kind?: string;
-  context?: string;
-  /** @deprecated Use `context`. Mirrors the resolved context for one release. */
   description?: string;
   /** Count of material locators available after pulling this node. */
   materials?: number;
@@ -24,7 +22,7 @@ export interface CatalogMenuEntry {
 }
 
 /**
- * Build the gather menu: every authored node, with its kind and context,
+ * Build the gather menu: every authored node, with its kind and description,
  * sorted by id for stable output. A flat catalog with no anchor or hierarchy;
  * the agent selects from it.
  */
@@ -35,9 +33,7 @@ export function buildCatalogMenu(catalog: GhostCatalog): CatalogMenuEntry[] {
     entries.push({
       id: node.id,
       ...(node.kind !== undefined ? { kind: node.kind } : {}),
-      ...(node.context
-        ? { context: node.context, description: node.context }
-        : {}),
+      ...(node.description ? { description: node.description } : {}),
       ...(node.materials !== undefined && node.materials.length > 0
         ? { materials: node.materials.length }
         : {}),

--- a/packages/ghost/src/ghost-core/catalog/menu.ts
+++ b/packages/ghost/src/ghost-core/catalog/menu.ts
@@ -1,16 +1,16 @@
 import type { GhostCatalog } from "./types.js";
 
 /**
- * One entry in the gather menu: a node presented as `id` + `kind` +
- * `description`, the retrieval payload the agent selects against. The agent
- * matches a natural-language ask against these and pulls applicable nodes;
- * ghost does no NLP and no selection.
+ * One entry in the gather menu: a node presented as `id` + `kind` + `for`,
+ * the retrieval payload the agent selects against. The agent matches a
+ * natural-language ask against these and pulls applicable nodes; ghost does
+ * no NLP and no selection.
  */
 export interface CatalogMenuEntry {
   id: string;
   /** The node's kind (filename prefix), when it declares one. */
   kind?: string;
-  description?: string;
+  for?: string;
   /** Count of material locators available after pulling this node. */
   materials?: number;
   /** True when this entry carries a material locator, fenced example, or Skeleton. */
@@ -22,9 +22,9 @@ export interface CatalogMenuEntry {
 }
 
 /**
- * Build the gather menu: every authored node, with its kind and description,
- * sorted by id for stable output. A flat catalog with no anchor or hierarchy;
- * the agent selects from it.
+ * Build the gather menu: every authored node, with its kind and `for`
+ * payload, sorted by id for stable output. A flat catalog with no anchor or
+ * hierarchy; the agent selects from it.
  */
 export function buildCatalogMenu(catalog: GhostCatalog): CatalogMenuEntry[] {
   const entries: CatalogMenuEntry[] = [];
@@ -33,7 +33,7 @@ export function buildCatalogMenu(catalog: GhostCatalog): CatalogMenuEntry[] {
     entries.push({
       id: node.id,
       ...(node.kind !== undefined ? { kind: node.kind } : {}),
-      ...(node.description ? { description: node.description } : {}),
+      ...(node.for ? { for: node.for } : {}),
       ...(node.materials !== undefined && node.materials.length > 0
         ? { materials: node.materials.length }
         : {}),

--- a/packages/ghost/src/ghost-core/catalog/types.ts
+++ b/packages/ghost/src/ghost-core/catalog/types.ts
@@ -13,11 +13,7 @@ export interface GhostCatalogNode {
   /** Filename slug: bare name, or the part after the first dot. */
   slug: string;
   /** Retrieval payload shown in gather: the condition under which this node applies. */
-  context?: string;
-  /** @deprecated Use `context`. Mirrors the resolved context for one release. */
   description?: string;
-  /** Whether the authored frontmatter used the deprecated `description` key. */
-  usesDeprecatedDescription?: true;
   /** Optional bare or annotated material locators carried by the authored node. */
   materials?: GhostMaterial[];
   /** True when the node carries a material locator, substantial fence, or Skeleton. */

--- a/packages/ghost/src/ghost-core/catalog/types.ts
+++ b/packages/ghost/src/ghost-core/catalog/types.ts
@@ -12,8 +12,8 @@ export interface GhostCatalogNode {
   kind?: string;
   /** Filename slug: bare name, or the part after the first dot. */
   slug: string;
-  /** Retrieval payload shown in gather: the condition under which this node applies. */
-  description?: string;
+  /** Retrieval payload shown in gather: the situation or activity this guidance is for. */
+  for?: string;
   /** Optional bare or annotated material locators carried by the authored node. */
   materials?: GhostMaterial[];
   /** True when the node carries a material locator, substantial fence, or Skeleton. */

--- a/packages/ghost/src/ghost-core/node/schema.ts
+++ b/packages/ghost/src/ghost-core/node/schema.ts
@@ -44,15 +44,21 @@ const AnnotatedMaterialSchema = z
  */
 export const GhostNodeFrontmatterSchema = z
   .object({
-    description: z.string().min(1).optional(),
+    for: z.string().min(1).optional(),
     materials: z
       .array(z.union([MaterialLocatorSchema, AnnotatedMaterialSchema]))
       .optional(),
-    // `context` was renamed back to `description`. Reject it with a message
-    // that names the rename so authors get a clear signal.
+    // The retrieval payload was renamed `description` → `context` → `for`.
+    // Reject both prior names with messages that name the rename so authors
+    // get a clear signal.
     context: z
       .never({
-        message: "`context` is a removed key (renamed to `description`)",
+        message: "`context` is a removed key (renamed to `for`)",
+      })
+      .optional(),
+    description: z
+      .never({
+        message: "`description` is a removed key (renamed to `for`)",
       })
       .optional(),
     // `relates` (and all typed edges) were removed. Reject it with a message

--- a/packages/ghost/src/ghost-core/node/schema.ts
+++ b/packages/ghost/src/ghost-core/node/schema.ts
@@ -40,15 +40,20 @@ const AnnotatedMaterialSchema = z
  *
  * Validates a node in isolation. Identity and containment are not here: they
  * come from the node's file path. Kind is the filename prefix, never a
- * frontmatter field. `description` is accepted as a deprecated read alias for
- * `context`; consumers resolve `context` first when both are present.
+ * frontmatter field.
  */
 export const GhostNodeFrontmatterSchema = z
   .object({
-    context: z.string().min(1).optional(),
     description: z.string().min(1).optional(),
     materials: z
       .array(z.union([MaterialLocatorSchema, AnnotatedMaterialSchema]))
+      .optional(),
+    // `context` was renamed back to `description`. Reject it with a message
+    // that names the rename so authors get a clear signal.
+    context: z
+      .never({
+        message: "`context` is a removed key (renamed to `description`)",
+      })
       .optional(),
     // `relates` (and all typed edges) were removed. Reject it with a message
     // that names the key so authors get a clear signal.

--- a/packages/ghost/src/ghost-core/node/schema.ts
+++ b/packages/ghost/src/ghost-core/node/schema.ts
@@ -48,18 +48,13 @@ export const GhostNodeFrontmatterSchema = z
     materials: z
       .array(z.union([MaterialLocatorSchema, AnnotatedMaterialSchema]))
       .optional(),
-    // The retrieval payload was renamed `description` → `context` → `for`.
-    // Reject both prior names with messages that name the rename so authors
-    // get a clear signal.
+    // The retrieval payload field is `for`. Reject near-miss keys that would
+    // otherwise ride along silently and leave the node invisible to gather.
     context: z
-      .never({
-        message: "`context` is a removed key (renamed to `for`)",
-      })
+      .never({ message: "`context` is not a node key; use `for`" })
       .optional(),
     description: z
-      .never({
-        message: "`description` is a removed key (renamed to `for`)",
-      })
+      .never({ message: "`description` is not a node key; use `for`" })
       .optional(),
     // `relates` (and all typed edges) were removed. Reject it with a message
     // that names the key so authors get a clear signal.

--- a/packages/ghost/src/ghost-core/node/serialize.ts
+++ b/packages/ghost/src/ghost-core/node/serialize.ts
@@ -1,7 +1,7 @@
 import { stringify as stringifyYaml } from "yaml";
 import type { GhostNodeDocument, GhostNodeFrontmatter } from "./types.js";
 
-const FRONTMATTER_KEY_ORDER = ["description", "materials"] as const;
+const FRONTMATTER_KEY_ORDER = ["for", "materials"] as const;
 
 function shouldSerializeFrontmatterValue(value: unknown): boolean {
   return value !== undefined;
@@ -9,7 +9,7 @@ function shouldSerializeFrontmatterValue(value: unknown): boolean {
 
 /**
  * Serialize a node back to its `---\n<yaml>\n---\n<body>` markdown form. Known
- * keys are emitted first in a stable order (description, materials), followed
+ * keys are emitted first in a stable order (for, materials), followed
  * by any free-form descriptive keys in alphabetical order so round-trips and
  * diffs are deterministic. Identity and kind are not serialized; they come
  * from the node's file path and optional filename prefix. Undefined fields are

--- a/packages/ghost/src/ghost-core/node/serialize.ts
+++ b/packages/ghost/src/ghost-core/node/serialize.ts
@@ -1,7 +1,7 @@
 import { stringify as stringifyYaml } from "yaml";
 import type { GhostNodeDocument, GhostNodeFrontmatter } from "./types.js";
 
-const FRONTMATTER_KEY_ORDER = ["context", "materials"] as const;
+const FRONTMATTER_KEY_ORDER = ["description", "materials"] as const;
 
 function shouldSerializeFrontmatterValue(value: unknown): boolean {
   return value !== undefined;
@@ -9,38 +9,28 @@ function shouldSerializeFrontmatterValue(value: unknown): boolean {
 
 /**
  * Serialize a node back to its `---\n<yaml>\n---\n<body>` markdown form. Known
- * keys are emitted first in a stable order (context, materials), followed by
- * any free-form descriptive keys in alphabetical order so round-trips and
- * diffs are deterministic. The deprecated `description` alias is written as
- * `context`, which makes serialize a safe migration boundary. Identity and kind
- * are not serialized; they come from the node's file path and optional filename
- * prefix. Undefined fields are omitted; a node with no frontmatter fields emits
- * an empty block.
+ * keys are emitted first in a stable order (description, materials), followed
+ * by any free-form descriptive keys in alphabetical order so round-trips and
+ * diffs are deterministic. Identity and kind are not serialized; they come
+ * from the node's file path and optional filename prefix. Undefined fields are
+ * omitted; a node with no frontmatter fields emits an empty block.
  */
 export function serializeNode(node: GhostNodeDocument): string {
   const fm = node.frontmatter as Record<string, unknown>;
-  const normalized: Record<string, unknown> = {
-    ...fm,
-    ...(fm.context === undefined && fm.description !== undefined
-      ? { context: fm.description }
-      : {}),
-  };
-  delete normalized.description;
-
   const ordered: Record<string, unknown> = {};
   const emitted = new Set<string>();
 
   for (const key of FRONTMATTER_KEY_ORDER) {
-    const value = normalized[key];
+    const value = fm[key];
     if (shouldSerializeFrontmatterValue(value)) {
       ordered[key] = value;
       emitted.add(key);
     }
   }
 
-  for (const key of Object.keys(normalized).sort()) {
+  for (const key of Object.keys(fm).sort()) {
     if (emitted.has(key)) continue;
-    const value = normalized[key];
+    const value = fm[key];
     if (shouldSerializeFrontmatterValue(value)) ordered[key] = value;
   }
 

--- a/packages/ghost/src/ghost-core/node/types.ts
+++ b/packages/ghost/src/ghost-core/node/types.ts
@@ -17,8 +17,6 @@ export interface GhostNodeFrontmatter {
    * applicability. Optional, but strongly encouraged on any node worth
    * anchoring a task at.
    */
-  context?: string;
-  /** @deprecated Use `context`. Accepted as a read alias for one release. */
   description?: string;
   /**
    * Optional locators for the concrete materials this guidance is about:

--- a/packages/ghost/src/ghost-core/node/types.ts
+++ b/packages/ghost/src/ghost-core/node/types.ts
@@ -12,12 +12,12 @@ export interface GhostNodeFrontmatter {
   /** Free-form descriptive properties parsed from node frontmatter. */
   [key: string]: unknown;
   /**
-   * Retrieval payload shown by gather: the observable condition under which
-   * this node applies. Together with the node's id, it is how an agent decides
-   * applicability. Optional, but strongly encouraged on any node worth
-   * anchoring a task at.
+   * Retrieval payload shown by gather: the situation or activity this
+   * guidance is for, never an audience. Together with the node's id, it is
+   * how an agent decides applicability. Optional, but strongly encouraged on
+   * any node worth anchoring a task at.
    */
-  description?: string;
+  for?: string;
   /**
    * Optional locators for the concrete materials this guidance is about:
    * explicit repo-relative file paths and supported external locators. Glob

--- a/packages/ghost/src/init-payloads/median/cliche.median.md
+++ b/packages/ghost/src/init-payloads/median/cliche.median.md
@@ -1,5 +1,5 @@
 ---
-context: Any greenfield visual surface or first-draft copy.
+description: Any greenfield visual surface or first-draft copy.
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/ghost/src/init-payloads/median/cliche.median.md
+++ b/packages/ghost/src/init-payloads/median/cliche.median.md
@@ -1,5 +1,5 @@
 ---
-description: Any greenfield visual surface or first-draft copy.
+for: Any greenfield visual surface or first-draft copy.
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/ghost/src/init-payloads/skeleton/brand.md
+++ b/packages/ghost/src/init-payloads/skeleton/brand.md
@@ -1,5 +1,5 @@
 ---
-description: Any task that should express this brand.
+for: Any task that should express this brand.
 ---
 
 This cover is unwritten. ghost gather always places this page in an agent's

--- a/packages/ghost/src/init-payloads/skeleton/brand.md
+++ b/packages/ghost/src/init-payloads/skeleton/brand.md
@@ -1,5 +1,5 @@
 ---
-context: Any task that should express this brand.
+description: Any task that should express this brand.
 ---
 
 This cover is unwritten. ghost gather always places this page in an agent's

--- a/packages/ghost/src/init-payloads/skeleton/context.conversation.md
+++ b/packages/ghost/src/init-payloads/skeleton/context.conversation.md
@@ -1,5 +1,5 @@
 ---
-description: Chat threads, agent consoles, and prompt composers.
+for: Chat threads, agent consoles, and prompt composers.
 ---
 
 In this context: AI conversation threads, agent consoles, review assistants,

--- a/packages/ghost/src/init-payloads/skeleton/context.conversation.md
+++ b/packages/ghost/src/init-payloads/skeleton/context.conversation.md
@@ -1,5 +1,5 @@
 ---
-context: Chat threads, agent consoles, and prompt composers.
+description: Chat threads, agent consoles, and prompt composers.
 ---
 
 In this context: AI conversation threads, agent consoles, review assistants,

--- a/packages/ghost/src/init-payloads/skeleton/foundation.color.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.color.md
@@ -1,5 +1,5 @@
 ---
-context: Choosing or applying color.
+description: Choosing or applying color.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.color.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.color.md
@@ -1,5 +1,5 @@
 ---
-description: Choosing or applying color.
+for: Choosing or applying color.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
@@ -1,5 +1,5 @@
 ---
-context: Assembling any view.
+description: Assembling any view.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.composition.md
@@ -1,5 +1,5 @@
 ---
-description: Assembling any view.
+for: Assembling any view.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
@@ -1,5 +1,5 @@
 ---
-description: Any view with actions or inputs.
+for: Any view with actions or inputs.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.controls.md
@@ -1,5 +1,5 @@
 ---
-context: Any view with actions or inputs.
+description: Any view with actions or inputs.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
@@ -1,5 +1,5 @@
 ---
-description: Laying out any view.
+for: Laying out any view.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.layout.md
@@ -1,5 +1,5 @@
 ---
-context: Laying out any view.
+description: Laying out any view.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
@@ -1,5 +1,5 @@
 ---
-description: Any transition, animation, or hover treatment.
+for: Any transition, animation, or hover treatment.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.motion.md
@@ -1,5 +1,5 @@
 ---
-context: Any transition, animation, or hover treatment.
+description: Any transition, animation, or hover treatment.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.type.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.type.md
@@ -1,5 +1,5 @@
 ---
-description: Any view containing text.
+for: Any view containing text.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.type.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.type.md
@@ -1,5 +1,5 @@
 ---
-context: Any view containing text.
+description: Any view containing text.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
@@ -1,5 +1,5 @@
 ---
-description: Writing or editing any copy.
+for: Writing or editing any copy.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
+++ b/packages/ghost/src/init-payloads/skeleton/foundation.voice.md
@@ -1,5 +1,5 @@
 ---
-context: Writing or editing any copy.
+description: Writing or editing any copy.
 ---
 
 Starter guidance the brand owner has not yet reviewed. Cite it as provisional

--- a/packages/ghost/src/review/baseline.ts
+++ b/packages/ghost/src/review/baseline.ts
@@ -8,7 +8,7 @@ export interface BaselineProse {
   ref: string;
   nodeId: string;
   heading?: string;
-  description?: string;
+  for?: string;
   body: string;
   warning?: string;
 }
@@ -25,9 +25,7 @@ export function resolveBaseline(
     return {
       ref: raw,
       nodeId: ref.nodeId,
-      ...(node.description !== undefined
-        ? { description: node.description }
-        : {}),
+      ...(node.for !== undefined ? { for: node.for } : {}),
       body: node.body,
     };
   }
@@ -36,9 +34,7 @@ export function resolveBaseline(
     ref: raw,
     nodeId: ref.nodeId,
     heading: ref.heading,
-    ...(node.description !== undefined
-      ? { description: node.description }
-      : {}),
+    ...(node.for !== undefined ? { for: node.for } : {}),
     body: section ?? node.body,
     ...(section === null
       ? {

--- a/packages/ghost/src/review/baseline.ts
+++ b/packages/ghost/src/review/baseline.ts
@@ -8,7 +8,7 @@ export interface BaselineProse {
   ref: string;
   nodeId: string;
   heading?: string;
-  context?: string;
+  description?: string;
   body: string;
   warning?: string;
 }
@@ -25,7 +25,9 @@ export function resolveBaseline(
     return {
       ref: raw,
       nodeId: ref.nodeId,
-      ...(node.context !== undefined ? { context: node.context } : {}),
+      ...(node.description !== undefined
+        ? { description: node.description }
+        : {}),
       body: node.body,
     };
   }
@@ -34,7 +36,9 @@ export function resolveBaseline(
     ref: raw,
     nodeId: ref.nodeId,
     heading: ref.heading,
-    ...(node.context !== undefined ? { context: node.context } : {}),
+    ...(node.description !== undefined
+      ? { description: node.description }
+      : {}),
     body: section ?? node.body,
     ...(section === null
       ? {

--- a/packages/ghost/src/review/review-packet.ts
+++ b/packages/ghost/src/review/review-packet.ts
@@ -22,7 +22,7 @@ export type { BaselineProse };
 export interface PacketMaterialNode {
   id: string;
   kind?: string;
-  description?: string;
+  for?: string;
   prose: string;
   materials: GhostMaterial[];
   matchedMaterials: string[];
@@ -112,9 +112,7 @@ function materialNodeFromMatch(
   return {
     id: node.id,
     ...(node.kind !== undefined ? { kind: node.kind } : {}),
-    ...(node.description !== undefined
-      ? { description: node.description }
-      : {}),
+    ...(node.for !== undefined ? { for: node.for } : {}),
     prose: node.body,
     materials: node.materials ?? [],
     matchedMaterials: matched.locators,
@@ -144,7 +142,7 @@ export function formatReviewPacket(packet: ReviewPacket): string {
     for (const node of packet.materialNodes) {
       const kind = node.kind ? ` _(${node.kind})_` : "";
       out.push(`### \`${node.id}\`${kind}`);
-      if (node.description) out.push(`_${node.description}_`, "");
+      if (node.for) out.push(`_${node.for}_`, "");
       out.push(node.prose, "");
       out.push("Matched materials:");
       for (const locator of node.matchedMaterials) {

--- a/packages/ghost/src/review/review-packet.ts
+++ b/packages/ghost/src/review/review-packet.ts
@@ -22,7 +22,7 @@ export type { BaselineProse };
 export interface PacketMaterialNode {
   id: string;
   kind?: string;
-  context?: string;
+  description?: string;
   prose: string;
   materials: GhostMaterial[];
   matchedMaterials: string[];
@@ -112,7 +112,9 @@ function materialNodeFromMatch(
   return {
     id: node.id,
     ...(node.kind !== undefined ? { kind: node.kind } : {}),
-    ...(node.context !== undefined ? { context: node.context } : {}),
+    ...(node.description !== undefined
+      ? { description: node.description }
+      : {}),
     prose: node.body,
     materials: node.materials ?? [],
     matchedMaterials: matched.locators,
@@ -142,7 +144,7 @@ export function formatReviewPacket(packet: ReviewPacket): string {
     for (const node of packet.materialNodes) {
       const kind = node.kind ? ` _(${node.kind})_` : "";
       out.push(`### \`${node.id}\`${kind}`);
-      if (node.context) out.push(`_${node.context}_`, "");
+      if (node.description) out.push(`_${node.description}_`, "");
       out.push(node.prose, "");
       out.push("Matched materials:");
       for (const locator of node.matchedMaterials) {

--- a/packages/ghost/src/scan/fingerprint-package-lint.ts
+++ b/packages/ghost/src/scan/fingerprint-package-lint.ts
@@ -80,7 +80,7 @@ export async function lintGhostPackage(
       await lintGlossary(paths.glossary, issues);
       lintCover(manifest.cover, catalog, issues);
       await lintKindPrefixes(paths, catalog, issues);
-      lintNodeContexts(catalog, issues);
+      lintNodeDescriptions(catalog, issues);
       lintSkeletonSections(catalog, issues);
       await lintMaterialLocators(paths, catalog, issues, cwd);
       lintCheckReferences(catalog, checks, issues);
@@ -187,28 +187,23 @@ async function lintKindPrefixes(
 }
 
 /**
- * `context` is a node's entire retrieval payload: `gather` lists it as the text
- * the agent selects against. A node without one renders as a bare id and cannot
- * show when it applies, so `validate` makes that loud. `description` remains a
- * read alias for one release and produces a migration warning.
+ * `description` is a node's entire retrieval payload: `gather` lists it as
+ * the text the agent selects against. A node without one renders as a bare id
+ * and cannot show when it applies, so `validate` makes that loud.
  */
-function lintNodeContexts(catalog: GhostCatalog, issues: LintIssue[]): void {
+function lintNodeDescriptions(
+  catalog: GhostCatalog,
+  issues: LintIssue[],
+): void {
   for (const node of catalog.nodes.values()) {
-    if (node.usesDeprecatedDescription) {
-      issues.push({
-        severity: "warning",
-        rule: "node-description-deprecated",
-        message:
-          "node uses deprecated `description`; rename it to `context` (the retrieval payload shown by `gather`)",
-        path: `${node.id}.md.description`,
-      });
+    if (node.description !== undefined && node.description.trim().length > 0) {
+      continue;
     }
-    if (node.context !== undefined && node.context.trim().length > 0) continue;
     issues.push({
       severity: "warning",
-      rule: "node-context-missing",
+      rule: "node-description-missing",
       message:
-        "node has no `context`, so `gather` lists it as a bare id without applicability context; add one line naming the observable condition under which this node applies",
+        "node has no `description`, so `gather` lists it as a bare id without applicability context; add one line naming the observable condition under which this node applies",
       path: `${node.id}.md`,
     });
   }

--- a/packages/ghost/src/scan/fingerprint-package-lint.ts
+++ b/packages/ghost/src/scan/fingerprint-package-lint.ts
@@ -80,7 +80,7 @@ export async function lintGhostPackage(
       await lintGlossary(paths.glossary, issues);
       lintCover(manifest.cover, catalog, issues);
       await lintKindPrefixes(paths, catalog, issues);
-      lintNodeDescriptions(catalog, issues);
+      lintNodeForPayloads(catalog, issues);
       lintSkeletonSections(catalog, issues);
       await lintMaterialLocators(paths, catalog, issues, cwd);
       lintCheckReferences(catalog, checks, issues);
@@ -187,23 +187,20 @@ async function lintKindPrefixes(
 }
 
 /**
- * `description` is a node's entire retrieval payload: `gather` lists it as
- * the text the agent selects against. A node without one renders as a bare id
- * and cannot show when it applies, so `validate` makes that loud.
+ * `for` is a node's entire retrieval payload: `gather` lists it as the text
+ * the agent selects against. A node without one renders as a bare id and
+ * cannot show when it applies, so `validate` makes that loud.
  */
-function lintNodeDescriptions(
-  catalog: GhostCatalog,
-  issues: LintIssue[],
-): void {
+function lintNodeForPayloads(catalog: GhostCatalog, issues: LintIssue[]): void {
   for (const node of catalog.nodes.values()) {
-    if (node.description !== undefined && node.description.trim().length > 0) {
+    if (node.for !== undefined && node.for.trim().length > 0) {
       continue;
     }
     issues.push({
       severity: "warning",
-      rule: "node-description-missing",
+      rule: "node-for-missing",
       message:
-        "node has no `description`, so `gather` lists it as a bare id without applicability context; add one line naming the observable condition under which this node applies",
+        "node has no `for`, so `gather` lists it as a bare id without applicability context; add one line naming the situation or activity this guidance is for",
       path: `${node.id}.md`,
     });
   }

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -36,7 +36,7 @@ it applies, and an agent reads the relevant guidance before building.
 
 ## The model in one breath
 
-- A **node** is a markdown file: `context`, optional `materials`, and prose brand guidance. `description` is a deprecated compatibility alias for one release.
+- A **node** is a markdown file: a `description`, optional `materials`, and prose brand guidance.
 - `materials` is one list of locators for the concrete stuff the guidance is about:
   explicit repo-relative file paths or supported external locators (see
   [schema.md](references/schema.md)); name each file rather than

--- a/packages/ghost/src/skill-bundle/SKILL.md
+++ b/packages/ghost/src/skill-bundle/SKILL.md
@@ -36,7 +36,7 @@ it applies, and an agent reads the relevant guidance before building.
 
 ## The model in one breath
 
-- A **node** is a markdown file: a `description`, optional `materials`, and prose brand guidance.
+- A **node** is a markdown file: a `for` payload, optional `materials`, and prose brand guidance.
 - `materials` is one list of locators for the concrete stuff the guidance is about:
   explicit repo-relative file paths or supported external locators (see
   [schema.md](references/schema.md)); name each file rather than

--- a/packages/ghost/src/skill-bundle/references/ground.md
+++ b/packages/ghost/src/skill-bundle/references/ground.md
@@ -14,7 +14,7 @@ Run `ghost gather <ask>` with the real task, not a generic label. The cover is
 inlined by gather, so do not pull it separately.
 
 `gather` presents every available node; it does not filter or rank. Judge each
-node's `description` against the actual task and pull what applies. When you are
+node's `for` payload against the actual task and pull what applies. When you are
 uncertain whether a node applies, pull it. Under-pull is silent and unrecoverable;
 over-pull is mild dilution. Skip only clear non-matches. Topic overlap alone is
 not applicability.

--- a/packages/ghost/src/skill-bundle/references/ground.md
+++ b/packages/ghost/src/skill-bundle/references/ground.md
@@ -14,7 +14,7 @@ Run `ghost gather <ask>` with the real task, not a generic label. The cover is
 inlined by gather, so do not pull it separately.
 
 `gather` presents every available node; it does not filter or rank. Judge each
-node's `context` against the actual task and pull what applies. When you are
+node's `description` against the actual task and pull what applies. When you are
 uncertain whether a node applies, pull it. Under-pull is silent and unrecoverable;
 over-pull is mild dilution. Skip only clear non-matches. Topic overlap alone is
 not applicability.

--- a/packages/ghost/src/skill-bundle/references/making.md
+++ b/packages/ghost/src/skill-bundle/references/making.md
@@ -17,7 +17,7 @@ judges, repairs, and reviews in the same session.
 ## Ground
 
 Follow [ground.md](ground.md), which ends with the anchor: gather with the real
-ask, select against each node's `description`, pull with an over-pull bias, and inspect decisive
+ask, select against each node's `for` payload, pull with an over-pull bias, and inspect decisive
 materials before generating.
 
 Use this triage for material inspection:

--- a/packages/ghost/src/skill-bundle/references/making.md
+++ b/packages/ghost/src/skill-bundle/references/making.md
@@ -17,7 +17,7 @@ judges, repairs, and reviews in the same session.
 ## Ground
 
 Follow [ground.md](ground.md), which ends with the anchor: gather with the real
-ask, select against `context`, pull with an over-pull bias, and inspect decisive
+ask, select against each node's `description`, pull with an over-pull bias, and inspect decisive
 materials before generating.
 
 Use this triage for material inspection:

--- a/packages/ghost/src/skill-bundle/references/nodes.md
+++ b/packages/ghost/src/skill-bundle/references/nodes.md
@@ -14,7 +14,7 @@ A node is one coherent decision with one applicability. Split only when a body
 contains another decision that should be gathered in a different situation.
 Do not split by destination or component name.
 
-Use `context` as retrieval payload, not summary. State the observable situation
+Use `description` as retrieval payload, not summary. State the observable situation
 in which the node applies. Read it alone: if it fits every brand or almost every
 task, it will not help selection. Put what to do and why in the body.
 
@@ -67,7 +67,7 @@ replacement.
 
 ```markdown
 ---
-context: Building or reviewing a performance dashboard.
+description: Building or reviewing a performance dashboard.
 ---
 
 Not rounded cards, celebratory gradients, and a wall of equal metrics.
@@ -109,7 +109,7 @@ Before curation, ask:
 | Dimension | Question |
 | --- | --- |
 | Testimony | Can you name the human words or evidence behind this? |
-| Discrimination | Does the context select a real situation rather than a topic? |
+| Discrimination | Does the description select a real situation rather than a topic? |
 | Force | Does the body decide something and reject a plausible alternative? |
 | Altitude | Is it universal on purpose, or conditioned? |
 | Residue | Is it free of starter prose, API mirroring, and brand-deck filler? |
@@ -121,7 +121,7 @@ canonical; human curation does.
 
 | If the agent keeps... | Author... |
 | --- | --- |
-| missing guidance | sharper `context`; universal guidance may belong on the cover |
+| missing guidance | sharper `description`; universal guidance may belong on the cover |
 | inventing values | a material-backed node with exact vocabulary |
 | producing generic output | replacement anti-goal plus a well-explained example |
 | choosing the wrong structure | bound/open pattern and, when needed, a Skeleton |
@@ -134,5 +134,5 @@ canonical; human curation does.
 - Never write a node the human neither said, showed, nor accepted.
 - Never make a node a container for observations or implementation inventory.
 - Never duplicate API documentation unless the API itself is the guidance.
-- Never use a broad context to compensate for unrelated decisions in one body.
+- Never use a broad description to compensate for unrelated decisions in one body.
 - Never ship a blacklist-only anti-goal.

--- a/packages/ghost/src/skill-bundle/references/nodes.md
+++ b/packages/ghost/src/skill-bundle/references/nodes.md
@@ -14,9 +14,10 @@ A node is one coherent decision with one applicability. Split only when a body
 contains another decision that should be gathered in a different situation.
 Do not split by destination or component name.
 
-Use `description` as retrieval payload, not summary. State the observable situation
-in which the node applies. Read it alone: if it fits every brand or almost every
-task, it will not help selection. Put what to do and why in the body.
+Use `for` as retrieval payload, not summary. State the situation or activity
+the guidance is for, never an audience. Read it alone: if it fits every brand
+or almost every task, it will not help selection. Put what to do and why in
+the body.
 
 Altitude lives in prose:
 
@@ -67,7 +68,7 @@ replacement.
 
 ```markdown
 ---
-description: Building or reviewing a performance dashboard.
+for: Building or reviewing a performance dashboard.
 ---
 
 Not rounded cards, celebratory gradients, and a wall of equal metrics.
@@ -109,7 +110,7 @@ Before curation, ask:
 | Dimension | Question |
 | --- | --- |
 | Testimony | Can you name the human words or evidence behind this? |
-| Discrimination | Does the description select a real situation rather than a topic? |
+| Discrimination | Does the `for` payload select a real situation rather than a topic? |
 | Force | Does the body decide something and reject a plausible alternative? |
 | Altitude | Is it universal on purpose, or conditioned? |
 | Residue | Is it free of starter prose, API mirroring, and brand-deck filler? |
@@ -121,7 +122,7 @@ canonical; human curation does.
 
 | If the agent keeps... | Author... |
 | --- | --- |
-| missing guidance | sharper `description`; universal guidance may belong on the cover |
+| missing guidance | sharper `for` payload; universal guidance may belong on the cover |
 | inventing values | a material-backed node with exact vocabulary |
 | producing generic output | replacement anti-goal plus a well-explained example |
 | choosing the wrong structure | bound/open pattern and, when needed, a Skeleton |
@@ -134,5 +135,5 @@ canonical; human curation does.
 - Never write a node the human neither said, showed, nor accepted.
 - Never make a node a container for observations or implementation inventory.
 - Never duplicate API documentation unless the API itself is the guidance.
-- Never use a broad description to compensate for unrelated decisions in one body.
+- Never use a broad `for` payload to compensate for unrelated decisions in one body.
 - Never ship a blacklist-only anti-goal.

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -38,7 +38,7 @@ segment. A bare filename has no kind. Undeclared kind prefixes warn.
 
 ```markdown
 ---
-description: Placing, sizing, or choosing a logo lockup or glyph.
+for: Placing, sizing, or choosing a logo lockup or glyph.
 materials:
   - brand/logo-primary.svg
   - https://figma.com/file/example?node-id=logo-lockups
@@ -49,7 +49,8 @@ materials:
 Use the full lockup when recognition matters.
 ```
 
-- `description` is the retrieval payload shown by `ghost gather`.
+- `for` is the retrieval payload shown by `ghost gather`: the situation or
+  activity the guidance is for, never an audience.
 - `materials` accepts explicit repo-relative file paths and external locators
   using `https:`, `mcp:`, `figma:`, or `github:`.
 - Glob patterns are invalid. Each local file must be named explicitly.

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -38,7 +38,7 @@ segment. A bare filename has no kind. Undeclared kind prefixes warn.
 
 ```markdown
 ---
-context: Placing, sizing, or choosing a logo lockup or glyph.
+description: Placing, sizing, or choosing a logo lockup or glyph.
 materials:
   - brand/logo-primary.svg
   - https://figma.com/file/example?node-id=logo-lockups
@@ -49,9 +49,7 @@ materials:
 Use the full lockup when recognition matters.
 ```
 
-- `context` is the retrieval payload shown by `ghost gather`.
-- `description` remains a deprecated read alias for one release; validation
-  warns until it is renamed.
+- `description` is the retrieval payload shown by `ghost gather`.
 - `materials` accepts explicit repo-relative file paths and external locators
   using `https:`, `mcp:`, `figma:`, or `github:`.
 - Glob patterns are invalid. Each local file must be named explicitly.

--- a/packages/ghost/src/skill-bundle/references/steering-audit.md
+++ b/packages/ghost/src/skill-bundle/references/steering-audit.md
@@ -30,13 +30,13 @@ Report first:
 - **Pull rate by concreteness:** concrete-material exposure/pull rate vs prose-only
   exposure/pull rate. In markdown this is the `Concrete material` row. This is
   the tuning instrument: if concrete nodes are not pulled when applicable,
-  descriptions or task selection are failing.
+  `for` payloads or task selection are failing.
 
 ## Corpus-level table
 
 | Row | Status | Evidence | Next move |
 | --- | --- | --- | --- |
-| Retrieval | strong / weak | descriptions, ids, cover | sharpen descriptions or move universal guidance to the cover |
+| Retrieval | strong / weak | `for` payloads, ids, cover | sharpen `for` payloads or move universal guidance to the cover |
 | Concreteness | strong / thin | materials, fenced examples, Skeletons | add concrete locators, examples, or opening structures |
 | Anti-goals | present / missing / vague | `anti-goal.*`, review packet | write not-X-instead-Y replacements and material locators |
 | Consistency | clean / conflicting | guidance vs concrete material | update or remove stale material |

--- a/packages/ghost/src/skill-bundle/references/steering-audit.md
+++ b/packages/ghost/src/skill-bundle/references/steering-audit.md
@@ -30,13 +30,13 @@ Report first:
 - **Pull rate by concreteness:** concrete-material exposure/pull rate vs prose-only
   exposure/pull rate. In markdown this is the `Concrete material` row. This is
   the tuning instrument: if concrete nodes are not pulled when applicable,
-  contexts or task selection are failing.
+  descriptions or task selection are failing.
 
 ## Corpus-level table
 
 | Row | Status | Evidence | Next move |
 | --- | --- | --- | --- |
-| Retrieval | strong / weak | contexts, ids, cover | sharpen contexts or move universal guidance to the cover |
+| Retrieval | strong / weak | descriptions, ids, cover | sharpen descriptions or move universal guidance to the cover |
 | Concreteness | strong / thin | materials, fenced examples, Skeletons | add concrete locators, examples, or opening structures |
 | Anti-goals | present / missing / vague | `anti-goal.*`, review packet | write not-X-instead-Y replacements and material locators |
 | Consistency | clean / conflicting | guidance vs concrete material | update or remove stale material |

--- a/packages/ghost/test/cli-exit.test.ts
+++ b/packages/ghost/test/cli-exit.test.ts
@@ -156,12 +156,15 @@ async function writeLargePullFixture(dir: string): Promise<void> {
         "",
       ].join("\n"),
     ),
-    writeFile(join(ghost, "index.md"), "---\ncontext: Cover.\n---\n\nCover.\n"),
+    writeFile(
+      join(ghost, "index.md"),
+      "---\ndescription: Cover.\n---\n\nCover.\n",
+    ),
     writeFile(
       join(ghost, "principle.long.md"),
       [
         "---",
-        "context: Large pull body.",
+        "description: Large pull body.",
         "---",
         "",
         "x".repeat(2 * 1024 * 1024),

--- a/packages/ghost/test/cli-exit.test.ts
+++ b/packages/ghost/test/cli-exit.test.ts
@@ -156,15 +156,12 @@ async function writeLargePullFixture(dir: string): Promise<void> {
         "",
       ].join("\n"),
     ),
-    writeFile(
-      join(ghost, "index.md"),
-      "---\ndescription: Cover.\n---\n\nCover.\n",
-    ),
+    writeFile(join(ghost, "index.md"), "---\nfor: Cover.\n---\n\nCover.\n"),
     writeFile(
       join(ghost, "principle.long.md"),
       [
         "---",
-        "description: Large pull body.",
+        "for: Large pull body.",
         "---",
         "",
         "x".repeat(2 * 1024 * 1024),

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -32,11 +32,11 @@ async function writeBareTestPackage(dir: string): Promise<void> {
     ),
     writeFile(
       join(packageDir, "index.md"),
-      "---\ncontext: Test package cover.\n---\n\nTest package.\n",
+      "---\ndescription: Test package cover.\n---\n\nTest package.\n",
     ),
     writeFile(
       join(packageDir, "cliche.median.md"),
-      "---\ncontext: Test cliche floor.\n---\n\nAvoid generic defaults.\n",
+      "---\ndescription: Test cliche floor.\n---\n\nAvoid generic defaults.\n",
     ),
   ]);
 }
@@ -595,7 +595,6 @@ describe("ghost CLI", () => {
       nodes: 9,
       concrete: 0,
       payloads: { materials: 0, fencedExamples: 0, skeletons: 0 },
-      withoutContext: 0,
       undescribed: 0,
     });
   });
@@ -746,15 +745,15 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ncontext: Tokens.\nmaterials:\n  - missing.css\n---\n\nUse exact tokens.\n",
+      "---\ndescription: Tokens.\nmaterials:\n  - missing.css\n---\n\nUse exact tokens.\n",
     );
     await writeFile(
       join(dir, ".ghost", "principle.rule.md"),
-      "---\ncontext: Rule.\n---\n\nPlain rule.\n",
+      "---\ndescription: Rule.\n---\n\nPlain rule.\n",
     );
     await writeFile(
       join(dir, ".ghost", "anti-goal.generic.md"),
-      "---\ncontext: Generic replacement.\n---\n\nNot vague; instead exact.\n",
+      "---\ndescription: Generic replacement.\n---\n\nNot vague; instead exact.\n",
     );
 
     // The seeded cover (`index`) is inlined above the menu, not counted in it.
@@ -764,17 +763,16 @@ describe("ghost CLI", () => {
       nodes: 4,
       concrete: 1,
       payloads: { materials: 1, fencedExamples: 0, skeletons: 0 },
-      withoutContext: 0,
       undescribed: 0,
     });
     const markdown = await runCli(["gather"], dir);
     expect(markdown.stdout).toContain(
       "4 nodes · 1 carry payloads (1 with materials, 0 with substantial fenced examples, 0 with Skeletons)",
     );
-    // No withoutContext nodes: the coverage line stays quiet about them.
-    expect(markdown.stdout).not.toContain("lack context");
+    // No undescribed nodes: the coverage line stays quiet about them.
+    expect(markdown.stdout).not.toContain("lack descriptions");
 
-    // A node without context is invisible to selection — the coverage
+    // A node without a description is invisible to selection — the coverage
     // line says so, and validate warns on it.
     await writeFile(
       join(dir, ".ghost", "principle.mute.md"),
@@ -782,10 +780,9 @@ describe("ghost CLI", () => {
     );
     const gatherMute = await runCli(["gather"], dir);
     expect(gatherMute.stdout).toContain(
-      "5 nodes · 1 carry payloads (1 with materials, 0 with substantial fenced examples, 0 with Skeletons) · 1 lack context",
+      "5 nodes · 1 carry payloads (1 with materials, 0 with substantial fenced examples, 0 with Skeletons) · 1 lack descriptions",
     );
     const gatherMuteJson = await runCli(["gather", "--format", "json"], dir);
-    expect(JSON.parse(gatherMuteJson.stdout).coverage.withoutContext).toBe(1);
     expect(JSON.parse(gatherMuteJson.stdout).coverage.undescribed).toBe(1);
 
     const steering = await runCli(
@@ -812,7 +809,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "asset.tokens.md"),
       [
         "---",
-        "context: Token material.",
+        "description: Token material.",
         "materials:",
         "  - materials/tokens.css",
         "---",
@@ -825,7 +822,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "copy.md"),
       [
         "---",
-        "context: Copy sample.",
+        "description: Copy sample.",
         "---",
         "",
         "```txt",
@@ -840,7 +837,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "pattern.card.md"),
       [
         "---",
-        "context: Card pattern.",
+        "description: Card pattern.",
         "---",
         "",
         "## Skeleton",
@@ -891,11 +888,11 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "pattern.card.md"),
-      "---\ncontext: Card pattern.\n---\n\nPattern prose.\n\n## Skeleton\n\n```tsx\n<section>{children}</section>\n```\n\nAfter skeleton should be stripped.\n",
+      "---\ndescription: Card pattern.\n---\n\nPattern prose.\n\n## Skeleton\n\n```tsx\n<section>{children}</section>\n```\n\nAfter skeleton should be stripped.\n",
     );
     await writeFile(
       join(dir, ".ghost", "pattern.bad.md"),
-      "---\ncontext: Bad skeleton.\n---\n\n## Skeleton\n\nNo fence here.\n",
+      "---\ndescription: Bad skeleton.\n---\n\n## Skeleton\n\nNo fence here.\n",
     );
 
     const pull = await runCli(["pull", "pattern.card"], dir);
@@ -936,7 +933,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "pattern.safe.md"),
       [
         "---",
-        "context: Fence safety.",
+        "description: Fence safety.",
         "materials:",
         "  - brand/example.md",
         "---",
@@ -987,7 +984,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.hostile.md"),
-      "---\ncontext: Hostile material.\nmaterials:\n  - brand/hostile.md\n---\n\nRead the material.\n",
+      "---\ndescription: Hostile material.\nmaterials:\n  - brand/hostile.md\n---\n\nRead the material.\n",
     );
 
     const pull = await runCli(["pull", "asset.hostile"], dir);
@@ -1009,7 +1006,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "mark.png"), Buffer.from([0, 1, 2]));
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ncontext: Logo.\nmaterials:\n  - brand/mark.png\n---\n\nInspect the blessed mark.\n",
+      "---\ndescription: Logo.\nmaterials:\n  - brand/mark.png\n---\n\nInspect the blessed mark.\n",
     );
 
     const md = await runCli(["pull", "asset.logo"], dir);
@@ -1031,11 +1028,11 @@ describe("ghost CLI", () => {
     await runCli(["init"], dir);
     await writeFile(
       join(dir, ".ghost", "principle.trust.md"),
-      "---\ncontext: Trust at the payment moment.\n---\n\nNear payment, reduce felt risk.\n",
+      "---\ndescription: Trust at the payment moment.\n---\n\nNear payment, reduce felt risk.\n",
     );
     await writeFile(
       join(dir, ".ghost", "voice.md"),
-      "---\ncontext: The brand voice.\n---\n\nPlain words. No hype.\n",
+      "---\ndescription: The brand voice.\n---\n\nPlain words. No hype.\n",
     );
 
     const gather = await runCli(
@@ -1079,7 +1076,7 @@ describe("ghost CLI", () => {
     expect(pull.stdout).toContain("Near payment, reduce felt risk.");
     expect(pull.stdout).toContain("Plain words. No hype.");
 
-    // JSON format carries id, kind, context, and body.
+    // JSON format carries id, kind, description, and body.
     const json = await runCli(
       ["pull", "principle.trust", "--format", "json"],
       dir,
@@ -1090,7 +1087,7 @@ describe("ghost CLI", () => {
     expect(payload.nodes[0]).toMatchObject({
       id: "principle.trust",
       kind: "principle",
-      context: "Trust at the payment moment.",
+      description: "Trust at the payment moment.",
     });
     expect(payload.nodes[0].body).toContain("reduce felt risk");
 
@@ -1174,7 +1171,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "large.txt"), "x".repeat(8 * 1024 + 1));
     await writeFile(
       join(dir, ".ghost", "asset.materials.md"),
-      "---\ncontext: Materials.\nmaterials:\n  - locator: materials/tokens.css\n    note: Canonical token values\n  - brand/voice.txt\n  - brand/mark.bin\n  - brand/large.txt\n  - https://example.com/brand-kit\n  - locator: mcp://brand-assets/brand-kit\n    note: Approved source artwork\n---\n\nRead these materials.\n",
+      "---\ndescription: Materials.\nmaterials:\n  - locator: materials/tokens.css\n    note: Canonical token values\n  - brand/voice.txt\n  - brand/mark.bin\n  - brand/large.txt\n  - https://example.com/brand-kit\n  - locator: mcp://brand-assets/brand-kit\n    note: Approved source artwork\n---\n\nRead these materials.\n",
     );
 
     const md = await runCli(["pull", "asset.materials"], dir);
@@ -1235,7 +1232,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
+      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
     );
 
     const md = await runCli(["pull", "asset.tokens", "--no-materials"], dir);
@@ -1266,7 +1263,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "voice.txt"), "Plain.\n");
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - locator: mcp://brand-assets/tokens\n    note: Canonical token source\n---\n\nToken prose.\n",
+      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - locator: mcp://brand-assets/tokens\n    note: Canonical token source\n---\n\nToken prose.\n",
     );
 
     const json = await runCli(
@@ -1307,7 +1304,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "samples", "b.txt"), "sample b\n");
     await writeFile(
       join(dir, ".ghost", "asset.samples.md"),
-      "---\ncontext: Samples.\nmaterials:\n  - brand/samples/a.txt\n  - brand/samples/b.txt\n---\n\nSample prose.\n",
+      "---\ndescription: Samples.\nmaterials:\n  - brand/samples/a.txt\n  - brand/samples/b.txt\n---\n\nSample prose.\n",
     );
 
     const json = await runCli(
@@ -1345,11 +1342,11 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.first.md"),
-      "---\ncontext: First.\nmaterials:\n  - materials/shared.css\n---\n\nFirst prose.\n",
+      "---\ndescription: First.\nmaterials:\n  - materials/shared.css\n---\n\nFirst prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "asset.second.md"),
-      "---\ncontext: Second.\nmaterials:\n  - materials/shared.css\n---\n\nSecond prose.\n",
+      "---\ndescription: Second.\nmaterials:\n  - materials/shared.css\n---\n\nSecond prose.\n",
     );
 
     const json = await runCli(
@@ -1383,7 +1380,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n\n## Skeleton\n\n```css\n:root { }\n```\n\nStrip me.\n",
+      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n\n## Skeleton\n\n```css\n:root { }\n```\n\nStrip me.\n",
     );
 
     const snapshot = await loadGhostSnapshot(
@@ -1408,7 +1405,7 @@ describe("ghost CLI", () => {
     );
     expect(cliPull.nodes[0]).toMatchObject({
       id: embedPull.nodes[0].id,
-      context: embedPull.nodes[0].context,
+      description: embedPull.nodes[0].description,
       body: embedPull.nodes[0].body,
     });
     expect(cliPull.nodes[0].materials).toEqual(
@@ -1428,7 +1425,7 @@ describe("ghost CLI", () => {
     await runCli(["init"], dir);
     await writeFile(
       join(dir, ".ghost", "principle.trust.md"),
-      "---\ncontext: Trust.\n---\n\nBody.\n",
+      "---\ndescription: Trust.\n---\n\nBody.\n",
     );
 
     const partial = await runCli(
@@ -1502,11 +1499,11 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "principle.trust.md"),
-      "---\ncontext: Trust.\n---\n\nBody.\n",
+      "---\ndescription: Trust.\n---\n\nBody.\n",
     );
     await writeFile(
       join(dir, ".ghost", "voice.md"),
-      "---\ncontext: Voice.\n---\n\nPlain.\n",
+      "---\ndescription: Voice.\n---\n\nPlain.\n",
     );
 
     await runCli(["gather", "checkout"], dir);
@@ -1682,7 +1679,7 @@ describe("ghost CLI", () => {
     await mkdir(checksDir, { recursive: true });
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ncontext: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
+      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
     );
     await writeFile(
       join(checksDir, "secret-check.md"),
@@ -1744,7 +1741,7 @@ describe("ghost CLI", () => {
     await runCli(["init", "--with", "checks"], dir);
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ncontext: Logo.\nmaterials:\n  - locator: brand/logo.svg\n    note: Use the approved clearspace source\n  - brand/icon.svg\n---\n\nLogo prose.\n",
+      "---\ndescription: Logo.\nmaterials:\n  - locator: brand/logo.svg\n    note: Use the approved clearspace source\n  - brand/icon.svg\n---\n\nLogo prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "checks", "logo-clearspace.md"),
@@ -1805,7 +1802,7 @@ describe("ghost CLI", () => {
     await runCli(["init", "--with", "checks"], dir);
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ncontext: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
+      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "checks", "logo-clearspace.md"),
@@ -1849,7 +1846,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, packageDir, "asset.tokens.md"),
-      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nTokens prose.\n",
+      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nTokens prose.\n",
     );
     await mkdir(join(dir, packageDir, "checks"), { recursive: true });
     await writeFile(
@@ -1891,7 +1888,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "anti-goal.generic-logo.md"),
-      "---\ncontext: Replace generic marks.\nmaterials:\n  - brand/logo.svg\n---\n\nNot a stock spark; instead use the wordmark and measured clearspace.\n",
+      "---\ndescription: Replace generic marks.\nmaterials:\n  - brand/logo.svg\n---\n\nNot a stock spark; instead use the wordmark and measured clearspace.\n",
     );
     await writeFile(
       join(dir, ".ghost", "checks", "unrelated.md"),
@@ -1925,7 +1922,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n  - https://example.com/tokens\n  - mcp://brand-assets/tokens\n---\n\nToken prose.\n",
+      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n  - https://example.com/tokens\n  - mcp://brand-assets/tokens\n---\n\nToken prose.\n",
     );
 
     const out = join(dir, "brand.tgz");
@@ -1984,7 +1981,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "voice.txt"), "Plain.\n");
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - https://example.com/tokens\n  - figma://file/abc\n---\n\nToken prose.\n",
+      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - https://example.com/tokens\n  - figma://file/abc\n---\n\nToken prose.\n",
     );
 
     const result = await runCli(["export", "--format", "json"], dir);
@@ -2024,7 +2021,7 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "asset.remote.md"),
-      "---\ncontext: Remote material.\nmaterials:\n  - mcp://brand-assets/tokens\n  - figma://file/abc\n  - github:acme/brand-assets\n---\n\nRemote prose.\n",
+      "---\ndescription: Remote material.\nmaterials:\n  - mcp://brand-assets/tokens\n  - figma://file/abc\n  - github:acme/brand-assets\n---\n\nRemote prose.\n",
     );
 
     const result = await runCli(["export", "--strict"], dir);
@@ -2048,7 +2045,7 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "asset.voice.md"),
-      "---\ncontext: Voice.\nmaterials:\n  - brand/voice.txt\n---\n\nVoice prose.\n",
+      "---\ndescription: Voice.\nmaterials:\n  - brand/voice.txt\n---\n\nVoice prose.\n",
     );
 
     const result = await runCli(["export", "--strict"], dir);
@@ -2067,7 +2064,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ncontext: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
+      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
     );
     const out = join(dir, "portable.tgz");
     await runCli(["export", "--out", out], dir);
@@ -2254,15 +2251,15 @@ async function writeGatherPackage(dir: string): Promise<void> {
   // Directories are a browsing convenience only; ids are paths minus .md.
   await writeFile(
     join(ghost, "index.md"),
-    "---\ncontext: Brand voice.\n---\n\nWarm and concise.\n",
+    "---\ndescription: Brand voice.\n---\n\nWarm and concise.\n",
   );
   await writeFile(
     join(ghost, "email", "index.md"),
-    "---\ncontext: Email surface.\n---\n\nEmail.\n",
+    "---\ndescription: Email surface.\n---\n\nEmail.\n",
   );
   await writeFile(
     join(ghost, "email", "marketing", "index.md"),
-    "---\ncontext: Marketing email.\n---\n\nMarketing may use urgency.\n",
+    "---\ndescription: Marketing email.\n---\n\nMarketing may use urgency.\n",
   );
   await writeFile(
     join(ghost, "checkout", "clarity.md"),

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -32,11 +32,11 @@ async function writeBareTestPackage(dir: string): Promise<void> {
     ),
     writeFile(
       join(packageDir, "index.md"),
-      "---\ndescription: Test package cover.\n---\n\nTest package.\n",
+      "---\nfor: Test package cover.\n---\n\nTest package.\n",
     ),
     writeFile(
       join(packageDir, "cliche.median.md"),
-      "---\ndescription: Test cliche floor.\n---\n\nAvoid generic defaults.\n",
+      "---\nfor: Test cliche floor.\n---\n\nAvoid generic defaults.\n",
     ),
   ]);
 }
@@ -595,7 +595,7 @@ describe("ghost CLI", () => {
       nodes: 9,
       concrete: 0,
       payloads: { materials: 0, fencedExamples: 0, skeletons: 0 },
-      undescribed: 0,
+      withoutFor: 0,
     });
   });
 
@@ -745,15 +745,15 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - missing.css\n---\n\nUse exact tokens.\n",
+      "---\nfor: Tokens.\nmaterials:\n  - missing.css\n---\n\nUse exact tokens.\n",
     );
     await writeFile(
       join(dir, ".ghost", "principle.rule.md"),
-      "---\ndescription: Rule.\n---\n\nPlain rule.\n",
+      "---\nfor: Rule.\n---\n\nPlain rule.\n",
     );
     await writeFile(
       join(dir, ".ghost", "anti-goal.generic.md"),
-      "---\ndescription: Generic replacement.\n---\n\nNot vague; instead exact.\n",
+      "---\nfor: Generic replacement.\n---\n\nNot vague; instead exact.\n",
     );
 
     // The seeded cover (`index`) is inlined above the menu, not counted in it.
@@ -763,16 +763,16 @@ describe("ghost CLI", () => {
       nodes: 4,
       concrete: 1,
       payloads: { materials: 1, fencedExamples: 0, skeletons: 0 },
-      undescribed: 0,
+      withoutFor: 0,
     });
     const markdown = await runCli(["gather"], dir);
     expect(markdown.stdout).toContain(
       "4 nodes · 1 carry payloads (1 with materials, 0 with substantial fenced examples, 0 with Skeletons)",
     );
-    // No undescribed nodes: the coverage line stays quiet about them.
-    expect(markdown.stdout).not.toContain("lack descriptions");
+    // No nodes lacking `for`: the coverage line stays quiet about them.
+    expect(markdown.stdout).not.toContain("lack `for` payloads");
 
-    // A node without a description is invisible to selection — the coverage
+    // A node without a `for` payload is invisible to selection — the coverage
     // line says so, and validate warns on it.
     await writeFile(
       join(dir, ".ghost", "principle.mute.md"),
@@ -780,10 +780,10 @@ describe("ghost CLI", () => {
     );
     const gatherMute = await runCli(["gather"], dir);
     expect(gatherMute.stdout).toContain(
-      "5 nodes · 1 carry payloads (1 with materials, 0 with substantial fenced examples, 0 with Skeletons) · 1 lack descriptions",
+      "5 nodes · 1 carry payloads (1 with materials, 0 with substantial fenced examples, 0 with Skeletons) · 1 lack `for` payloads",
     );
     const gatherMuteJson = await runCli(["gather", "--format", "json"], dir);
-    expect(JSON.parse(gatherMuteJson.stdout).coverage.undescribed).toBe(1);
+    expect(JSON.parse(gatherMuteJson.stdout).coverage.withoutFor).toBe(1);
 
     const steering = await runCli(
       ["pull", "principle.rule", "asset.tokens"],
@@ -809,7 +809,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "asset.tokens.md"),
       [
         "---",
-        "description: Token material.",
+        "for: Token material.",
         "materials:",
         "  - materials/tokens.css",
         "---",
@@ -822,7 +822,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "copy.md"),
       [
         "---",
-        "description: Copy sample.",
+        "for: Copy sample.",
         "---",
         "",
         "```txt",
@@ -837,7 +837,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "pattern.card.md"),
       [
         "---",
-        "description: Card pattern.",
+        "for: Card pattern.",
         "---",
         "",
         "## Skeleton",
@@ -888,11 +888,11 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "pattern.card.md"),
-      "---\ndescription: Card pattern.\n---\n\nPattern prose.\n\n## Skeleton\n\n```tsx\n<section>{children}</section>\n```\n\nAfter skeleton should be stripped.\n",
+      "---\nfor: Card pattern.\n---\n\nPattern prose.\n\n## Skeleton\n\n```tsx\n<section>{children}</section>\n```\n\nAfter skeleton should be stripped.\n",
     );
     await writeFile(
       join(dir, ".ghost", "pattern.bad.md"),
-      "---\ndescription: Bad skeleton.\n---\n\n## Skeleton\n\nNo fence here.\n",
+      "---\nfor: Bad skeleton.\n---\n\n## Skeleton\n\nNo fence here.\n",
     );
 
     const pull = await runCli(["pull", "pattern.card"], dir);
@@ -933,7 +933,7 @@ describe("ghost CLI", () => {
       join(dir, ".ghost", "pattern.safe.md"),
       [
         "---",
-        "description: Fence safety.",
+        "for: Fence safety.",
         "materials:",
         "  - brand/example.md",
         "---",
@@ -984,7 +984,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.hostile.md"),
-      "---\ndescription: Hostile material.\nmaterials:\n  - brand/hostile.md\n---\n\nRead the material.\n",
+      "---\nfor: Hostile material.\nmaterials:\n  - brand/hostile.md\n---\n\nRead the material.\n",
     );
 
     const pull = await runCli(["pull", "asset.hostile"], dir);
@@ -1006,7 +1006,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "mark.png"), Buffer.from([0, 1, 2]));
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - brand/mark.png\n---\n\nInspect the blessed mark.\n",
+      "---\nfor: Logo.\nmaterials:\n  - brand/mark.png\n---\n\nInspect the blessed mark.\n",
     );
 
     const md = await runCli(["pull", "asset.logo"], dir);
@@ -1028,11 +1028,11 @@ describe("ghost CLI", () => {
     await runCli(["init"], dir);
     await writeFile(
       join(dir, ".ghost", "principle.trust.md"),
-      "---\ndescription: Trust at the payment moment.\n---\n\nNear payment, reduce felt risk.\n",
+      "---\nfor: Trust at the payment moment.\n---\n\nNear payment, reduce felt risk.\n",
     );
     await writeFile(
       join(dir, ".ghost", "voice.md"),
-      "---\ndescription: The brand voice.\n---\n\nPlain words. No hype.\n",
+      "---\nfor: The brand voice.\n---\n\nPlain words. No hype.\n",
     );
 
     const gather = await runCli(
@@ -1076,7 +1076,7 @@ describe("ghost CLI", () => {
     expect(pull.stdout).toContain("Near payment, reduce felt risk.");
     expect(pull.stdout).toContain("Plain words. No hype.");
 
-    // JSON format carries id, kind, description, and body.
+    // JSON format carries id, kind, for, and body.
     const json = await runCli(
       ["pull", "principle.trust", "--format", "json"],
       dir,
@@ -1087,7 +1087,7 @@ describe("ghost CLI", () => {
     expect(payload.nodes[0]).toMatchObject({
       id: "principle.trust",
       kind: "principle",
-      description: "Trust at the payment moment.",
+      for: "Trust at the payment moment.",
     });
     expect(payload.nodes[0].body).toContain("reduce felt risk");
 
@@ -1171,7 +1171,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "large.txt"), "x".repeat(8 * 1024 + 1));
     await writeFile(
       join(dir, ".ghost", "asset.materials.md"),
-      "---\ndescription: Materials.\nmaterials:\n  - locator: materials/tokens.css\n    note: Canonical token values\n  - brand/voice.txt\n  - brand/mark.bin\n  - brand/large.txt\n  - https://example.com/brand-kit\n  - locator: mcp://brand-assets/brand-kit\n    note: Approved source artwork\n---\n\nRead these materials.\n",
+      "---\nfor: Materials.\nmaterials:\n  - locator: materials/tokens.css\n    note: Canonical token values\n  - brand/voice.txt\n  - brand/mark.bin\n  - brand/large.txt\n  - https://example.com/brand-kit\n  - locator: mcp://brand-assets/brand-kit\n    note: Approved source artwork\n---\n\nRead these materials.\n",
     );
 
     const md = await runCli(["pull", "asset.materials"], dir);
@@ -1232,7 +1232,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
+      "---\nfor: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
     );
 
     const md = await runCli(["pull", "asset.tokens", "--no-materials"], dir);
@@ -1263,7 +1263,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "voice.txt"), "Plain.\n");
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - locator: mcp://brand-assets/tokens\n    note: Canonical token source\n---\n\nToken prose.\n",
+      "---\nfor: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - locator: mcp://brand-assets/tokens\n    note: Canonical token source\n---\n\nToken prose.\n",
     );
 
     const json = await runCli(
@@ -1304,7 +1304,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "samples", "b.txt"), "sample b\n");
     await writeFile(
       join(dir, ".ghost", "asset.samples.md"),
-      "---\ndescription: Samples.\nmaterials:\n  - brand/samples/a.txt\n  - brand/samples/b.txt\n---\n\nSample prose.\n",
+      "---\nfor: Samples.\nmaterials:\n  - brand/samples/a.txt\n  - brand/samples/b.txt\n---\n\nSample prose.\n",
     );
 
     const json = await runCli(
@@ -1342,11 +1342,11 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.first.md"),
-      "---\ndescription: First.\nmaterials:\n  - materials/shared.css\n---\n\nFirst prose.\n",
+      "---\nfor: First.\nmaterials:\n  - materials/shared.css\n---\n\nFirst prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "asset.second.md"),
-      "---\ndescription: Second.\nmaterials:\n  - materials/shared.css\n---\n\nSecond prose.\n",
+      "---\nfor: Second.\nmaterials:\n  - materials/shared.css\n---\n\nSecond prose.\n",
     );
 
     const json = await runCli(
@@ -1380,7 +1380,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n\n## Skeleton\n\n```css\n:root { }\n```\n\nStrip me.\n",
+      "---\nfor: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n\n## Skeleton\n\n```css\n:root { }\n```\n\nStrip me.\n",
     );
 
     const snapshot = await loadGhostSnapshot(
@@ -1405,7 +1405,7 @@ describe("ghost CLI", () => {
     );
     expect(cliPull.nodes[0]).toMatchObject({
       id: embedPull.nodes[0].id,
-      description: embedPull.nodes[0].description,
+      for: embedPull.nodes[0].for,
       body: embedPull.nodes[0].body,
     });
     expect(cliPull.nodes[0].materials).toEqual(
@@ -1425,7 +1425,7 @@ describe("ghost CLI", () => {
     await runCli(["init"], dir);
     await writeFile(
       join(dir, ".ghost", "principle.trust.md"),
-      "---\ndescription: Trust.\n---\n\nBody.\n",
+      "---\nfor: Trust.\n---\n\nBody.\n",
     );
 
     const partial = await runCli(
@@ -1499,11 +1499,11 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "principle.trust.md"),
-      "---\ndescription: Trust.\n---\n\nBody.\n",
+      "---\nfor: Trust.\n---\n\nBody.\n",
     );
     await writeFile(
       join(dir, ".ghost", "voice.md"),
-      "---\ndescription: Voice.\n---\n\nPlain.\n",
+      "---\nfor: Voice.\n---\n\nPlain.\n",
     );
 
     await runCli(["gather", "checkout"], dir);
@@ -1679,7 +1679,7 @@ describe("ghost CLI", () => {
     await mkdir(checksDir, { recursive: true });
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
+      "---\nfor: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
     );
     await writeFile(
       join(checksDir, "secret-check.md"),
@@ -1741,7 +1741,7 @@ describe("ghost CLI", () => {
     await runCli(["init", "--with", "checks"], dir);
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - locator: brand/logo.svg\n    note: Use the approved clearspace source\n  - brand/icon.svg\n---\n\nLogo prose.\n",
+      "---\nfor: Logo.\nmaterials:\n  - locator: brand/logo.svg\n    note: Use the approved clearspace source\n  - brand/icon.svg\n---\n\nLogo prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "checks", "logo-clearspace.md"),
@@ -1802,7 +1802,7 @@ describe("ghost CLI", () => {
     await runCli(["init", "--with", "checks"], dir);
     await writeFile(
       join(dir, ".ghost", "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
+      "---\nfor: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "checks", "logo-clearspace.md"),
@@ -1846,7 +1846,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, packageDir, "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nTokens prose.\n",
+      "---\nfor: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nTokens prose.\n",
     );
     await mkdir(join(dir, packageDir, "checks"), { recursive: true });
     await writeFile(
@@ -1888,7 +1888,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "anti-goal.generic-logo.md"),
-      "---\ndescription: Replace generic marks.\nmaterials:\n  - brand/logo.svg\n---\n\nNot a stock spark; instead use the wordmark and measured clearspace.\n",
+      "---\nfor: Replace generic marks.\nmaterials:\n  - brand/logo.svg\n---\n\nNot a stock spark; instead use the wordmark and measured clearspace.\n",
     );
     await writeFile(
       join(dir, ".ghost", "checks", "unrelated.md"),
@@ -1922,7 +1922,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n  - https://example.com/tokens\n  - mcp://brand-assets/tokens\n---\n\nToken prose.\n",
+      "---\nfor: Tokens.\nmaterials:\n  - materials/tokens.css\n  - https://example.com/tokens\n  - mcp://brand-assets/tokens\n---\n\nToken prose.\n",
     );
 
     const out = join(dir, "brand.tgz");
@@ -1981,7 +1981,7 @@ describe("ghost CLI", () => {
     await writeFile(join(dir, "brand", "voice.txt"), "Plain.\n");
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - https://example.com/tokens\n  - figma://file/abc\n---\n\nToken prose.\n",
+      "---\nfor: Tokens.\nmaterials:\n  - materials/tokens.css\n  - brand/voice.txt\n  - https://example.com/tokens\n  - figma://file/abc\n---\n\nToken prose.\n",
     );
 
     const result = await runCli(["export", "--format", "json"], dir);
@@ -2021,7 +2021,7 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "asset.remote.md"),
-      "---\ndescription: Remote material.\nmaterials:\n  - mcp://brand-assets/tokens\n  - figma://file/abc\n  - github:acme/brand-assets\n---\n\nRemote prose.\n",
+      "---\nfor: Remote material.\nmaterials:\n  - mcp://brand-assets/tokens\n  - figma://file/abc\n  - github:acme/brand-assets\n---\n\nRemote prose.\n",
     );
 
     const result = await runCli(["export", "--strict"], dir);
@@ -2045,7 +2045,7 @@ describe("ghost CLI", () => {
     await writeBareTestPackage(dir);
     await writeFile(
       join(dir, ".ghost", "asset.voice.md"),
-      "---\ndescription: Voice.\nmaterials:\n  - brand/voice.txt\n---\n\nVoice prose.\n",
+      "---\nfor: Voice.\nmaterials:\n  - brand/voice.txt\n---\n\nVoice prose.\n",
     );
 
     const result = await runCli(["export", "--strict"], dir);
@@ -2064,7 +2064,7 @@ describe("ghost CLI", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
+      "---\nfor: Tokens.\nmaterials:\n  - materials/tokens.css\n---\n\nToken prose.\n",
     );
     const out = join(dir, "portable.tgz");
     await runCli(["export", "--out", out], dir);
@@ -2251,15 +2251,15 @@ async function writeGatherPackage(dir: string): Promise<void> {
   // Directories are a browsing convenience only; ids are paths minus .md.
   await writeFile(
     join(ghost, "index.md"),
-    "---\ndescription: Brand voice.\n---\n\nWarm and concise.\n",
+    "---\nfor: Brand voice.\n---\n\nWarm and concise.\n",
   );
   await writeFile(
     join(ghost, "email", "index.md"),
-    "---\ndescription: Email surface.\n---\n\nEmail.\n",
+    "---\nfor: Email surface.\n---\n\nEmail.\n",
   );
   await writeFile(
     join(ghost, "email", "marketing", "index.md"),
-    "---\ndescription: Marketing email.\n---\n\nMarketing may use urgency.\n",
+    "---\nfor: Marketing email.\n---\n\nMarketing may use urgency.\n",
   );
   await writeFile(
     join(ghost, "checkout", "clarity.md"),

--- a/packages/ghost/test/embed.test.ts
+++ b/packages/ghost/test/embed.test.ts
@@ -45,7 +45,7 @@ async function writePackage(dir: string): Promise<void> {
   );
   await writeFile(
     join(dir, ".ghost", "cover.md"),
-    "---\ndescription: Cover.\n---\n\nSilence posture.\n",
+    "---\nfor: Cover.\n---\n\nSilence posture.\n",
   );
   await writeFile(join(dir, ".ghost", "materials", "tokens.css"), ":root{}\n");
   await writeFile(join(dir, "brand", "voice.txt"), "Plain.\n");
@@ -57,7 +57,7 @@ async function writePackage(dir: string): Promise<void> {
     join(dir, ".ghost", "asset.tokens.md"),
     [
       "---",
-      "description: Tokens.",
+      "for: Tokens.",
       "materials:",
       "  - materials/tokens.css",
       "  - brand/voice.txt",
@@ -81,7 +81,7 @@ async function writePackage(dir: string): Promise<void> {
   );
   await writeFile(
     join(dir, ".ghost", "principle.rule.md"),
-    "---\ndescription: Rule.\n---\n\nRule prose.\n",
+    "---\nfor: Rule.\n---\n\nRule prose.\n",
   );
   await mkdir(join(dir, ".ghost", "checks"), { recursive: true });
   await writeFile(
@@ -150,7 +150,7 @@ describe("embed contract", () => {
       nodes: 2,
       concrete: 1,
       payloads: { materials: 1, fencedExamples: 0, skeletons: 1 },
-      undescribed: 0,
+      withoutFor: 0,
     });
     expect(result.kinds).toContainEqual({
       name: "asset",
@@ -417,11 +417,11 @@ describe("embed contract", () => {
     await writePackage(dir);
     await writeFile(
       join(dir, ".ghost", "asset.traversal.md"),
-      "---\ndescription: Traversal.\nmaterials:\n  - ../outside.txt\n---\n\nTraversal prose.\n",
+      "---\nfor: Traversal.\nmaterials:\n  - ../outside.txt\n---\n\nTraversal prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "asset.absolute.md"),
-      `---\ndescription: Absolute.\nmaterials:\n  - ${join(dir, "brand", "voice.txt")}\n---\n\nAbsolute prose.\n`,
+      `---\nfor: Absolute.\nmaterials:\n  - ${join(dir, "brand", "voice.txt")}\n---\n\nAbsolute prose.\n`,
     );
     const baseSnapshot = await loadGhostSnapshot(
       resolveGhostPackage(undefined, dir),
@@ -492,7 +492,7 @@ describe("embed contract", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.escape.md"),
-      "---\ndescription: Escape.\nmaterials:\n  - brand/escape.txt\n---\n\nEscape prose.\n",
+      "---\nfor: Escape.\nmaterials:\n  - brand/escape.txt\n---\n\nEscape prose.\n",
     );
     try {
       const snapshot = await loadGhostSnapshot(

--- a/packages/ghost/test/embed.test.ts
+++ b/packages/ghost/test/embed.test.ts
@@ -45,7 +45,7 @@ async function writePackage(dir: string): Promise<void> {
   );
   await writeFile(
     join(dir, ".ghost", "cover.md"),
-    "---\ncontext: Cover.\n---\n\nSilence posture.\n",
+    "---\ndescription: Cover.\n---\n\nSilence posture.\n",
   );
   await writeFile(join(dir, ".ghost", "materials", "tokens.css"), ":root{}\n");
   await writeFile(join(dir, "brand", "voice.txt"), "Plain.\n");
@@ -57,7 +57,7 @@ async function writePackage(dir: string): Promise<void> {
     join(dir, ".ghost", "asset.tokens.md"),
     [
       "---",
-      "context: Tokens.",
+      "description: Tokens.",
       "materials:",
       "  - materials/tokens.css",
       "  - brand/voice.txt",
@@ -81,7 +81,7 @@ async function writePackage(dir: string): Promise<void> {
   );
   await writeFile(
     join(dir, ".ghost", "principle.rule.md"),
-    "---\ncontext: Rule.\n---\n\nRule prose.\n",
+    "---\ndescription: Rule.\n---\n\nRule prose.\n",
   );
   await mkdir(join(dir, ".ghost", "checks"), { recursive: true });
   await writeFile(
@@ -150,7 +150,6 @@ describe("embed contract", () => {
       nodes: 2,
       concrete: 1,
       payloads: { materials: 1, fencedExamples: 0, skeletons: 1 },
-      withoutContext: 0,
       undescribed: 0,
     });
     expect(result.kinds).toContainEqual({
@@ -418,11 +417,11 @@ describe("embed contract", () => {
     await writePackage(dir);
     await writeFile(
       join(dir, ".ghost", "asset.traversal.md"),
-      "---\ncontext: Traversal.\nmaterials:\n  - ../outside.txt\n---\n\nTraversal prose.\n",
+      "---\ndescription: Traversal.\nmaterials:\n  - ../outside.txt\n---\n\nTraversal prose.\n",
     );
     await writeFile(
       join(dir, ".ghost", "asset.absolute.md"),
-      `---\ncontext: Absolute.\nmaterials:\n  - ${join(dir, "brand", "voice.txt")}\n---\n\nAbsolute prose.\n`,
+      `---\ndescription: Absolute.\nmaterials:\n  - ${join(dir, "brand", "voice.txt")}\n---\n\nAbsolute prose.\n`,
     );
     const baseSnapshot = await loadGhostSnapshot(
       resolveGhostPackage(undefined, dir),
@@ -493,7 +492,7 @@ describe("embed contract", () => {
     );
     await writeFile(
       join(dir, ".ghost", "asset.escape.md"),
-      "---\ncontext: Escape.\nmaterials:\n  - brand/escape.txt\n---\n\nEscape prose.\n",
+      "---\ndescription: Escape.\nmaterials:\n  - brand/escape.txt\n---\n\nEscape prose.\n",
     );
     try {
       const snapshot = await loadGhostSnapshot(

--- a/packages/ghost/test/fingerprint-package.test.ts
+++ b/packages/ghost/test/fingerprint-package.test.ts
@@ -58,7 +58,7 @@ describe("ghost package", () => {
     await mkdir(join(dir, "checkout"), { recursive: true });
     await writeFile(
       join(dir, "checkout", "principle.trust.md"),
-      "---\ncontext: Trust at the payment moment.\n---\n\nReduce felt risk near payment.\n",
+      "---\ndescription: Trust at the payment moment.\n---\n\nReduce felt risk near payment.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));
@@ -66,7 +66,7 @@ describe("ghost package", () => {
     // id is the path; kind/slug come from the filename.
     const authored = loaded.catalog.nodes.get("checkout/principle.trust");
     expect(authored?.body).toBe("Reduce felt risk near payment.");
-    expect(authored?.context).toBe("Trust at the payment moment.");
+    expect(authored?.description).toBe("Trust at the payment moment.");
     expect(authored?.kind).toBe("principle");
     expect(authored?.slug).toBe("trust");
   });
@@ -78,7 +78,7 @@ describe("ghost package", () => {
     // while loading, but must not vanish silently.
     await writeFile(
       join(dir, "features", "index.md"),
-      "---\ncontext: All feature UI.\nrelates:\n  - to: core\n---\n\nFeature prose.\n",
+      "---\ndescription: All feature UI.\nrelates:\n  - to: core\n---\n\nFeature prose.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));
@@ -131,7 +131,7 @@ Replacement rule.
     await writeGlossary(dir, ["principle"]);
     await writeFile(
       join(dir, "principle.density.md"),
-      "---\ncontext: Density stance.\n---\n\nUse density deliberately.\n",
+      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -149,7 +149,7 @@ Replacement rule.
     await writeGlossary(dir, ["principle"]);
     await writeFile(
       join(dir, "voice.md"),
-      "---\ncontext: Voice.\n---\n\nSpeak plainly.\n",
+      "---\ndescription: Voice.\n---\n\nSpeak plainly.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -162,7 +162,7 @@ Replacement rule.
     );
   });
 
-  it("warns when a node has no context", async () => {
+  it("warns when a node has no description", async () => {
     await writeManifest(dir);
     await writeGlossary(dir, ["principle"]);
     await writeFile(
@@ -173,59 +173,18 @@ Replacement rule.
     const report = await lintGhostPackage(dir);
 
     expect(report.errors).toBe(0);
-    // Undeclared cover + missing context.
+    // Undeclared cover + missing description.
     expect(report.warnings).toBe(2);
     expect(report.issues).toContainEqual(
       expect.objectContaining({
         severity: "warning",
-        rule: "node-context-missing",
+        rule: "node-description-missing",
         path: "principle.density.md",
       }),
     );
   });
 
-  it("reads deprecated description as context and warns to migrate", async () => {
-    await writeManifest(dir);
-    await writeGlossary(dir, ["principle"]);
-    await writeFile(
-      join(dir, "principle.density.md"),
-      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
-    );
-
-    const loaded = await loadGhostPackage(resolveGhostPackage(dir));
-    expect(loaded.catalog.nodes.get("principle.density")?.context).toBe(
-      "Density stance.",
-    );
-
-    const report = await lintGhostPackage(dir);
-    expect(report.errors).toBe(0);
-    expect(report.issues).toContainEqual(
-      expect.objectContaining({
-        severity: "warning",
-        rule: "node-description-deprecated",
-        path: "principle.density.md.description",
-      }),
-    );
-    expect(report.issues).not.toContainEqual(
-      expect.objectContaining({ rule: "node-context-missing" }),
-    );
-  });
-
-  it("prefers context when context and deprecated description coexist", async () => {
-    await writeManifest(dir);
-    await writeGlossary(dir, ["principle"]);
-    await writeFile(
-      join(dir, "principle.density.md"),
-      "---\ncontext: Canonical context.\ndescription: Legacy context.\n---\n\nUse density deliberately.\n",
-    );
-
-    const loaded = await loadGhostPackage(resolveGhostPackage(dir));
-    expect(loaded.catalog.nodes.get("principle.density")?.context).toBe(
-      "Canonical context.",
-    );
-  });
-
-  it("does not warn about context when every node has one", async () => {
+  it("rejects the removed context key with a rename message", async () => {
     await writeManifest(dir);
     await writeGlossary(dir, ["principle"]);
     await writeFile(
@@ -234,10 +193,27 @@ Replacement rule.
     );
 
     const report = await lintGhostPackage(dir);
+    expect(report.errors).toBeGreaterThan(0);
+    expect(
+      report.issues.some((issue) =>
+        issue.message.includes("renamed to `description`"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn about descriptions when every node has one", async () => {
+    await writeManifest(dir);
+    await writeGlossary(dir, ["principle"]);
+    await writeFile(
+      join(dir, "principle.density.md"),
+      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
+    );
+
+    const report = await lintGhostPackage(dir);
 
     expect(report.errors).toBe(0);
     expect(report.issues).not.toContainEqual(
-      expect.objectContaining({ rule: "node-context-missing" }),
+      expect.objectContaining({ rule: "node-description-missing" }),
     );
   });
 
@@ -246,7 +222,7 @@ Replacement rule.
     await writeGlossary(dir, ["principle"]);
     await writeFile(
       join(dir, "principles.density.md"),
-      "---\ncontext: Density stance.\n---\n\nUse density deliberately.\n",
+      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -270,7 +246,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "principles.density.md"),
-      "---\ncontext: Density stance.\n---\n\nUse density deliberately.\n",
+      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -287,7 +263,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ncontext: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
+      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));
@@ -303,7 +279,7 @@ Replacement rule.
     await mkdir(join(dir, "materials"), { recursive: true });
     await writeFile(
       join(dir, "materials", "asset.logo.md"),
-      "---\ncontext: Bundled material.\n---\n\nNot a node.\n",
+      "---\ndescription: Bundled material.\n---\n\nNot a node.\n",
     );
 
     const loadedFiles = await loadNodeFiles(dir);
@@ -328,7 +304,7 @@ Replacement rule.
     await writeFile(join(dir, "materials", "orphan.txt"), "orphan\n");
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ncontext: Logo.\nmaterials:\n  - materials/claimed.txt\n  - missing/logo.svg\n  - https://example.com/logo.svg\n---\n\nLogo prose.\n",
+      "---\ndescription: Logo.\nmaterials:\n  - materials/claimed.txt\n  - missing/logo.svg\n  - https://example.com/logo.svg\n---\n\nLogo prose.\n",
     );
 
     const report = await lintGhostPackage(dir, dir);
@@ -362,7 +338,7 @@ Replacement rule.
     await writeFile(join(dir, "materials", "tokens.css"), ":root {}\n");
     await writeFile(
       join(dir, "asset.tokens.md"),
-      "---\ncontext: Tokens.\nmaterials:\n  - materials/*.css\n---\n\nToken prose.\n",
+      "---\ndescription: Tokens.\nmaterials:\n  - materials/*.css\n---\n\nToken prose.\n",
     );
 
     const report = await lintGhostPackage(dir, dir);
@@ -386,7 +362,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ncontext: Logo.\nmaterials:\n  - /absolute/logo.svg\n---\n\nLogo prose.\n",
+      "---\ndescription: Logo.\nmaterials:\n  - /absolute/logo.svg\n---\n\nLogo prose.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -402,7 +378,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ncontext: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
+      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
     );
     await writeChecks(dir, [
       [
@@ -447,12 +423,12 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "index.md"),
-      "---\ncontext: The package cover and coverage map.\n---\n\nFront door prose.\n",
+      "---\ndescription: The package cover and coverage map.\n---\n\nFront door prose.\n",
     );
     await mkdir(join(dir, "email"), { recursive: true });
     await writeFile(
       join(dir, "email", "index.md"),
-      "---\ncontext: Email surface.\n---\n\nEmail.\n",
+      "---\ndescription: Email surface.\n---\n\nEmail.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));

--- a/packages/ghost/test/fingerprint-package.test.ts
+++ b/packages/ghost/test/fingerprint-package.test.ts
@@ -184,7 +184,7 @@ Replacement rule.
     );
   });
 
-  it("rejects the removed context key with a rename message", async () => {
+  it("rejects the context key and points to `for`", async () => {
     await writeManifest(dir);
     await writeGlossary(dir, ["principle"]);
     await writeFile(
@@ -195,11 +195,11 @@ Replacement rule.
     const report = await lintGhostPackage(dir);
     expect(report.errors).toBeGreaterThan(0);
     expect(
-      report.issues.some((issue) => issue.message.includes("renamed to `for`")),
+      report.issues.some((issue) => issue.message.includes("use `for`")),
     ).toBe(true);
   });
 
-  it("rejects the removed description key with a rename message", async () => {
+  it("rejects the description key and points to `for`", async () => {
     await writeManifest(dir);
     await writeGlossary(dir, ["principle"]);
     await writeFile(
@@ -210,7 +210,7 @@ Replacement rule.
     const report = await lintGhostPackage(dir);
     expect(report.errors).toBeGreaterThan(0);
     expect(
-      report.issues.some((issue) => issue.message.includes("renamed to `for`")),
+      report.issues.some((issue) => issue.message.includes("use `for`")),
     ).toBe(true);
   });
 

--- a/packages/ghost/test/fingerprint-package.test.ts
+++ b/packages/ghost/test/fingerprint-package.test.ts
@@ -58,7 +58,7 @@ describe("ghost package", () => {
     await mkdir(join(dir, "checkout"), { recursive: true });
     await writeFile(
       join(dir, "checkout", "principle.trust.md"),
-      "---\ndescription: Trust at the payment moment.\n---\n\nReduce felt risk near payment.\n",
+      "---\nfor: Trust at the payment moment.\n---\n\nReduce felt risk near payment.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));
@@ -66,7 +66,7 @@ describe("ghost package", () => {
     // id is the path; kind/slug come from the filename.
     const authored = loaded.catalog.nodes.get("checkout/principle.trust");
     expect(authored?.body).toBe("Reduce felt risk near payment.");
-    expect(authored?.description).toBe("Trust at the payment moment.");
+    expect(authored?.for).toBe("Trust at the payment moment.");
     expect(authored?.kind).toBe("principle");
     expect(authored?.slug).toBe("trust");
   });
@@ -78,7 +78,7 @@ describe("ghost package", () => {
     // while loading, but must not vanish silently.
     await writeFile(
       join(dir, "features", "index.md"),
-      "---\ndescription: All feature UI.\nrelates:\n  - to: core\n---\n\nFeature prose.\n",
+      "---\nfor: All feature UI.\nrelates:\n  - to: core\n---\n\nFeature prose.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));
@@ -131,7 +131,7 @@ Replacement rule.
     await writeGlossary(dir, ["principle"]);
     await writeFile(
       join(dir, "principle.density.md"),
-      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
+      "---\nfor: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -149,7 +149,7 @@ Replacement rule.
     await writeGlossary(dir, ["principle"]);
     await writeFile(
       join(dir, "voice.md"),
-      "---\ndescription: Voice.\n---\n\nSpeak plainly.\n",
+      "---\nfor: Voice.\n---\n\nSpeak plainly.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -162,7 +162,7 @@ Replacement rule.
     );
   });
 
-  it("warns when a node has no description", async () => {
+  it("warns when a node has no for payload", async () => {
     await writeManifest(dir);
     await writeGlossary(dir, ["principle"]);
     await writeFile(
@@ -173,12 +173,12 @@ Replacement rule.
     const report = await lintGhostPackage(dir);
 
     expect(report.errors).toBe(0);
-    // Undeclared cover + missing description.
+    // Undeclared cover + missing `for`.
     expect(report.warnings).toBe(2);
     expect(report.issues).toContainEqual(
       expect.objectContaining({
         severity: "warning",
-        rule: "node-description-missing",
+        rule: "node-for-missing",
         path: "principle.density.md",
       }),
     );
@@ -195,13 +195,11 @@ Replacement rule.
     const report = await lintGhostPackage(dir);
     expect(report.errors).toBeGreaterThan(0);
     expect(
-      report.issues.some((issue) =>
-        issue.message.includes("renamed to `description`"),
-      ),
+      report.issues.some((issue) => issue.message.includes("renamed to `for`")),
     ).toBe(true);
   });
 
-  it("does not warn about descriptions when every node has one", async () => {
+  it("rejects the removed description key with a rename message", async () => {
     await writeManifest(dir);
     await writeGlossary(dir, ["principle"]);
     await writeFile(
@@ -210,10 +208,25 @@ Replacement rule.
     );
 
     const report = await lintGhostPackage(dir);
+    expect(report.errors).toBeGreaterThan(0);
+    expect(
+      report.issues.some((issue) => issue.message.includes("renamed to `for`")),
+    ).toBe(true);
+  });
+
+  it("does not warn about for payloads when every node has one", async () => {
+    await writeManifest(dir);
+    await writeGlossary(dir, ["principle"]);
+    await writeFile(
+      join(dir, "principle.density.md"),
+      "---\nfor: Density stance.\n---\n\nUse density deliberately.\n",
+    );
+
+    const report = await lintGhostPackage(dir);
 
     expect(report.errors).toBe(0);
     expect(report.issues).not.toContainEqual(
-      expect.objectContaining({ rule: "node-description-missing" }),
+      expect.objectContaining({ rule: "node-for-missing" }),
     );
   });
 
@@ -222,7 +235,7 @@ Replacement rule.
     await writeGlossary(dir, ["principle"]);
     await writeFile(
       join(dir, "principles.density.md"),
-      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
+      "---\nfor: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -246,7 +259,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "principles.density.md"),
-      "---\ndescription: Density stance.\n---\n\nUse density deliberately.\n",
+      "---\nfor: Density stance.\n---\n\nUse density deliberately.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -263,7 +276,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
+      "---\nfor: Logo.\nmaterials:\n  - brand/logo.svg\n  - https://example.com/logo\n---\n\nLogo prose.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));
@@ -279,7 +292,7 @@ Replacement rule.
     await mkdir(join(dir, "materials"), { recursive: true });
     await writeFile(
       join(dir, "materials", "asset.logo.md"),
-      "---\ndescription: Bundled material.\n---\n\nNot a node.\n",
+      "---\nfor: Bundled material.\n---\n\nNot a node.\n",
     );
 
     const loadedFiles = await loadNodeFiles(dir);
@@ -304,7 +317,7 @@ Replacement rule.
     await writeFile(join(dir, "materials", "orphan.txt"), "orphan\n");
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - materials/claimed.txt\n  - missing/logo.svg\n  - https://example.com/logo.svg\n---\n\nLogo prose.\n",
+      "---\nfor: Logo.\nmaterials:\n  - materials/claimed.txt\n  - missing/logo.svg\n  - https://example.com/logo.svg\n---\n\nLogo prose.\n",
     );
 
     const report = await lintGhostPackage(dir, dir);
@@ -338,7 +351,7 @@ Replacement rule.
     await writeFile(join(dir, "materials", "tokens.css"), ":root {}\n");
     await writeFile(
       join(dir, "asset.tokens.md"),
-      "---\ndescription: Tokens.\nmaterials:\n  - materials/*.css\n---\n\nToken prose.\n",
+      "---\nfor: Tokens.\nmaterials:\n  - materials/*.css\n---\n\nToken prose.\n",
     );
 
     const report = await lintGhostPackage(dir, dir);
@@ -362,7 +375,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - /absolute/logo.svg\n---\n\nLogo prose.\n",
+      "---\nfor: Logo.\nmaterials:\n  - /absolute/logo.svg\n---\n\nLogo prose.\n",
     );
 
     const report = await lintGhostPackage(dir);
@@ -378,7 +391,7 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "asset.logo.md"),
-      "---\ndescription: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
+      "---\nfor: Logo.\nmaterials:\n  - brand/logo.svg\n---\n\nLogo prose.\n",
     );
     await writeChecks(dir, [
       [
@@ -423,12 +436,12 @@ Replacement rule.
     await writeManifest(dir);
     await writeFile(
       join(dir, "index.md"),
-      "---\ndescription: The package cover and coverage map.\n---\n\nFront door prose.\n",
+      "---\nfor: The package cover and coverage map.\n---\n\nFront door prose.\n",
     );
     await mkdir(join(dir, "email"), { recursive: true });
     await writeFile(
       join(dir, "email", "index.md"),
-      "---\ndescription: Email surface.\n---\n\nEmail.\n",
+      "---\nfor: Email surface.\n---\n\nEmail.\n",
     );
 
     const loaded = await loadGhostPackage(resolveGhostPackage(dir));

--- a/packages/ghost/test/ghost-core/node-schema.test.ts
+++ b/packages/ghost/test/ghost-core/node-schema.test.ts
@@ -47,19 +47,19 @@ describe("ghost.node/v1 schema", () => {
     expect(lintGhostNode(node("for: Lifecycle email.")).errors).toBe(0);
   });
 
-  it("rejects the removed context key with a rename message", () => {
+  it("rejects the context key and points to `for`", () => {
     const report = lintGhostNode(node("context: Lifecycle email."));
     expect(report.errors).toBeGreaterThan(0);
     expect(
-      report.issues.some((issue) => issue.message.includes("renamed to `for`")),
+      report.issues.some((issue) => issue.message.includes("use `for`")),
     ).toBe(true);
   });
 
-  it("rejects the removed description key with a rename message", () => {
+  it("rejects the description key and points to `for`", () => {
     const report = lintGhostNode(node("description: Lifecycle email."));
     expect(report.errors).toBeGreaterThan(0);
     expect(
-      report.issues.some((issue) => issue.message.includes("renamed to `for`")),
+      report.issues.some((issue) => issue.message.includes("use `for`")),
     ).toBe(true);
   });
 

--- a/packages/ghost/test/ghost-core/node-schema.test.ts
+++ b/packages/ghost/test/ghost-core/node-schema.test.ts
@@ -43,24 +43,30 @@ describe("ghost.node/v1 schema", () => {
     expect(lintGhostNode(node("audience: enterprise")).errors).toBe(0);
   });
 
-  it("accepts description (the retrieval payload)", () => {
-    expect(lintGhostNode(node("description: Lifecycle email.")).errors).toBe(0);
+  it("accepts for (the retrieval payload)", () => {
+    expect(lintGhostNode(node("for: Lifecycle email.")).errors).toBe(0);
   });
 
   it("rejects the removed context key with a rename message", () => {
     const report = lintGhostNode(node("context: Lifecycle email."));
     expect(report.errors).toBeGreaterThan(0);
     expect(
-      report.issues.some((issue) =>
-        issue.message.includes("renamed to `description`"),
-      ),
+      report.issues.some((issue) => issue.message.includes("renamed to `for`")),
+    ).toBe(true);
+  });
+
+  it("rejects the removed description key with a rename message", () => {
+    const report = lintGhostNode(node("description: Lifecycle email."));
+    expect(report.errors).toBeGreaterThan(0);
+    expect(
+      report.issues.some((issue) => issue.message.includes("renamed to `for`")),
     ).toBe(true);
   });
 
   it("round-trips through serialize/parse (frontmatter is properties only)", () => {
     const original: GhostNodeDocument = {
       frontmatter: {
-        description: "Near payment, reduce felt risk.",
+        for: "Near payment, reduce felt risk.",
       },
       body: "Near payment, reduce felt risk.",
     };
@@ -73,7 +79,7 @@ describe("ghost.node/v1 schema", () => {
   it("round-trips complete frontmatter through serialize/parse", () => {
     const original = {
       frontmatter: {
-        description: "Checkout trust signals.",
+        for: "Checkout trust signals.",
         materials: [
           "src/components/checkout/trust-signals.tsx",
           "https://example.com/logo.svg",
@@ -164,7 +170,7 @@ describe("ghost.node/v1 schema", () => {
     const serialized = serializeNode({
       frontmatter: {
         stage: "purchase",
-        description: "Checkout trust signals.",
+        for: "Checkout trust signals.",
         audience: "enterprise",
         materials: ["src/components/checkout/**"],
       },
@@ -173,7 +179,7 @@ describe("ghost.node/v1 schema", () => {
 
     expect(serialized).toMatchInlineSnapshot(`
       "---
-      description: Checkout trust signals.
+      for: Checkout trust signals.
       materials:
         - src/components/checkout/**
       audience: enterprise

--- a/packages/ghost/test/ghost-core/node-schema.test.ts
+++ b/packages/ghost/test/ghost-core/node-schema.test.ts
@@ -43,41 +43,24 @@ describe("ghost.node/v1 schema", () => {
     expect(lintGhostNode(node("audience: enterprise")).errors).toBe(0);
   });
 
-  it("accepts context (the retrieval payload)", () => {
-    expect(lintGhostNode(node("context: Lifecycle email.")).errors).toBe(0);
+  it("accepts description (the retrieval payload)", () => {
+    expect(lintGhostNode(node("description: Lifecycle email.")).errors).toBe(0);
   });
 
-  it("accepts description as a deprecated read alias", () => {
-    const parsed = parseNode(node("description: Lifecycle email."));
-    expect(parsed.report.errors).toBe(0);
-    expect(parsed.node?.frontmatter.description).toBe("Lifecycle email.");
-  });
-
-  it("serializes the deprecated description alias as context", () => {
-    const serialized = serializeNode({
-      frontmatter: { description: "Lifecycle email." },
-      body: "Send only when useful.",
-    });
-    expect(serialized).toContain("context: Lifecycle email.");
-    expect(serialized).not.toContain("description:");
-  });
-
-  it("prefers context when both keys are present", () => {
-    const serialized = serializeNode({
-      frontmatter: {
-        context: "Canonical retrieval payload.",
-        description: "Legacy retrieval payload.",
-      },
-      body: "Body.",
-    });
-    expect(serialized).toContain("context: Canonical retrieval payload.");
-    expect(serialized).not.toContain("Legacy retrieval payload.");
+  it("rejects the removed context key with a rename message", () => {
+    const report = lintGhostNode(node("context: Lifecycle email."));
+    expect(report.errors).toBeGreaterThan(0);
+    expect(
+      report.issues.some((issue) =>
+        issue.message.includes("renamed to `description`"),
+      ),
+    ).toBe(true);
   });
 
   it("round-trips through serialize/parse (frontmatter is properties only)", () => {
     const original: GhostNodeDocument = {
       frontmatter: {
-        context: "Near payment, reduce felt risk.",
+        description: "Near payment, reduce felt risk.",
       },
       body: "Near payment, reduce felt risk.",
     };
@@ -90,7 +73,7 @@ describe("ghost.node/v1 schema", () => {
   it("round-trips complete frontmatter through serialize/parse", () => {
     const original = {
       frontmatter: {
-        context: "Checkout trust signals.",
+        description: "Checkout trust signals.",
         materials: [
           "src/components/checkout/trust-signals.tsx",
           "https://example.com/logo.svg",
@@ -181,7 +164,7 @@ describe("ghost.node/v1 schema", () => {
     const serialized = serializeNode({
       frontmatter: {
         stage: "purchase",
-        context: "Checkout trust signals.",
+        description: "Checkout trust signals.",
         audience: "enterprise",
         materials: ["src/components/checkout/**"],
       },
@@ -190,7 +173,7 @@ describe("ghost.node/v1 schema", () => {
 
     expect(serialized).toMatchInlineSnapshot(`
       "---
-      context: Checkout trust signals.
+      description: Checkout trust signals.
       materials:
         - src/components/checkout/**
       audience: enterprise

--- a/packages/vessel-light/.ghost/anti-goal.median.md
+++ b/packages/vessel-light/.ghost/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-context: Any greenfield visual surface or first-draft copy.
+description: Any greenfield visual surface or first-draft copy.
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/vessel-light/.ghost/anti-goal.median.md
+++ b/packages/vessel-light/.ghost/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-description: Any greenfield visual surface or first-draft copy.
+for: Any greenfield visual surface or first-draft copy.
 ---
 
 This is the model's median, not your brand. Each rule is reject→replace.

--- a/packages/vessel-light/.ghost/anti-goal.tells.md
+++ b/packages/vessel-light/.ghost/anti-goal.tells.md
@@ -1,5 +1,5 @@
 ---
-description: Any work applying this brand's signature.
+for: Any work applying this brand's signature.
 ---
 
 These are the near-misses of Vessel's own signature: outputs that got close

--- a/packages/vessel-light/.ghost/anti-goal.tells.md
+++ b/packages/vessel-light/.ghost/anti-goal.tells.md
@@ -1,5 +1,5 @@
 ---
-context: Any work applying this brand's signature.
+description: Any work applying this brand's signature.
 ---
 
 These are the near-misses of Vessel's own signature: outputs that got close

--- a/packages/vessel-light/.ghost/grammar.color-roles.md
+++ b/packages/vessel-light/.ghost/grammar.color-roles.md
@@ -1,5 +1,5 @@
 ---
-description: Choosing or applying color.
+for: Choosing or applying color.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/grammar.color-roles.md
+++ b/packages/vessel-light/.ghost/grammar.color-roles.md
@@ -1,5 +1,5 @@
 ---
-context: Choosing or applying color.
+description: Choosing or applying color.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/grammar.conversation.md
+++ b/packages/vessel-light/.ghost/grammar.conversation.md
@@ -1,5 +1,5 @@
 ---
-context: Any AI thread, agent console, review assistant, or prompt composer.
+description: Any AI thread, agent console, review assistant, or prompt composer.
 materials:
   - materials/examples/composition.conversation.html
 ---

--- a/packages/vessel-light/.ghost/grammar.conversation.md
+++ b/packages/vessel-light/.ghost/grammar.conversation.md
@@ -1,5 +1,5 @@
 ---
-description: Any AI thread, agent console, review assistant, or prompt composer.
+for: Any AI thread, agent console, review assistant, or prompt composer.
 materials:
   - materials/examples/composition.conversation.html
 ---

--- a/packages/vessel-light/.ghost/grammar.deletion.md
+++ b/packages/vessel-light/.ghost/grammar.deletion.md
@@ -1,5 +1,5 @@
 ---
-context: The final pass over any composition, or whenever a view feels crowded, busy, or dressed up.
+description: The final pass over any composition, or whenever a view feels crowded, busy, or dressed up.
 ---
 
 Restraint is not a mood; it is a test every element has to pass. Before a

--- a/packages/vessel-light/.ghost/grammar.deletion.md
+++ b/packages/vessel-light/.ghost/grammar.deletion.md
@@ -1,5 +1,5 @@
 ---
-description: The final pass over any composition, or whenever a view feels crowded, busy, or dressed up.
+for: The final pass over any composition, or whenever a view feels crowded, busy, or dressed up.
 ---
 
 Restraint is not a mood; it is a test every element has to pass. Before a

--- a/packages/vessel-light/.ghost/grammar.hierarchy.md
+++ b/packages/vessel-light/.ghost/grammar.hierarchy.md
@@ -1,5 +1,5 @@
 ---
-context: Any view containing text or actions.
+description: Any view containing text or actions.
 materials:
   - materials/primitives.css
   - materials/examples/composition.form.html

--- a/packages/vessel-light/.ghost/grammar.hierarchy.md
+++ b/packages/vessel-light/.ghost/grammar.hierarchy.md
@@ -1,5 +1,5 @@
 ---
-description: Any view containing text or actions.
+for: Any view containing text or actions.
 materials:
   - materials/primitives.css
   - materials/examples/composition.form.html

--- a/packages/vessel-light/.ghost/grammar.job.md
+++ b/packages/vessel-light/.ghost/grammar.job.md
@@ -1,5 +1,5 @@
 ---
-context: Any new view before its structure or register is chosen.
+description: Any new view before its structure or register is chosen.
 materials:
   - materials/examples/composition.form.html
   - materials/examples/composition.table.html

--- a/packages/vessel-light/.ghost/grammar.job.md
+++ b/packages/vessel-light/.ghost/grammar.job.md
@@ -1,5 +1,5 @@
 ---
-description: Any new view before its structure or register is chosen.
+for: Any new view before its structure or register is chosen.
 materials:
   - materials/examples/composition.form.html
   - materials/examples/composition.table.html

--- a/packages/vessel-light/.ghost/grammar.motion.md
+++ b/packages/vessel-light/.ghost/grammar.motion.md
@@ -1,5 +1,5 @@
 ---
-context: Any transition, animation, or hover treatment.
+description: Any transition, animation, or hover treatment.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/grammar.motion.md
+++ b/packages/vessel-light/.ghost/grammar.motion.md
@@ -1,5 +1,5 @@
 ---
-description: Any transition, animation, or hover treatment.
+for: Any transition, animation, or hover treatment.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/grammar.rhythm.md
+++ b/packages/vessel-light/.ghost/grammar.rhythm.md
@@ -1,5 +1,5 @@
 ---
-description: Laying out any view.
+for: Laying out any view.
 materials:
   - materials/primitives.css
 ---

--- a/packages/vessel-light/.ghost/grammar.rhythm.md
+++ b/packages/vessel-light/.ghost/grammar.rhythm.md
@@ -1,5 +1,5 @@
 ---
-context: Laying out any view.
+description: Laying out any view.
 materials:
   - materials/primitives.css
 ---

--- a/packages/vessel-light/.ghost/grammar.surfaces.md
+++ b/packages/vessel-light/.ghost/grammar.surfaces.md
@@ -1,5 +1,5 @@
 ---
-context: Any card, popover, modal, dialog, scrim, or bordered container.
+description: Any card, popover, modal, dialog, scrim, or bordered container.
 materials:
   - materials/primitives.css
   - materials/examples/composition.overlay.html

--- a/packages/vessel-light/.ghost/grammar.surfaces.md
+++ b/packages/vessel-light/.ghost/grammar.surfaces.md
@@ -1,5 +1,5 @@
 ---
-description: Any card, popover, modal, dialog, scrim, or bordered container.
+for: Any card, popover, modal, dialog, scrim, or bordered container.
 materials:
   - materials/primitives.css
   - materials/examples/composition.overlay.html

--- a/packages/vessel-light/.ghost/index.md
+++ b/packages/vessel-light/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-description: Any task using the complete Vessel design language.
+for: Any task using the complete Vessel design language.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/index.md
+++ b/packages/vessel-light/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-context: Any task using the complete Vessel design language.
+description: Any task using the complete Vessel design language.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/register.data-density.md
+++ b/packages/vessel-light/.ghost/register.data-density.md
@@ -1,5 +1,5 @@
 ---
-context: Tables, dashboards, logs, monitoring, or other data-dense consoles.
+description: Tables, dashboards, logs, monitoring, or other data-dense consoles.
 materials:
   - materials/examples/composition.table.html
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/register.data-density.md
+++ b/packages/vessel-light/.ghost/register.data-density.md
@@ -1,5 +1,5 @@
 ---
-description: Tables, dashboards, logs, monitoring, or other data-dense consoles.
+for: Tables, dashboards, logs, monitoring, or other data-dense consoles.
 materials:
   - materials/examples/composition.table.html
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/register.editorial.md
+++ b/packages/vessel-light/.ghost/register.editorial.md
@@ -1,5 +1,5 @@
 ---
-description: Heroes, marketing pages, pull quotes, or full-bleed dark moments.
+for: Heroes, marketing pages, pull quotes, or full-bleed dark moments.
 materials:
   - materials/examples/composition.editorial.html
   - materials/tokens.css

--- a/packages/vessel-light/.ghost/register.editorial.md
+++ b/packages/vessel-light/.ghost/register.editorial.md
@@ -1,5 +1,5 @@
 ---
-context: Heroes, marketing pages, pull quotes, or full-bleed dark moments.
+description: Heroes, marketing pages, pull quotes, or full-bleed dark moments.
 materials:
   - materials/examples/composition.editorial.html
   - materials/tokens.css

--- a/packages/vessel-light/.ghost/register.email.md
+++ b/packages/vessel-light/.ghost/register.email.md
@@ -1,5 +1,5 @@
 ---
-context: Transactional email only.
+description: Transactional email only.
 materials:
   - materials/examples/email.html
 ---

--- a/packages/vessel-light/.ghost/register.email.md
+++ b/packages/vessel-light/.ghost/register.email.md
@@ -1,5 +1,5 @@
 ---
-description: Transactional email only.
+for: Transactional email only.
 materials:
   - materials/examples/email.html
 ---

--- a/packages/vessel-light/.ghost/signature.palette.md
+++ b/packages/vessel-light/.ghost/signature.palette.md
@@ -1,5 +1,5 @@
 ---
-context: Color beyond the base roles, in any register.
+description: Color beyond the base roles, in any register.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.palette.md
+++ b/packages/vessel-light/.ghost/signature.palette.md
@@ -1,5 +1,5 @@
 ---
-description: Color beyond the base roles, in any register.
+for: Color beyond the base roles, in any register.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.shape.md
+++ b/packages/vessel-light/.ghost/signature.shape.md
@@ -1,5 +1,5 @@
 ---
-description: Choosing or implementing any radius or corner treatment.
+for: Choosing or implementing any radius or corner treatment.
 materials:
   - materials/tokens.css
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/signature.shape.md
+++ b/packages/vessel-light/.ghost/signature.shape.md
@@ -1,5 +1,5 @@
 ---
-context: Choosing or implementing any radius or corner treatment.
+description: Choosing or implementing any radius or corner treatment.
 materials:
   - materials/tokens.css
   - materials/primitives.css

--- a/packages/vessel-light/.ghost/signature.temperature.md
+++ b/packages/vessel-light/.ghost/signature.temperature.md
@@ -1,5 +1,5 @@
 ---
-context: Writing any copy or choosing the character of motion.
+description: Writing any copy or choosing the character of motion.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.temperature.md
+++ b/packages/vessel-light/.ghost/signature.temperature.md
@@ -1,5 +1,5 @@
 ---
-description: Writing any copy or choosing the character of motion.
+for: Writing any copy or choosing the character of motion.
 materials:
   - materials/tokens.css
 ---

--- a/packages/vessel-light/.ghost/signature.type.md
+++ b/packages/vessel-light/.ghost/signature.type.md
@@ -1,5 +1,5 @@
 ---
-description: Any text, hero, landing page, or editorial moment.
+for: Any text, hero, landing page, or editorial moment.
 materials:
   - materials/tokens.css
   - materials/fonts/HKGrotesk-Black.woff2

--- a/packages/vessel-light/.ghost/signature.type.md
+++ b/packages/vessel-light/.ghost/signature.type.md
@@ -1,5 +1,5 @@
 ---
-context: Any text, hero, landing page, or editorial moment.
+description: Any text, hero, landing page, or editorial moment.
 materials:
   - materials/tokens.css
   - materials/fonts/HKGrotesk-Black.woff2

--- a/packages/vessel-react/.ghost/asset.registry.md
+++ b/packages/vessel-react/.ghost/asset.registry.md
@@ -1,5 +1,5 @@
 ---
-context: Changing registry distribution, registry metadata, or copy-and-own component delivery.
+description: Changing registry distribution, registry metadata, or copy-and-own component delivery.
 materials:
   - packages/vessel-react/registry.json
   - packages/vessel-react/public/r/registry.json

--- a/packages/vessel-react/.ghost/asset.registry.md
+++ b/packages/vessel-react/.ghost/asset.registry.md
@@ -1,5 +1,5 @@
 ---
-description: Changing registry distribution, registry metadata, or copy-and-own component delivery.
+for: Changing registry distribution, registry metadata, or copy-and-own component delivery.
 materials:
   - packages/vessel-react/registry.json
   - packages/vessel-react/public/r/registry.json

--- a/packages/vessel-react/.ghost/asset.tokens.md
+++ b/packages/vessel-react/.ghost/asset.tokens.md
@@ -1,5 +1,5 @@
 ---
-context: Changing tokens, semantic roles, or the Tailwind utility bridge.
+description: Changing tokens, semantic roles, or the Tailwind utility bridge.
 materials:
   - packages/vessel-react/src/styles/main.css
   - packages/vessel-react/src/styles/font-faces.css

--- a/packages/vessel-react/.ghost/asset.tokens.md
+++ b/packages/vessel-react/.ghost/asset.tokens.md
@@ -1,5 +1,5 @@
 ---
-description: Changing tokens, semantic roles, or the Tailwind utility bridge.
+for: Changing tokens, semantic roles, or the Tailwind utility bridge.
 materials:
   - packages/vessel-react/src/styles/main.css
   - packages/vessel-react/src/styles/font-faces.css

--- a/packages/vessel-react/.ghost/condition.escape-hatches.md
+++ b/packages/vessel-react/.ghost/condition.escape-hatches.md
@@ -1,5 +1,5 @@
 ---
-description: Component work needs className, inline style, arbitrary values, or a local primitive fork.
+for: Component work needs className, inline style, arbitrary values, or a local primitive fork.
 materials:
   - packages/vessel-react/scripts/audit-agent-safety.mjs
 ---

--- a/packages/vessel-react/.ghost/condition.escape-hatches.md
+++ b/packages/vessel-react/.ghost/condition.escape-hatches.md
@@ -1,5 +1,5 @@
 ---
-context: Component work needs className, inline style, arbitrary values, or a local primitive fork.
+description: Component work needs className, inline style, arbitrary values, or a local primitive fork.
 materials:
   - packages/vessel-react/scripts/audit-agent-safety.mjs
 ---

--- a/packages/vessel-react/.ghost/condition.upstream-sync.md
+++ b/packages/vessel-react/.ghost/condition.upstream-sync.md
@@ -1,5 +1,5 @@
 ---
-description: Reconciling Vessel with upstream shadcn or evaluating an upstream change.
+for: Reconciling Vessel with upstream shadcn or evaluating an upstream change.
 ---
 
 Condition: you are syncing Vessel components against newer upstream shadcn

--- a/packages/vessel-react/.ghost/condition.upstream-sync.md
+++ b/packages/vessel-react/.ghost/condition.upstream-sync.md
@@ -1,5 +1,5 @@
 ---
-context: Reconciling Vessel with upstream shadcn or evaluating an upstream change.
+description: Reconciling Vessel with upstream shadcn or evaluating an upstream change.
 ---
 
 Condition: you are syncing Vessel components against newer upstream shadcn

--- a/packages/vessel-react/.ghost/index.md
+++ b/packages/vessel-react/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-description: Any task changing the Vessel workspace.
+for: Any task changing the Vessel workspace.
 ---
 
 Vessel is ghost's reference body: an agnostic, agent-safe shadcn-compatible

--- a/packages/vessel-react/.ghost/index.md
+++ b/packages/vessel-react/.ghost/index.md
@@ -1,5 +1,5 @@
 ---
-context: Any task changing the Vessel workspace.
+description: Any task changing the Vessel workspace.
 ---
 
 Vessel is ghost's reference body: an agnostic, agent-safe shadcn-compatible

--- a/packages/vessel-react/.ghost/principle.named-decisions.md
+++ b/packages/vessel-react/.ghost/principle.named-decisions.md
@@ -1,5 +1,5 @@
 ---
-description: Authoring or reviewing components, tokens, variants, or agent-safety checks.
+for: Authoring or reviewing components, tokens, variants, or agent-safety checks.
 materials:
   - packages/vessel-react/scripts/audit-agent-safety.mjs
 ---

--- a/packages/vessel-react/.ghost/principle.named-decisions.md
+++ b/packages/vessel-react/.ghost/principle.named-decisions.md
@@ -1,5 +1,5 @@
 ---
-context: Authoring or reviewing components, tokens, variants, or agent-safety checks.
+description: Authoring or reviewing components, tokens, variants, or agent-safety checks.
 materials:
   - packages/vessel-react/scripts/audit-agent-safety.mjs
 ---

--- a/packages/vessel-react/.ghost/principle.reference-not-brand.md
+++ b/packages/vessel-react/.ghost/principle.reference-not-brand.md
@@ -1,5 +1,5 @@
 ---
-description: Any Vessel change that could encode product-specific brand truth.
+for: Any Vessel change that could encode product-specific brand truth.
 ---
 
 Vessel provides a coherent implementation vocabulary — tokens, primitives, AI

--- a/packages/vessel-react/.ghost/principle.reference-not-brand.md
+++ b/packages/vessel-react/.ghost/principle.reference-not-brand.md
@@ -1,5 +1,5 @@
 ---
-context: Any Vessel change that could encode product-specific brand truth.
+description: Any Vessel change that could encode product-specific brand truth.
 ---
 
 Vessel provides a coherent implementation vocabulary — tokens, primitives, AI

--- a/packages/vessel-react/fingerprint/anti-goal.median.md
+++ b/packages/vessel-react/fingerprint/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-context: Any build using the vendored component set.
+description: Any build using the vendored component set.
 ---
 
 These are not aesthetic opinions. They are the measured convergence of 300

--- a/packages/vessel-react/fingerprint/anti-goal.median.md
+++ b/packages/vessel-react/fingerprint/anti-goal.median.md
@@ -1,5 +1,5 @@
 ---
-description: Any build using the vendored component set.
+for: Any build using the vendored component set.
 ---
 
 These are not aesthetic opinions. They are the measured convergence of 300

--- a/packages/vessel-react/fingerprint/contract.theming.md
+++ b/packages/vessel-react/fingerprint/contract.theming.md
@@ -1,5 +1,5 @@
 ---
-context: Creating or changing a theme, token binding, font stack, radius, shadow, or gray ramp.
+description: Creating or changing a theme, token binding, font stack, radius, shadow, or gray ramp.
 materials:
   - packages/vessel-react/src/styles/main.css
 ---

--- a/packages/vessel-react/fingerprint/contract.theming.md
+++ b/packages/vessel-react/fingerprint/contract.theming.md
@@ -1,5 +1,5 @@
 ---
-description: Creating or changing a theme, token binding, font stack, radius, shadow, or gray ramp.
+for: Creating or changing a theme, token binding, font stack, radius, shadow, or gray ramp.
 materials:
   - packages/vessel-react/src/styles/main.css
 ---

--- a/packages/vessel-react/fingerprint/contract.tokens.md
+++ b/packages/vessel-react/fingerprint/contract.tokens.md
@@ -1,5 +1,5 @@
 ---
-description: Changing tokens, component styles, semantic roles, or the Tailwind utility bridge.
+for: Changing tokens, component styles, semantic roles, or the Tailwind utility bridge.
 materials:
   - packages/vessel-react/src/styles/main.css
   - packages/vessel-react/src/components/ui/button.tsx

--- a/packages/vessel-react/fingerprint/contract.tokens.md
+++ b/packages/vessel-react/fingerprint/contract.tokens.md
@@ -1,5 +1,5 @@
 ---
-context: Changing tokens, component styles, semantic roles, or the Tailwind utility bridge.
+description: Changing tokens, component styles, semantic roles, or the Tailwind utility bridge.
 materials:
   - packages/vessel-react/src/styles/main.css
   - packages/vessel-react/src/components/ui/button.tsx

--- a/packages/vessel-react/fingerprint/index.md
+++ b/packages/vessel-react/fingerprint/index.md
@@ -1,5 +1,5 @@
 ---
-description: Any task using or changing the vendored component set.
+for: Any task using or changing the vendored component set.
 materials:
   - packages/vessel-react/src/styles/main.css
 ---

--- a/packages/vessel-react/fingerprint/index.md
+++ b/packages/vessel-react/fingerprint/index.md
@@ -1,5 +1,5 @@
 ---
-context: Any task using or changing the vendored component set.
+description: Any task using or changing the vendored component set.
 materials:
   - packages/vessel-react/src/styles/main.css
 ---

--- a/packages/vessel-react/fingerprint/pattern.conversation.md
+++ b/packages/vessel-react/fingerprint/pattern.conversation.md
@@ -1,5 +1,5 @@
 ---
-context: Any AI conversation, prompt input, reasoning display, or tool output.
+description: Any AI conversation, prompt input, reasoning display, or tool output.
 materials:
   - packages/vessel-react/src/components/ai-elements/conversation.tsx
   - packages/vessel-react/src/components/ai-elements/message.tsx

--- a/packages/vessel-react/fingerprint/pattern.conversation.md
+++ b/packages/vessel-react/fingerprint/pattern.conversation.md
@@ -1,5 +1,5 @@
 ---
-description: Any AI conversation, prompt input, reasoning display, or tool output.
+for: Any AI conversation, prompt input, reasoning display, or tool output.
 materials:
   - packages/vessel-react/src/components/ai-elements/conversation.tsx
   - packages/vessel-react/src/components/ai-elements/message.tsx

--- a/packages/vessel-react/fingerprint/primitive.composition.md
+++ b/packages/vessel-react/fingerprint/primitive.composition.md
@@ -1,5 +1,5 @@
 ---
-context: Composing layout, surfaces, text hierarchy, spacing, cards, separators, or loading states.
+description: Composing layout, surfaces, text hierarchy, spacing, cards, separators, or loading states.
 materials:
   - packages/vessel-react/src/components/ui/stack.tsx
   - packages/vessel-react/src/components/ui/surface.tsx

--- a/packages/vessel-react/fingerprint/primitive.composition.md
+++ b/packages/vessel-react/fingerprint/primitive.composition.md
@@ -1,5 +1,5 @@
 ---
-description: Composing layout, surfaces, text hierarchy, spacing, cards, separators, or loading states.
+for: Composing layout, surfaces, text hierarchy, spacing, cards, separators, or loading states.
 materials:
   - packages/vessel-react/src/components/ui/stack.tsx
   - packages/vessel-react/src/components/ui/surface.tsx

--- a/packages/vessel-react/fingerprint/primitive.controls.md
+++ b/packages/vessel-react/fingerprint/primitive.controls.md
@@ -1,5 +1,5 @@
 ---
-description: Any view with buttons, inputs, forms, labels, or field errors.
+for: Any view with buttons, inputs, forms, labels, or field errors.
 materials:
   - packages/vessel-react/src/components/ui/button.tsx
   - packages/vessel-react/src/components/ui/button-group.tsx

--- a/packages/vessel-react/fingerprint/primitive.controls.md
+++ b/packages/vessel-react/fingerprint/primitive.controls.md
@@ -1,5 +1,5 @@
 ---
-context: Any view with buttons, inputs, forms, labels, or field errors.
+description: Any view with buttons, inputs, forms, labels, or field errors.
 materials:
   - packages/vessel-react/src/components/ui/button.tsx
   - packages/vessel-react/src/components/ui/button-group.tsx


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Ghost package nodes declare their retrieval payload with a `for:` frontmatter field: the situation or activity the guidance is for. Near-miss keys (`context`, `description`) are rejected with a pointer to `for`.
**Problem:** #252 renamed the node retrieval field from `description` to `context`, but `context` reads as the mechanism (what ends up in the model's context) rather than the payload itself, and it collides with the everyday "context" vocabulary used throughout ghost's own prose. `description` was semantically loose in the other direction: the field's content never describes the node, it names when the node applies. The team converged on `for`.
**Solution:** A forward rename to `for` rather than a revert. Every value in the corpora already completes the sentence "this guidance is for ___" (`for: Choosing or applying color.`, `for: Any view containing text or actions.`), so the field teaches itself from its own values. `for` is canonical across the schema, catalog, embed API, CLI output, lint rules, corpora, and docs. Authoring `context:` or `description:` fails validation with a pointer to the right key ("`description` is not a node key; use `for`"), mirroring the existing `relates` rejection pattern; without the explicit rejection, the passthrough schema would let an old key ride along silently and leave the node invisible to gather. Check frontmatter keeps its own `description` field: that is the established `.agents/checks` format, not the node schema. The skill prose adds the one guardrail `for` needs: it names a situation or activity, never an audience.

**Validation:**
- `pnpm build`: pass
- `pnpm test`: 211/211 pass (adds rejection tests for both near-miss keys)
- `pnpm check`: pass (biome, typecheck, terminology, package checks)
- Smoke tests: fresh `ghost init` (skeleton and vessel-light bodies) validates clean and emits `for:`; nodes authored with `context:` or `description:` fail validation with the pointer to `for`; all three in-repo corpora (`apps/docs`, `vessel-light`, `vessel-react`) validate with no new findings.

**Changeset:** added (`minor`) — public CLI/embed output shape and validation behavior change.

**ghost Review:**
- `ghost review`: not run — no root `.ghost/checks/` directory in this repo.

<details>
<summary>File changes</summary>

**.changeset/rename-retrieval-field-to-for.md**
New minor changeset describing the field and the rejection behavior.

**packages/ghost/src/ghost-core/node/schema.ts, types.ts, serialize.ts**
`for` is the canonical frontmatter field. `context` and `description` are rejected keys that point to `for`. Key order is `for, materials`.

**packages/ghost/src/ghost-core/catalog/types.ts, menu.ts, assemble.ts, closest.ts**
Catalog nodes and menu entries carry `for`.

**packages/ghost/src/embed/types.ts, gather.ts, pull.ts**
Embed API emits `for`; coverage field is `withoutFor`; gather selection instruction updated.

**packages/ghost/src/commands/gather-command.ts, pull-command.ts**
CLI markdown/JSON output uses `for`; coverage line says "N lack `for` payloads".

**packages/ghost/src/review/baseline.ts, review-packet.ts**
Review packet and baseline prose carry `for`.

**packages/ghost/src/scan/fingerprint-package-lint.ts**
Lint rule is `node-for-missing`.

**packages/ghost/src/skill-bundle/** (SKILL.md, references/schema.md, nodes.md, making.md, ground.md, steering-audit.md)
Skill prose teaches `for` as the retrieval payload: the situation or activity the guidance is for, never an audience.

**packages/ghost/src/init-payloads/** (median, skeleton)
Scaffolded nodes author `for:`. The median-tells check keeps its check-format `description` field.

**packages/ghost/test/** (cli.test.ts, cli-exit.test.ts, embed.test.ts, fingerprint-package.test.ts, ghost-core/node-schema.test.ts)
Node fixtures author `for:`; rejection tests cover both near-miss keys. Check fixtures keep `description` (check format).

**apps/docs/.ghost/** (9 nodes), **packages/vessel-light/.ghost/** (18 nodes), **packages/vessel-react/.ghost/ + fingerprint/** (25 nodes)
Mechanical frontmatter rename to `for:`.

**apps/docs/src/components/docs/gather-demo.tsx, apps/docs/src/pages/index.astro**
Demo menu data and landing-page examples use `for`.

**packages/context-control/README.md, lib/model.mjs, ui/index.html**
Bench consumes the renamed menu field; coverage line reads `withoutFor`.

**README.md, CLAUDE.md, docs/purposes.md**
Docs describe `for` as the retrieval payload.

</details>

**Screenshots/Demos:** N/A
