### PR TITLE
Fix internal sync secret references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       # `secrets` context can't be used in step-level `if:`, so surface a
       # presence flag here. Skips the tap bump on forks / unconfigured repos.
       HAS_TAP_APP: ${{ secrets.BLOCK_HOMEBREW_TAP_APP_ID != '' && secrets.BLOCK_HOMEBREW_TAP_PRIVATE_KEY != '' }}
-      HAS_GHOST_SYNC_APP: ${{ vars.GHOST_SYNC_VERSION_APP_ID != '' && secrets.GHOST_SYNC_VERSION_PRIVATE_KEY != '' && vars.GHOST_SYNC_VERSION_OWNER != '' && vars.GHOST_SYNC_VERSION_REPOSITORY != '' }}
+      HAS_GHOST_SYNC_APP: ${{ secrets.GHOST_SYNC_VERSION_APP_ID != '' && secrets.GHOST_SYNC_VERSION_PRIVATE_KEY != '' && secrets.GHOST_SYNC_VERSION_OWNER != '' && secrets.GHOST_SYNC_VERSION_REPOSITORY != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -127,10 +127,10 @@ jobs:
         if: ${{ steps.changesets.outputs.published == 'true' && env.HAS_GHOST_SYNC_APP == 'true' }}
         uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
         with:
-          app-id: ${{ vars.GHOST_SYNC_VERSION_APP_ID }}
+          app-id: ${{ secrets.GHOST_SYNC_VERSION_APP_ID }}
           private-key: ${{ secrets.GHOST_SYNC_VERSION_PRIVATE_KEY }}
-          owner: ${{ vars.GHOST_SYNC_VERSION_OWNER }}
-          repositories: ${{ vars.GHOST_SYNC_VERSION_REPOSITORY }}
+          owner: ${{ secrets.GHOST_SYNC_VERSION_OWNER }}
+          repositories: ${{ secrets.GHOST_SYNC_VERSION_REPOSITORY }}
 
       - name: Trigger internal version sync
         if: ${{ steps.changesets.outputs.published == 'true' && env.HAS_GHOST_SYNC_APP == 'true' }}
@@ -139,6 +139,6 @@ jobs:
           TAG: ${{ steps.tarball.outputs.tag }}
         run: |
           VERSION="${TAG#design-intelligence-ghost@}"
-          gh api "repos/${{ vars.GHOST_SYNC_VERSION_OWNER }}/${{ vars.GHOST_SYNC_VERSION_REPOSITORY }}/dispatches" \
+          gh api "repos/${{ secrets.GHOST_SYNC_VERSION_OWNER }}/${{ secrets.GHOST_SYNC_VERSION_REPOSITORY }}/dispatches" \
             -f event_type=bump_ghost \
             -F "client_payload[version]=$VERSION"


### PR DESCRIPTION
## Why
The internal version sync credentials are configured as repository secrets, but the release workflow reads three of them as repository variables. This makes `HAS_GHOST_SYNC_APP` false and silently skips the sync after publishing.

## What
- Read all internal version sync configuration from the existing repository secrets
- Use those secrets when minting the app token and dispatching the sync event

## Risk Assessment
Low. This only changes credential context references in the release workflow; the sync remains gated on a newly published package and the presence of all four values.

## References
- Failed-to-trigger release: https://github.com/block/ghost/actions/runs/32520871738

Generated with Goose
