### PR TITLE
Document the manifest command

### DIFF
--- a/.changeset/document-manifest-command.md
+++ b/.changeset/document-manifest-command.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": patch
+---
+
+Document the manifest command in the CLI overview.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ ghost pull <ids>    # read the picked nodes' full bodies
 ghost review        # during review: match a diff to guidance and checks
 ghost export        # bundle the guidance as a portable artifact
 ghost stats         # while tuning: see what agents reached for
+ghost manifest      # emit a machine-readable index of commands and flags
 ```
 
 For a task-specific gather, your agent reads the complete, unfiltered menu and

--- a/packages/ghost/README.md
+++ b/packages/ghost/README.md
@@ -48,6 +48,7 @@ ghost pull <ids>    # read the picked nodes' full bodies
 ghost review        # during review: match a diff to guidance and checks
 ghost export        # bundle the guidance as a portable artifact
 ghost stats         # while tuning: see what agents reached for
+ghost manifest      # emit a machine-readable index of commands and flags
 ```
 
 For a task-specific gather, your agent reads the complete, unfiltered menu and


### PR DESCRIPTION
**Category:** improvement
**User Impact:** People can discover the machine-readable CLI manifest from the command overview.
**Problem:** The `ghost manifest` command exists but is absent from the command lists in the public readmes.
**Solution:** Add the command to both overviews with a concise description.

**Validation:**
- `git diff --check`: passed
- `pnpm check:terminology`: passed
- pre-commit checks (`check`, `format`, `sadscan`, `test`, `aittributor`): passed
- pre-push CI: passed

**Changeset:** added a patch changeset for the public documentation update.

**ghost Review:**
- `ghost check --base origin/main`: not run because this is a documentation-only command-list addition.
- `ghost review --base origin/main --include-memory`: not run because no surface behavior or fingerprint semantics changed.

<details>
<summary>File changes</summary>

**README.md**
Adds `ghost manifest` to the root CLI overview.

**packages/ghost/README.md**
Adds `ghost manifest` to the published package overview.

**.changeset/document-manifest-command.md**
Records the patch-level documentation change for release.

</details>

**Screenshots/Demos:** N/A
