### PR TITLE
Clarify gather menu heading

### DIFF
--- a/.changeset/clean-gather-menu-heading.md
+++ b/.changeset/clean-gather-menu-heading.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": patch
+---
+
+Label gather output as a guidance menu instead of implying its guidance is preselected.

--- a/packages/ghost/src/commands/gather-command.ts
+++ b/packages/ghost/src/commands/gather-command.ts
@@ -88,14 +88,20 @@ function formatMenuMarkdown(menu: GhostGatherResult): string {
     throw new UsageError("Markdown gather output requires a task.");
   }
 
-  const lines: string[] = ["# Guidance menu", "", `Task: ${menu.ask}`, ""];
-
-  lines.push(
+  const lines: string[] = [
+    "# Guidance menu",
+    "",
+    "This is the complete, unfiltered menu. For the task below, check every `Applies when` condition and pull every applicable ID. The entries have not been selected or ranked.",
+    "",
+    "## Task",
+    "",
+    menu.ask,
+    "",
     "## Available guidance",
     "",
-    "Check every item below. Pull all applicable IDs together with `ghost pull <id> [<id>…]`. If no listed guidance applies, run bare `ghost pull` to receive the cover and uncovered-guidance policy. Skip clear non-matches; topic overlap alone is not enough. Do not limit the number.",
+    "Pull the applicable IDs together with `ghost pull <id> [<id>…]`. If no listed guidance applies, run bare `ghost pull` to receive the cover and uncovered-guidance policy. Skip clear non-matches; topic overlap alone is not enough. Do not limit the number.",
     "",
-  );
+  ];
 
   const groups = groupMenuByKind(menu.nodes, menu.kinds ?? []);
   for (const group of groups) {

--- a/packages/ghost/src/commands/gather-command.ts
+++ b/packages/ghost/src/commands/gather-command.ts
@@ -88,12 +88,7 @@ function formatMenuMarkdown(menu: GhostGatherResult): string {
     throw new UsageError("Markdown gather output requires a task.");
   }
 
-  const lines: string[] = [
-    "# Guidance for this task",
-    "",
-    `Task: ${menu.ask}`,
-    "",
-  ];
+  const lines: string[] = ["# Guidance menu", "", `Task: ${menu.ask}`, ""];
 
   lines.push(
     "## Available guidance",

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -605,7 +605,12 @@ describe("ghost CLI", () => {
     const markdown = await runCli(["gather", "build", "a", "page"], dir);
     expect(markdown.code).toBe(0);
     expect(markdown.stdout).toContain("# Guidance menu");
-    expect(markdown.stdout).toContain("Task: build a page");
+    expect(markdown.stdout).toContain("This is the complete, unfiltered menu.");
+    expect(markdown.stdout).toContain("have not been selected or ranked");
+    expect(markdown.stdout).toContain("## Task\n\nbuild a page");
+    expect(markdown.stdout.indexOf("complete, unfiltered")).toBeLessThan(
+      markdown.stdout.indexOf("## Task"),
+    );
     expect(markdown.stdout).not.toContain(
       "Use a quiet, precise, content-first stance",
     );
@@ -1272,7 +1277,7 @@ describe("ghost CLI", () => {
 
     const gatherMarkdown = await runCli(["gather", "checkout", "hero"], dir);
     expect(gatherMarkdown.stdout).toContain("# Guidance menu");
-    expect(gatherMarkdown.stdout).toContain("Task: checkout hero");
+    expect(gatherMarkdown.stdout).toContain("## Task\n\ncheckout hero");
     expect(gatherMarkdown.stdout).toContain("## Available guidance");
     expect(gatherMarkdown.stdout).not.toContain(menuPayload.contract.noAsk);
     expect(gatherMarkdown.stdout).toContain("### Other guidance");

--- a/packages/ghost/test/cli.test.ts
+++ b/packages/ghost/test/cli.test.ts
@@ -604,7 +604,7 @@ describe("ghost CLI", () => {
 
     const markdown = await runCli(["gather", "build", "a", "page"], dir);
     expect(markdown.code).toBe(0);
-    expect(markdown.stdout).toContain("# Guidance for this task");
+    expect(markdown.stdout).toContain("# Guidance menu");
     expect(markdown.stdout).toContain("Task: build a page");
     expect(markdown.stdout).not.toContain(
       "Use a quiet, precise, content-first stance",
@@ -1271,7 +1271,7 @@ describe("ghost CLI", () => {
     ).toBe(true);
 
     const gatherMarkdown = await runCli(["gather", "checkout", "hero"], dir);
-    expect(gatherMarkdown.stdout).toContain("# Guidance for this task");
+    expect(gatherMarkdown.stdout).toContain("# Guidance menu");
     expect(gatherMarkdown.stdout).toContain("Task: checkout hero");
     expect(gatherMarkdown.stdout).toContain("## Available guidance");
     expect(gatherMarkdown.stdout).not.toContain(menuPayload.contract.noAsk);


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Agents receive a self-contained selection contract before the task and guidance menu.
**Problem:** The old heading implied that the guidance was already filtered, and presenting the task first gave agents no context for what to do with it.
**Solution:** Label the output as a guidance menu, explain that it is complete and unfiltered, then present the task and available guidance as separate sections.

**Validation:**
- `pnpm run quality:all`: passed
- pre-commit hooks: passed
- pre-push hooks: passed

**Changeset:** added a patch changeset for `@design-intelligence/ghost`

**ghost Review:**
- `ghost check --base main`: not run because this repository version does not expose that command
- `ghost review --base main --include-memory`: not run because this copy-only CLI output change does not affect generated UI or guidance semantics

<details>
<summary>File changes</summary>

**packages/ghost/src/commands/gather-command.ts**
Introduces the complete, unfiltered selection contract before separate task and available-guidance sections.

**packages/ghost/test/cli.test.ts**
Updates CLI expectations for the heading, instruction contract, and task placement.

**.changeset/clean-gather-menu-heading.md**
Records the user-visible patch change.

</details>

**Screenshots/Demos:** N/A
