### PR TITLE
Document the skill install command

### DIFF
--- a/.changeset/document-manifest-command.md
+++ b/.changeset/document-manifest-command.md
@@ -1,5 +1,0 @@
----
-"@design-intelligence/ghost": patch
----
-
-Document the manifest command in the CLI overview.

--- a/.changeset/document-manifest-command.md
+++ b/.changeset/document-manifest-command.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": patch
+---
+
+Document the manifest command in the CLI overview.

--- a/.changeset/document-skill-install-command.md
+++ b/.changeset/document-skill-install-command.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": patch
+---
+
+Document the skill install command in the CLI overview.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ ghost pull <ids>    # read the picked nodes' full bodies
 ghost review        # during review: match a diff to guidance and checks
 ghost export        # bundle the guidance as a portable artifact
 ghost stats         # while tuning: see what agents reached for
+ghost skill install # install the unified ghost skill bundle
 ghost manifest      # emit a machine-readable index of commands and flags
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ ghost pull <ids>    # read the picked nodes' full bodies
 ghost review        # during review: match a diff to guidance and checks
 ghost export        # bundle the guidance as a portable artifact
 ghost stats         # while tuning: see what agents reached for
+ghost manifest      # emit a machine-readable index of commands and flags
 ```
 
 For a task-specific gather, your agent reads the complete, unfiltered menu and

--- a/packages/ghost/README.md
+++ b/packages/ghost/README.md
@@ -48,6 +48,7 @@ ghost pull <ids>    # read the picked nodes' full bodies
 ghost review        # during review: match a diff to guidance and checks
 ghost export        # bundle the guidance as a portable artifact
 ghost stats         # while tuning: see what agents reached for
+ghost manifest      # emit a machine-readable index of commands and flags
 ```
 
 For a task-specific gather, your agent reads the complete, unfiltered menu and

--- a/packages/ghost/README.md
+++ b/packages/ghost/README.md
@@ -48,6 +48,7 @@ ghost pull <ids>    # read the picked nodes' full bodies
 ghost review        # during review: match a diff to guidance and checks
 ghost export        # bundle the guidance as a portable artifact
 ghost stats         # while tuning: see what agents reached for
+ghost skill install # install the unified ghost skill bundle
 ghost manifest      # emit a machine-readable index of commands and flags
 ```
 


### PR DESCRIPTION
**Category:** improvement
**User Impact:** People can discover how to install the unified ghost skill from the CLI overview.
**Problem:** The quickstart uses `ghost skill install`, but the command overview omitted it. This left the package documentation incomplete and gives us a small public-package patch for validating the release-sync path.
**Solution:** Add the command to both CLI overview blocks and include a patch changeset so the normal release workflow publishes and syncs it.

**Validation:**
- `pnpm check`: passed
- `pnpm exec changeset status`: reports one patch bump for `@design-intelligence/ghost`
- commit hooks (`check`, `format`, `sadscan`, `test`, `aittributor`): passed
- push hook (`check-push-org`, `ci`): passed
- `pnpm dump:cli-help`: not run because this repository has no such script; no generated CLI output changed

**Changeset:** added a patch changeset for `@design-intelligence/ghost`

**ghost Review:**
- `ghost check --base origin/main`: not run because this is documentation-only and does not change implementation or fingerprint behavior
- `ghost review --base origin/main --include-memory`: not run because this does not change generation behavior, fingerprint semantics, or review packets

<details>
<summary>File changes</summary>

**.changeset/document-skill-install-command.md**
Adds the patch release note for the public package.

**README.md**
Lists `ghost skill install` in the repository CLI overview.

**packages/ghost/README.md**
Lists `ghost skill install` in the README shipped with the npm package.

</details>

**Screenshots/Demos:** N/A
