### PR TITLE
Enforce resolved material access boundaries

### DIFF
--- a/.changeset/material-realpath-policy.md
+++ b/.changeset/material-realpath-policy.md
@@ -1,0 +1,5 @@
+---
+"@design-intelligence/ghost": patch
+---
+
+Treat bundled symlinks that resolve outside the materials directory as referenced files, requiring explicit inspection permission and honoring the referenced-file inline limit.

--- a/packages/ghost/README.md
+++ b/packages/ghost/README.md
@@ -86,8 +86,11 @@ selected ids, returns misses with suggestions, stable concrete/prose ordering,
 stripped node bodies, extracted Skeletons, and material transport packets. Use
 `inspectGhostMaterial` only for materials declared by a pulled node; it is local
 and bundled-only by default, with explicit host policy required for referenced
-files. HTTPS inspection is always rejected. Included and inspected material is
-marked `untrusted: true`; hosts must keep it in a data or tool-result channel
+files. Symlinks must resolve within the permitted directory. Pull still inlines
+small referenced text by default; use `inlineMaterials: false` before inspection
+when the host requires explicit read permission. HTTPS inspection is always
+rejected. Included and inspected material is marked `untrusted: true`; hosts
+must keep it in a data or tool-result channel
 rather than an instruction channel. Embedded operations do not write
 `.ghost/.events`; hosts may
 persist exported observability events in their own telemetry.

--- a/packages/ghost/src/embed/inspect.ts
+++ b/packages/ghost/src/embed/inspect.ts
@@ -13,6 +13,7 @@ import {
   resolveLocalMaterialLocator,
   validateMaterialLocator,
 } from "#ghost-core";
+import { effectiveLocalMaterialTier } from "../ghost-core/material-transport.js";
 import { GHOST_MATERIALS_DIR } from "../scan/constants.js";
 import type {
   GhostEmbedSnapshot,
@@ -98,9 +99,17 @@ export async function inspectGhostMaterial(
     );
   }
 
