### PR TITLE
Ignore deleted headerless diff paths

### DIFF
--- a/.changeset/calm-diffs-rest.md
+++ b/.changeset/calm-diffs-rest.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": patch
+---
+
+Prevent review packets from treating deleted files as a `dev/null` material.

--- a/packages/ghost/src/review/diff.ts
+++ b/packages/ghost/src/review/diff.ts
@@ -27,10 +27,13 @@ export function parseTouchedFiles(diffText: string): TouchedFile[] {
       current = { path: gitHeader[2], start: i };
       continue;
     }
-    const plusPlus = line.match(/^\+\+\+ b?\/?(.+)$/);
+    const plusPlus = line.match(/^\+\+\+ (.+)$/);
     if (plusPlus && current === null) {
-      const p = plusPlus[1].trim();
-      if (p !== "/dev/null") current = { path: p, start: i };
+      const destination = plusPlus[1].trim();
+      if (destination !== "/dev/null") {
+        const path = destination.replace(/^b\//, "");
+        current = { path, start: i };
+      }
     }
   }
   flush(lines.length);

--- a/packages/ghost/test/review-diff.test.ts
+++ b/packages/ghost/test/review-diff.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { parseTouchedFiles } from "../src/review/diff.js";
+
+describe("parseTouchedFiles", () => {
+  it("ignores deleted files in headerless unified diffs", () => {
+    const diff = [
+      "--- a/brand/logo.svg",
+      "+++ /dev/null",
+      "@@ -1 +0,0 @@",
+      "-old logo",
+    ].join("\n");
+
+    expect(parseTouchedFiles(diff)).toEqual([]);
+  });
+
+  it("keeps destination paths in headerless unified diffs", () => {
+    const diff = [
+      "--- /dev/null",
+      "+++ b/brand/logo.svg",
+      "@@ -0,0 +1 @@",
+      "+new logo",
+    ].join("\n");
+
+    expect(parseTouchedFiles(diff)).toEqual([
+      { path: "brand/logo.svg", patch: diff.split("\n").slice(1).join("\n") },
+    ]);
+  });
+});


### PR DESCRIPTION
## Why
Headerless unified diffs represent deleted files with `+++ /dev/null`. The review parser strips the leading slash first, so it can incorrectly treat `dev/null` as a touched material path.

## What
- Ignore `/dev/null` destinations before normalizing headerless diff paths
- Cover deleted and newly added files with focused parser tests
- Add a patch changeset for the public package

## Risk Assessment
Low. The change only affects fallback parsing for unified diffs without `diff --git` headers.

Generated with Goose
