### PR TITLE
Match closing hashes in heading anchors

### DIFF
--- a/.changeset/tidy-headings-match.md
+++ b/.changeset/tidy-headings-match.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": patch
+---
+
+Resolve check heading anchors against Markdown headings with optional closing hashes.

--- a/packages/ghost/src/ghost-core/check/source-ref.ts
+++ b/packages/ghost/src/ghost-core/check/source-ref.ts
@@ -46,7 +46,11 @@ export function sliceNodeSection(body: string, heading: string): string | null {
   let level = 0;
   for (let i = 0; i < lines.length; i += 1) {
     const match = headingPattern.exec(lines[i]);
-    if (match && match[2].trim().toLowerCase() === wanted) {
+    const headingText = match?.[2]
+      .replace(/[ \t]+#+[ \t]*$/, "")
+      .trim()
+      .toLowerCase();
+    if (match && headingText === wanted) {
       startLine = i;
       level = match[1].length;
       break;

--- a/packages/ghost/test/ghost-core/source-ref.test.ts
+++ b/packages/ghost/test/ghost-core/source-ref.test.ts
@@ -73,6 +73,16 @@ Other prose.
     );
   });
 
+  it("matches headings with optional closing hashes", () => {
+    const body = "## Confirmation ##\n\nConfirmation prose.\n";
+    expect(sliceNodeSection(body, "Confirmation")).toBe("Confirmation prose.");
+  });
+
+  it("preserves hashes that are part of the heading text", () => {
+    const body = "## Confirm #1\n\nFirst confirmation.\n";
+    expect(sliceNodeSection(body, "Confirm #1")).toBe("First confirmation.");
+  });
+
   it("stops at the next heading of the same level", () => {
     const slice = sliceNodeSection(BODY, "Confirmation");
     expect(slice).not.toContain("Next Section");


### PR DESCRIPTION
## Why
Check source references can anchor to a node heading, but valid Markdown headings with optional closing hashes do not match. Ghost then warns and embeds the whole node instead of the requested section.

## What
- Normalize optional closing hashes when matching heading anchors
- Preserve hashes that are part of heading text
- Add a patch changeset for the public package

## Risk Assessment
Low. This only broadens heading-anchor matching to valid ATX heading syntax.

Generated with Goose