-  let info: Awaited<ReturnType<typeof stat>>;
+  let effectiveTier: Awaited<ReturnType<typeof effectiveLocalMaterialTier>>;
   try {
-    info = await stat(contained.realPath);
+    effectiveTier = await effectiveLocalMaterialTier(
+      resolved.tier,
+      contained.realPath,
+      {
+        repoRoot: request.repoRoot,
+        packageDir: snapshot.package.dir,
+        materialsDir: GHOST_MATERIALS_DIR,
+      },
+    );
   } catch {
     return rejected(
       request,
@@ -109,11 +118,31 @@ export async function inspectGhostMaterial(
       contained.repoRelativePath,
     );
   }
+  if (effectiveTier === "referenced" && policy.local === "bundled") {
+    return rejected(
+      request,
+      "referenced material inspection is disabled by policy",
+      effectiveTier,
+      contained.repoRelativePath,
+    );
+  }
+
+  let info: Awaited<ReturnType<typeof stat>>;
+  try {
+    info = await stat(contained.realPath);
+  } catch {
+    return rejected(
+      request,
+      "matched file could not be read",
+      effectiveTier,
+      contained.repoRelativePath,
+    );
+  }
   if (!info.isFile()) {
     return rejected(
       request,
       "not a file",
-      resolved.tier,
+      effectiveTier,
       contained.repoRelativePath,
     );
   }
@@ -121,7 +150,7 @@ export async function inspectGhostMaterial(
     return rejected(
       request,
       `exceeds ${policy.maxBytes} byte inspect limit`,
-      resolved.tier,
+      effectiveTier,
       contained.repoRelativePath,
       info.size,
     );
@@ -132,7 +161,7 @@ export async function inspectGhostMaterial(
     return rejected(
       request,
       `MIME type ${mime} is not allowed by policy`,
-      resolved.tier,
+      effectiveTier,
       contained.repoRelativePath,
       info.size,
       mime,
@@ -146,7 +175,7 @@ export async function inspectGhostMaterial(
     return rejected(
       request,
       "matched file could not be read",
-      resolved.tier,
+      effectiveTier,
       contained.repoRelativePath,
     );
   }
@@ -154,7 +183,7 @@ export async function inspectGhostMaterial(
     return rejected(
       request,
       `exceeds ${policy.maxBytes} byte inspect limit`,
-      resolved.tier,
+      effectiveTier,
       contained.repoRelativePath,
       buffer.byteLength,
       mime,
@@ -165,7 +194,7 @@ export async function inspectGhostMaterial(
     ok: true as const,
     nodeId: request.nodeId,
     locator: request.locator,
-    tier: resolved.tier,
+    tier: effectiveTier,
     path: contained.repoRelativePath,
     byteLength: buffer.byteLength,
     mime,
@@ -184,7 +213,7 @@ export async function inspectGhostMaterial(
         return rejected(
           request,
           "not valid UTF-8 text",
-          resolved.tier,
+          effectiveTier,
           contained.repoRelativePath,
           buffer.byteLength,
           mime,

--- a/packages/ghost/src/ghost-core/material-transport.ts
+++ b/packages/ghost/src/ghost-core/material-transport.ts
@@ -208,7 +208,25 @@ async function transportFile(
     };
   }
 
-  const base = { locator, tier, path: contained.repoRelativePath };
+  let effectiveTier: Exclude<TransportedMaterialTier, "url">;
+  try {
+    effectiveTier = await effectiveLocalMaterialTier(
+      tier,
+      contained.realPath,
+      options,
+    );
+  } catch {
+    return {
+      ...lexicalBase,
+      omitted: true,
+      reason: "matched file could not be read",
+    };
+  }
+  const base = {
+    locator,
+    tier: effectiveTier,
+    path: contained.repoRelativePath,
+  };
   let s: Awaited<ReturnType<typeof stat>>;
   try {
     s = await stat(contained.realPath);
@@ -226,7 +244,7 @@ async function transportFile(
 
   const inlineLimit =
     options.referencedInlineBytes ?? DEFAULT_REFERENCED_INLINE_BYTES;
-  if (tier === "referenced" && s.size > inlineLimit) {
+  if (effectiveTier === "referenced" && s.size > inlineLimit) {
     return {
       ...base,
       omitted: true as const,
@@ -317,6 +335,23 @@ export async function resolveContainedRealFile(
     realPath,
     repoRelativePath: toRepoRelative(realPath, realRepoRoot),
   };
+}
+
+/** Tighten lexical bundled access against the real materials root; never promote a reference. */
+export async function effectiveLocalMaterialTier(
+  lexicalTier: Exclude<TransportedMaterialTier, "url">,
+  realPath: string,
+  options: MaterialTransportOptions,
+): Promise<Exclude<TransportedMaterialTier, "url">> {
+  if (lexicalTier === "referenced") return "referenced";
+
+  const materialsDir = options.materialsDir ?? DEFAULT_MATERIALS_DIR;
+  const realPackageMaterialsDir = await realpath(
+    resolve(options.packageDir, materialsDir),
+  );
+  return isInsideOrEqual(realPath, realPackageMaterialsDir)
+    ? "bundled"
+    : "referenced";
 }
 
 export function inferMaterialMime(path: string): MaterialMimeInfo {

--- a/packages/ghost/src/skill-bundle/references/schema.md
+++ b/packages/ghost/src/skill-bundle/references/schema.md
@@ -131,3 +131,15 @@ it does not grade them.
 - `ghost review` matches touched files to exact local material paths, offers
   relevant checks, and emits a review packet for the host agent.
 - `ghost stats` summarizes local gather and pull events.
+
+### Local material access
+
+Bundled-only inspection requires the resolved file to stay inside the resolved
+materials directory and the repository. A bundled symlink to another in-repo
+file is referenced material: inspection requires explicit permission, and pull
+applies the referenced-file inline limit. Links within the materials directory
+remain usable. Outside-repo targets stay unavailable.
+
+Pull still inlines eligible referenced text by default. Hosts that need
+explicit permission for each read should pull with `inlineMaterials: false`,
+then inspect under their chosen policy.

--- a/packages/ghost/test/material-access.test.ts
+++ b/packages/ghost/test/material-access.test.ts
@@ -1,0 +1,244 @@
+import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  inspectGhostMaterial,
+  loadGhostSnapshot,
+  pullGhostNodes,
+} from "../src/embed/index.js";
+import { resolveGhostPackage } from "../src/package.js";
+
+async function writeAccessPackage(dir: string): Promise<void> {
+  await mkdir(join(dir, ".ghost", "materials"), { recursive: true });
+  await mkdir(join(dir, "brand"), { recursive: true });
+  await writeFile(
+    join(dir, ".ghost", "manifest.yml"),
+    "schema: ghost.package/v1\nid: local\ncover: cover\n",
+  );
+  await writeFile(
+    join(dir, ".ghost", "glossary.md"),
+    "---\nkinds:\n  - name: asset\n---\n\n# asset\n\nConcrete materials.\n",
+  );
+  await writeFile(
+    join(dir, ".ghost", "cover.md"),
+    "---\nfor: Cover.\n---\n\nCover.\n",
+  );
+  await writeFile(join(dir, "brand", "outside-small.txt"), "Outside small.\n");
+  await writeFile(join(dir, "brand", "direct-small.txt"), "Direct small.\n");
+  await writeFile(
+    join(dir, "brand", "outside-big.txt"),
+    "x".repeat(8 * 1024 + 1),
+  );
+  await writeFile(join(dir, ".ghost", "materials", "inside.txt"), "Inside.\n");
+  await symlink(
+    join(dir, "brand", "outside-small.txt"),
+    join(dir, ".ghost", "materials", "outside-small-link.txt"),
+  );
+  await symlink(
+    join(dir, "brand", "outside-big.txt"),
+    join(dir, ".ghost", "materials", "outside-big-link.txt"),
+  );
+  await symlink(
+    join(dir, ".ghost", "materials", "inside.txt"),
+    join(dir, ".ghost", "materials", "inside-link.txt"),
+  );
+  await writeFile(
+    join(dir, ".ghost", "asset.links.md"),
+    [
+      "---",
+      "for: Links.",
+      "materials:",
+      "  - materials/outside-small-link.txt",
+      "  - materials/outside-big-link.txt",
+      "  - materials/inside-link.txt",
+      "  - brand/direct-small.txt",
+      "---",
+      "",
+      "Link prose.",
+    ].join("\n"),
+  );
+}
+
+async function writeSymlinkedRootsPackage(dir: string): Promise<string> {
+  await mkdir(join(dir, ".ghost"), { recursive: true });
+  await mkdir(join(dir, "material-root"), { recursive: true });
+  await writeFile(
+    join(dir, "material-root", "root-token.txt"),
+    "Root token.\n",
+  );
+  await symlink(join(dir, "material-root"), join(dir, ".ghost", "materials"));
+  await writeFile(
+    join(dir, ".ghost", "manifest.yml"),
+    "schema: ghost.package/v1\nid: local\ncover: cover\n",
+  );
+  await writeFile(
+    join(dir, ".ghost", "glossary.md"),
+    "---\nkinds:\n  - name: asset\n---\n\n# asset\n\nConcrete materials.\n",
+  );
+  await writeFile(
+    join(dir, ".ghost", "cover.md"),
+    "---\nfor: Cover.\n---\n\nCover.\n",
+  );
+  await writeFile(
+    join(dir, ".ghost", "asset.root.md"),
+    "---\nfor: Root.\nmaterials:\n  - materials/root-token.txt\n---\n\nRoot prose.\n",
+  );
+
+  const repoLink = `${dir}-link`;
+  await symlink(dir, repoLink);
+  return repoLink;
+}
+
+describe("material access realpath policy", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = join(
+      tmpdir(),
+      `ghost-material-access-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(dir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+    await rm(`${dir}-link`, { recursive: true, force: true });
+  });
+
+  it("downgrades bundled symlinks to in-repo outside-material files for inspection policy", async () => {
+    await writeAccessPackage(dir);
+    const snapshot = await loadGhostSnapshot(
+      resolveGhostPackage(undefined, dir),
+    );
+
+    const defaultPolicy = await inspectGhostMaterial(snapshot, {
+      nodeId: "asset.links",
+      locator: "materials/outside-small-link.txt",
+      repoRoot: dir,
+    });
+    expect(defaultPolicy).toMatchObject({
+      ok: false,
+      tier: "referenced",
+      path: "brand/outside-small.txt",
+      reason: "referenced material inspection is disabled by policy",
+    });
+
+    const explicitPolicy = await inspectGhostMaterial(snapshot, {
+      nodeId: "asset.links",
+      locator: "materials/outside-small-link.txt",
+      repoRoot: dir,
+      policy: { local: "bundled-and-referenced" },
+    });
+    expect(explicitPolicy).toMatchObject({
+      ok: true,
+      tier: "referenced",
+      path: "brand/outside-small.txt",
+      text: "Outside small.\n",
+      untrusted: true,
+    });
+  });
+
+  it("applies the referenced inline limit after bundled symlink downgrade during pull", async () => {
+    await writeAccessPackage(dir);
+    const snapshot = await loadGhostSnapshot(
+      resolveGhostPackage(undefined, dir),
+    );
+
+    const result = await pullGhostNodes(snapshot, {
+      ids: ["asset.links"],
+      repoRoot: dir,
+    });
+
+    expect(result.nodes[0]?.materials).toContainEqual({
+      locator: "materials/outside-big-link.txt",
+      tier: "referenced",
+      path: "brand/outside-big.txt",
+      omitted: true,
+      reason: "exceeds 8 KB inline limit",
+    });
+    expect(result.nodes[0]?.materials).toContainEqual({
+      locator: "brand/direct-small.txt",
+      tier: "referenced",
+      path: "brand/direct-small.txt",
+      inlined: "Direct small.\n",
+      untrusted: true,
+    });
+  });
+
+  it("keeps internal material symlinks bundled under default inspection policy", async () => {
+    await writeAccessPackage(dir);
+    const snapshot = await loadGhostSnapshot(
+      resolveGhostPackage(undefined, dir),
+    );
+
+    const result = await inspectGhostMaterial(snapshot, {
+      nodeId: "asset.links",
+      locator: "materials/inside-link.txt",
+      repoRoot: dir,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      tier: "bundled",
+      path: ".ghost/materials/inside.txt",
+      text: "Inside.\n",
+      untrusted: true,
+    });
+  });
+
+  it("allows symlinked repo and material roots when real targets stay contained", async () => {
+    const repoLink = await writeSymlinkedRootsPackage(dir);
+    const snapshot = await loadGhostSnapshot(
+      resolveGhostPackage(undefined, repoLink),
+    );
+
+    const result = await inspectGhostMaterial(snapshot, {
+      nodeId: "asset.root",
+      locator: "materials/root-token.txt",
+      repoRoot: repoLink,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      tier: "bundled",
+      path: "material-root/root-token.txt",
+      text: "Root token.\n",
+      untrusted: true,
+    });
+  });
+
+  it("denies bundled symlinks that resolve outside the repo", async () => {
+    await writeAccessPackage(dir);
+    const outsideDir = `${dir}-outside`;
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(join(outsideDir, "secret.txt"), "Secret.\n");
+    await symlink(
+      join(outsideDir, "secret.txt"),
+      join(dir, ".ghost", "materials", "outside-repo-link.txt"),
+    );
+    await writeFile(
+      join(dir, ".ghost", "asset.outside.md"),
+      "---\nfor: Outside.\nmaterials:\n  - materials/outside-repo-link.txt\n---\n\nOutside prose.\n",
+    );
+    const snapshot = await loadGhostSnapshot(
+      resolveGhostPackage(undefined, dir),
+    );
+
+    const result = await inspectGhostMaterial(snapshot, {
+      nodeId: "asset.outside",
+      locator: "materials/outside-repo-link.txt",
+      repoRoot: dir,
+      policy: { local: "bundled-and-referenced" },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      tier: "bundled",
+      path: ".ghost/materials/outside-repo-link.txt",
+      reason: "resolved material path escapes repo",
+    });
+
+    await rm(outsideDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
**Category:** fix
**User Impact:** Hosts can enforce material-read permissions even when a bundled path is a symlink.

**Problem:** A bundled symlink could resolve outside the materials directory while retaining bundled permissions and inline limits.

**Solution:** Classify local material after resolving its real path. Require referenced-file permission and apply the referenced inline limit when the target leaves the materials directory; keep outside-repository targets unavailable.

**Compatibility:** Internal symlinks remain supported. Pull still inlines eligible referenced text by default; permission-sensitive hosts should use `inlineMaterials: false` before inspection.

**Scope:** Narrowed from the original 32-file PR to the material-access fix. The other four concerns have separate draft PRs; this branch targets `main`.

**Related:** [Preserve guidance meaning in CLI output](https://github.com/block/ghost/pull/292), [Report incomplete guidance loading](https://github.com/block/ghost/pull/293), [Add read-only installed skill checks](https://github.com/block/ghost/pull/294), [Fix and validate rendered guidance examples](https://github.com/block/ghost/pull/295).

**Validation:**
- `pnpm run quality:all`: passed on this standalone branch, including build, package/release checks, tests (231 passed), workspace builds, and package validations.
- Pre-commit checks and `git diff origin/main...HEAD --check`: passed.
- Fresh dependency installation hit registry checksum errors. Validation used an isolated copy of the existing checkout's dependencies; the lockfile is unchanged.

**Changeset:** Existing patch changeset retained.

**ghost Review:** Review packet assembled against `apps/docs/.ghost`. This package does not bind the changed CLI/test/docs files, so the packet is coverage context, not a passing brand review. Used the current `ghost review --package apps/docs/.ghost --base origin/main --format json` and inspected `ghost manifest`; the older `ghost check`, `--include-memory`, and `dump:cli-help` workflows are unavailable in this checkout.

<details>
<summary>File changes (6 files)</summary>

| File | Purpose |
| --- | --- |
| `.changeset/material-realpath-policy.md` | Record the access-policy fix. |
| `packages/ghost/README.md` | Explain inspection permissions and pull's default inline behavior. |
| `packages/ghost/src/embed/inspect.ts` | Enforce inspection policy against the resolved material tier. |
| `packages/ghost/src/ghost-core/material-transport.ts` | Share realpath tier resolution and apply referenced inline limits. |
| `packages/ghost/src/skill-bundle/references/schema.md` | Document local material access boundaries. |
| `packages/ghost/test/material-access.test.ts` | Cover internal, escaping, and outside-repository symlinks, permissions, and limits. |

</details>

**Screenshots/Demos:** N/A: no visual surface changes.
