### PR TITLE
Fix and validate rendered guidance examples

### DIFF
--- a/apps/docs/src/data/guidance-examples.ts
+++ b/apps/docs/src/data/guidance-examples.ts
@@ -1,0 +1,58 @@
+export const guidanceExamples = [
+  {
+    label: "visual decision",
+    path: "pattern.crop-with-intent.md",
+    body: `---
+for: Photography. Gather when a composition uses a photo.
+materials:
+  - brand/photography/portrait.jpg
+---
+
+# Crop with intent
+
+Crop around one clear subject. Let the subject meet at least one edge.
+
+Reject cautious full-object framing and collages that avoid choosing a focal point.`,
+    palette: [],
+  },
+  {
+    label: "product pattern",
+    path: "condition.blocked-progress.md",
+    body: `---
+for: Blocked progress. Gather when someone cannot continue a task.
+materials:
+  - src/components/error-state/index.tsx
+---
+
+# Keep a path forward
+
+Keep the explanation and one next action together.
+
+If the person cannot resolve the problem, state what happens next. Do not end on a disabled control.`,
+    palette: [],
+  },
+  {
+    label: "exact material",
+    path: "asset.color-roles.md",
+    body: `---
+for: Exact color roles and values. Gather before assigning color.
+materials:
+  - src/styles/brand-tokens.css
+---
+
+# Color roles
+
+Ink carries content. Signal marks selection. Correction marks review.
+
+\`\`\`css
+--ink: #171714;
+--signal: #e8df55;
+--correction: #c83e36;
+\`\`\``,
+    palette: [
+      ["ink", "#171714"],
+      ["signal", "#e8df55"],
+      ["correction", "#c83e36"],
+    ],
+  },
+] as const;

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -3,6 +3,7 @@ import DocSection from "@/components/DocSection.astro";
 import { GatherDemo } from "@/components/docs/gather-demo";
 import Hero from "@/components/Hero.astro";
 import SectionWrapper from "@/components/SectionWrapper.astro";
+import { guidanceExamples } from "@/data/guidance-examples";
 import Base from "@/layouts/Base.astro";
 const fragments = [
   ["product", "components, tokens, interaction patterns, UI copy"],
@@ -39,64 +40,6 @@ const steeringDiagnoses = [
   },
 ] as const;
 
-const guidanceExamples = [
-  {
-    label: "visual decision",
-    path: "pattern.crop-with-intent.md",
-    body: `---
-for: Photography. Gather when a composition uses a photo.
-materials:
-  - brand/photography/**
----
-
-# Crop with intent
-
-Crop around one clear subject. Let the subject meet at least one edge.
-
-Reject cautious full-object framing and collages that avoid choosing a focal point.`,
-    palette: [],
-  },
-  {
-    label: "product pattern",
-    path: "condition.blocked-progress.md",
-    body: `---
-for: Blocked progress. Gather when someone cannot continue a task.
-materials:
-  - src/components/error-state/**
----
-
-# Keep a path forward
-
-Keep the explanation and one next action together.
-
-If the person cannot resolve the problem, state what happens next. Do not end on a disabled control.`,
-    palette: [],
-  },
-  {
-    label: "exact material",
-    path: "asset.color-roles.md",
-    body: `---
-for: Exact color roles and values. Gather before assigning color.
-materials:
-  - src/styles/brand-tokens.css
----
-
-# Color roles
-
-Ink carries content. Signal marks selection. Correction marks review.
-
-\`\`\`css
---ink: #171714;
---signal: #e8df55;
---correction: #c83e36;
-\`\`\``,
-    palette: [
-      ["ink", "#171714"],
-      ["signal", "#e8df55"],
-      ["correction", "#c83e36"],
-    ],
-  },
-] as const;
 
 ---
 

--- a/packages/ghost/test/docs-examples.test.ts
+++ b/packages/ghost/test/docs-examples.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { guidanceExamples } from "../../../apps/docs/src/data/guidance-examples.js";
+import { parseNode } from "../src/ghost-core/node/parse.js";
+
+describe("rendered docs guidance examples", () => {
+  it.each(guidanceExamples)("$path parses without errors", ({ body }) => {
+    const { node, report } = parseNode(body);
+    expect(report.errors, JSON.stringify(report.issues)).toBe(0);
+    expect(node).not.toBeNull();
+  });
+});


### PR DESCRIPTION
**Category:** fix
**User Impact:** Readers see guidance examples that pass the parser used by ghost.

**Problem:** Two landing-page examples used material globs even though ghost requires explicit file paths.

**Solution:** Replace those globs with explicit paths and extract the example data so tests parse the same examples that the page renders.

**Compatibility:** No CLI, package schema, layout, or style changes.

**Scope:** One of five independent PRs split from the original #291. This branch targets `main` and contains only this concern, its tests, and its documentation.

**Related:** [Enforce resolved material access boundaries](https://github.com/block/ghost/pull/291), [Preserve guidance meaning in CLI output](https://github.com/block/ghost/pull/292), [Report incomplete guidance loading](https://github.com/block/ghost/pull/293), [Add read-only installed skill checks](https://github.com/block/ghost/pull/294).

**Validation:**
- `pnpm run quality:all`: passed on this standalone branch, including build, package/release checks, tests (229 passed), workspace builds, and package validations.
- Pre-commit checks and `git diff origin/main...HEAD --check`: passed.
- Fresh dependency installation hit registry checksum errors. Validation used an isolated copy of the existing checkout's dependencies; the lockfile is unchanged.

**Changeset:** Not needed: private docs-site data and tests only.

**ghost Review:** Docs review packet assembled. Source inspection found no markup or style changes; the visual check is advisory. Rendered visual verification was not performed. Unbound test/data files and nodes without checks remain coverage gaps. Used the current `ghost review --package apps/docs/.ghost --base origin/main --format json` and inspected `ghost manifest`; the older `ghost check`, `--include-memory`, and `dump:cli-help` workflows are unavailable in this checkout.

<details>
<summary>File changes (3 files)</summary>

| File | Purpose |
| --- | --- |
| `apps/docs/src/data/guidance-examples.ts` | Extract the examples and replace invalid material globs. |
| `apps/docs/src/pages/index.astro` | Import shared example data without changing rendered markup or styles. |
| `packages/ghost/test/docs-examples.test.ts` | Validate the rendered examples through the node parser. |

</details>

**Screenshots/Demos:** Not captured: example paths and data placement changed, with no layout or style edits.
